### PR TITLE
Implement unread badges at a series, volume and comic level

### DIFF
--- a/app/templates/partials/comic_card.html
+++ b/app/templates/partials/comic_card.html
@@ -10,6 +10,12 @@
                 loading="lazy"
             >
 
+            <template x-if="!comic.read">
+                <div class="absolute top-0 right-0 z-0 drop-shadow-md">
+                    <div style="border-width: 0 40px 40px 0; border-color: transparent #f97316 transparent transparent;" class="border-style-solid"></div>
+                </div>
+            </template>
+
             <template x-if="comic.format && comic.format !== 'Comic'">
                 <div
                     class="absolute top-2 right-2 text-white text-[10px] uppercase font-bold px-2 py-1 rounded shadow-md z-10"

--- a/app/templates/partials/series_card.html
+++ b/app/templates/partials/series_card.html
@@ -15,6 +15,13 @@
             </div>
         </template>
 
+        <template x-if="!series.read">
+            <div class="absolute top-0 right-0 z-10 drop-shadow-md">
+                <div style="border-width: 0 40px 40px 0; border-color: transparent #f97316 transparent transparent;" class="border-style-solid"></div>
+            </div>
+        </template>
+
+
         <div class="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-60 transition-all flex items-center justify-center opacity-0 group-hover:opacity-100">
             <span class="text-white font-bold bg-blue-600 px-3 py-1 text-sm rounded-full shadow-lg">View</span>
         </div>

--- a/app/templates/partials/volume_card.html
+++ b/app/templates/partials/volume_card.html
@@ -16,6 +16,12 @@
             </div>
         </template>
 
+        <template x-if="!volume.read">
+            <div class="absolute top-0 right-0 z-10 drop-shadow-md">
+                <div style="border-width: 0 40px 40px 0; border-color: transparent #f97316 transparent transparent;" class="border-style-solid"></div>
+            </div>
+        </template>
+
         <div class="absolute inset-0 bg-gradient-to-t from-black/90 via-black/20 to-transparent opacity-80"></div>
 
         <div class="absolute bottom-3 left-3 right-3">


### PR DESCRIPTION

# PR: Feature Polish & UX Enhancements (Imprints, Read Indicators, Smart Tabs)

## 📝 Description
This PR introduces several "V1.0 Polish" features to improve metadata display and user experience. It adds first-class support for Publisher Imprints (e.g., Vertigo, MAX), implements "Plex-style" unread indicators across the UI, and optimizes navigation for single-volume series. It also patches a serialization bug in the series issues endpoint.

## ✨ Key Changes

### 1. Imprint Support
* **UI:** Added `imprint_link.html` partial.
* **Integration:** Displaying Imprint next to Publisher on Comic, Volume, and Series detail pages.
* **Search:** Imprint links now drive the Advanced Search correctly via deep-linking (`/search?field=imprint&value=...`).
* **Backend:** Updated Series and Volume API endpoints to aggregate and return `imprint` metadata.

### 2. Unread Indicators ("The Plex Triangle")
* **Visuals:** Added an orange CSS triangle to the top-right corner of cards to indicate unread status.
* **Logic:**
    * **Comics:** Shows if the specific issue is not marked as `completed`.
    * **Volumes/Series:** Shows if the user has **not started** the container (read count == 0). Hides once at least one issue is read.
    * **Layering:** Fixed z-index to ensure "Annual/Special" badges sit *above* the unread indicator.
* **Performance:** Optimized API queries to fetch `ReadingProgress` via `outerjoin` to prevent N+1 query issues.

### 3. UX Improvements
* **Smart Tab Switching:** The Series Detail page now automatically switches to the **Issues** tab if the series contains only **1 Volume**, saving the user a click.

### 4. Bug Fixes
* **API Serialization:** Fixed a `TypeError` in `get_series_issues` where raw SQLAlchemy `Row` tuples were being returned instead of the processed dictionary list.

## 📂 Files Changed

**Backend (`app/api/endpoints/`)**
* `series.py`: Added `imprint` aggregation; added `read` status logic to list/detail/issues endpoints; fixed serialization bug.
* `volumes.py`: Added `imprint` aggregation; added `read` status logic to detail/issues endpoints.

**Frontend (`templates/`)**
* `partials/imprint_link.html` (New)
* `partials/comic_card.html`, `volume_card.html`, `series_card.html`: Added unread indicator logic.
* `comic_detail.html`: Added Imprint display.
* `series_detail.html`: Added Imprint display; added "Smart Tab" JS logic.
* `volume_detail.html`: Added Imprint display.

## ✅ Checklist
- [x] Imprints display correctly and link to search.
- [x] Unread triangles appear on unread items and disappear upon reading.
- [x] Series with single volume auto-selects the Issues tab.
- [x] Serialization error resolved.