### PR TITLE
Add incognito mode to comic detail read button

### DIFF
--- a/app/templates/partials/read_comic_button.html
+++ b/app/templates/partials/read_comic_button.html
@@ -1,8 +1,41 @@
-<a
-    :href="`/reader/${comicId}`"
-    class="text-white font-bold py-3 px-4 rounded-lg text-center transition-colors flex items-center justify-center gap-2 shadow-lg shadow-blue-900/20"
-    :class="comic?.read_status === 'in_progress' ? 'bg-blue-600 hover:bg-blue-500' : 'bg-green-600 hover:bg-green-500'"
->
-    <span class="text-xl" x-text="comic?.read_status === 'in_progress' ? '▶' : '📖'"></span>
-    <span x-text="comic?.read_status === 'in_progress' ? 'Continue' : 'Read Now'"></span>
-</a>
+<div class="relative flex items-center w-full" x-data="{ open: false }">
+
+    <a :href="`/reader/${comicId}`"
+       class="flex-1 bg-blue-600 hover:bg-blue-500 text-white font-bold py-3 px-4 rounded-l-lg transition-colors flex items-center justify-center gap-2 shadow-lg shadow-blue-900/20 border-r border-black"
+        :class="comic?.read_status === 'in_progress' ? 'bg-blue-600 hover:bg-blue-500' : 'bg-green-600 hover:bg-green-500'"
+    >
+        <span class="text-xl" x-text="comic?.read_status === 'in_progress' ? '▶' : '📖'"></span>
+        <span x-text="comic?.read_status === 'in_progress' ? 'Continue' : 'Read Now'"></span>
+    </a>
+
+    <button x-on:click="open = !open" x-on:click.away="open = false"
+            class="text-white font-bold py-3 px-3 rounded-r-lg transition-colors flex items-center justify-center"
+            :class="comic?.read_status === 'in_progress' ? 'bg-blue-600 hover:bg-blue-500' : 'bg-green-600 hover:bg-green-500'"
+            title="More Options">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+        </svg>
+    </button>
+
+    <div x-show="open"
+         x-transition:enter="transition ease-out duration-100"
+         x-transition:enter-start="transform opacity-0 scale-95"
+         x-transition:enter-end="transform opacity-100 scale-100"
+         x-transition:leave="transition ease-in duration-75"
+         x-transition:leave-start="transform opacity-100 scale-100"
+         x-transition:leave-end="transform opacity-0 scale-95"
+         class="absolute top-full left-0 right-0 mt-2 rounded-md shadow-lg bg-gray-800 ring-1 ring-black ring-opacity-5 z-50 border border-gray-700"
+         style="display: none;">
+
+        <div class="py-1">
+            <a :href="`/reader/${comicId}?incognito=true`"
+               class="group flex items-center px-4 py-3 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors">
+                <span class="mr-3 text-lg opacity-70 group-hover:opacity-100">👓</span>
+                <div>
+                    <span class="font-bold block">Read in Incognito</span>
+                    <span class="text-xs text-gray-500 group-hover:text-gray-400">Progress won't be saved</span>
+                </div>
+            </a>
+        </div>
+    </div>
+</div>

--- a/app/templates/reader.html
+++ b/app/templates/reader.html
@@ -388,6 +388,7 @@ function reader() {
         uiLocked: false,  // If true, UI is always on
         isHoveringZone: false,  // If true, mouse is at the bottom
         isHoveringBar: false,  // The actual button bar
+        isIncognito: false,
 
         // Filter State
         filters: {
@@ -398,6 +399,15 @@ function reader() {
         },
 
         init() {
+
+            // Check for incognito flag immediately
+            const params = new URLSearchParams(window.location.search);
+            this.isIncognito = params.get('incognito') === 'true';
+
+            if (this.isIncognito) {
+                window.comicServer.showToast("👓 Incognito Mode: Progress will not be saved.");
+            }
+
             this.loadInitData();
 
             // Sync Slider -> Page (Watch for external page changes)
@@ -421,6 +431,9 @@ function reader() {
                 const res = await fetch(`/api/comics/${this.comicId}/read-init`);
                 if (!res.ok) throw new Error("Failed to init reader");
                 this.meta = await res.json();
+
+                // If Incognito, DO NOT load previous progress. Start fresh.
+                if (this.isIncognito) { return; }
 
                 // Check for saved progress
                 const progRes = await fetch(`/api/progress/${this.comicId}`);
@@ -477,7 +490,7 @@ function reader() {
             } else if (this.meta.next_comic_id) {
                 // Optional: Auto-advance to next book
                 // if(confirm("Next Issue?")) this.goToBook(this.meta.next_comic_id);
-                this.showToast("End of Book. Press ] for next issue.");
+                window.comicServer.showToast("End of Book. Press ] for next issue.");
             }
         },
 
@@ -501,6 +514,10 @@ function reader() {
         },
 
         async updateProgress() {
+
+            // Block updates if incognito
+            if (this.isIncognito) { return; }
+
             // Debounce or fire-and-forget
             fetch(`/api/progress/${this.comicId}`, {
                 method: 'POST',
@@ -517,15 +534,6 @@ function reader() {
         toggleFullscreen() {
             if (!document.fullscreenElement) document.documentElement.requestFullscreen();
             else document.exitFullscreen();
-        },
-
-        showToast(msg) {
-            // Simple toast implementation
-            const div = document.createElement('div');
-            div.className = 'fixed bottom-20 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded shadow-lg z-50';
-            div.innerText = msg;
-            document.body.appendChild(div);
-            setTimeout(() => div.remove(), 2000);
         },
 
         // Centralized Key Handler
@@ -668,7 +676,7 @@ function reader() {
 
         toggleUiLock() {
             this.uiLocked = !this.uiLocked;
-            this.showToast(this.uiLocked ? "UI Pinned" : "UI Auto-Hide");
+            window.comicServer.showToast(this.uiLocked ? "UI Pinned" : "UI Auto-Hide");
         },
 
     }


### PR DESCRIPTION

# Feature: Incognito Reading Mode

## 📝 Description
This PR introduces **Incognito Mode** for the Web Reader. This feature allows users to open and read a comic without affecting their "Reading Progress" or "Continue Reading" history.

This is particularly useful for:
* Quickly checking a file/page quality without losing your place in a currently "In Progress" book.
* Re-reading favorite scenes without marking a book as "In Progress" or "Read" again.

## 🚀 Key Changes

### Frontend (`app/templates/`)

* **Comic Detail Page (`comic_detail.html`):**
    * Replaced the standard "Read" button with a **Split Button** component.
    * **Main Action:** Continues to launch the standard reader.
    * **Dropdown Action:** Added a "Read in Incognito" option that launches the reader with the `?incognito=true` query parameter.
    * *Implementation:* Built using Alpine.js for the dropdown state management.

* **Web Reader (`reader.html`):**
    * **State Management:** Added `isIncognito` flag to the Alpine component, initialized by parsing `window.location.search`.
    * **Logic Updates:**
        * **Init:** If `isIncognito` is true, the reader **skips** loading previous progress from the API (starts at page 0).
        * **Progress Tracking:** If `isIncognito` is true, the reader **aborts** all calls to `updateProgress()` (API calls to save page numbers are blocked).
    * **User Feedback:** Displays a "🕵️ Incognito Mode" toast notification upon launch to confirm status.

## 📸 UI/UX
* **Comic Page:** New split-button UI allows easy access to standard vs. incognito reading.
* **Reader:** Visual confirmation via toast. No database writes occur during the session.

## 🧪 Testing
1.  Navigate to a Comic Detail page.
2.  Click the dropdown arrow next to the "Read" button.
3.  Select **Read in Incognito**.
4.  Verify the Reader opens at Page 1 (even if you had previous progress).
5.  Read a few pages, then exit.
6.  **Verify:** The comic's progress bar on the detail page has **not** changed/moved.

## 📁 Files Changed
* `app/templates/comic_detail.html`: Implemented split-button dropdown.
* `app/templates/reader.html`: Added query param parsing and progress-blocking logic.

---

**Ticket:** #INCOGNITO-V1
**Assignee:** @ParkerAdmin