### PR TITLE
apply bubbling timestamp

### DIFF
--- a/app/services/scanner.py
+++ b/app/services/scanner.py
@@ -297,6 +297,12 @@ class LibraryScanner:
             metadata.get('series_group')
         )
 
+        # Touch Parent Series to update 'updated_at'
+        # This ensures it shows up in "Recently Updated"
+        series.updated_at = datetime.utcnow()
+        # Note: SQLAlchemy tracks dirty state, so this will trigger an UPDATE on commit
+
+
         print(f"Imported: {series_name} #{metadata.get('number', '?')} - {file_path.name}")
         self.logger.info(f"Imported: {series_name} #{metadata.get('number', '?')} - {file_path.name}")
 
@@ -374,6 +380,9 @@ class LibraryScanner:
             comic,
             metadata.get('series_group')
         )
+
+        # Touch Parent Series
+        series.updated_at = datetime.utcnow()
 
         # NO COMMIT HERE - handled by batch loop
 


### PR DESCRIPTION

# Fix: Timestamp Bubbling for "Recently Updated"

## 📝 Description
This PR fixes a logic gap where adding new issues or volumes to an *existing* series did not update the `Series.updated_at` timestamp.

As a result, the "Recently Updated" slider on the Home Page failed to show series that received new content, because the database thought the Series entity itself hadn't changed since creation.

## 🚀 Key Changes

### Scanner Service (`app/services/scanner.py`)
* **Timestamp Propagation:** Updated `_import_comic` and `_update_comic`.
    * **Logic:** Whenever a Comic is successfully added or modified, the scanner now explicitly "touches" the parent `Series.updated_at` field (setting it to `datetime.utcnow()`).
    * **Impact:** This ensures that `list_series(sort_by="updated")` correctly bubbles active series to the top of the list.

## 🧪 Testing
1.  **Baseline:** Note the position of an existing Series (e.g., "Ragman") in the "Recently Updated" list (or verify it's missing).
2.  **Action:** Add a new file (e.g., Volume 2, Issue #1) to the library folder and run a Scan.
3.  **Result:** Verify "Ragman" moves to the #1 spot in the "Recently Updated" slider on the Home Page.

## 📁 Files Changed
* `app/services/scanner.py`: Added timestamp update logic.

---

**Ticket:** #FIX-TIMESTAMPS-V1
**Assignee:** @ParkerAdmin
