### PR TITLE
fixes and tweaks in user migration system

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ from app.api import auth, users, saved_searches
 from app.api import tasks, jobs, stats, settings as settings_api
 from app.api import pull_lists
 from app.api import reports
+from app.api import migration
 
 # Frontend Routes (HTML)
 from app.routers import pages, admin
@@ -211,6 +212,8 @@ app.include_router(stats.router, prefix="/api/stats", tags=["stats"])
 app.include_router(saved_searches.router, prefix="/api/saved-searches", tags=["saved-searches"])
 app.include_router(pull_lists.router, prefix="/api/pull-lists", tags=["pull-lists"])
 app.include_router(reports.router, prefix="/api/reports", tags=["reports"])
+app.include_router(migration.router, prefix="/api/migration", tags=["migration"])
+
 
 # 2. Frontend Routers (HTML)
 # We don't use a prefix for 'pages' because they live at the root (/)

--- a/app/templates/admin/migration.html
+++ b/app/templates/admin/migration.html
@@ -99,7 +99,7 @@ function migrationTool() {
             formData.append('user_strategy', this.userStrategy);
 
             try {
-                const res = await fetch(window.url('/api/admin/migration/run'), {
+                const res = await fetch(window.url('/api/migration/run'), {
                     method: 'POST',
                     body: formData,
                 });


### PR DESCRIPTION
### 🔧 Fix: Kavita "Virtual Volume" Collision Workaround

**The Problem:**
Kavita deviates from standard comic schemas by putting non-standard issues (Annuals, Specials) into a single "Virtual Volume" (often named `100000` or Volume `0`) instead of creating distinct Volume entities.
* **Result:** This caused a hash collision in our migration map. "Superman 6" (Regular) and "Superman Annual 6" (Virtual Vol 0) would both map to the key `superman|6`, causing the Annual to overwrite the Regular issue in the import logic.

**The Solution:**
We updated `KavitaMigrationService` to respect `format` as a distinct entity key.

1.  **Split Namespace:** The migration map now generates composite keys using `is_special` status: `series|number|is_special`.
2.  **Format Detection (Parker Side):** We import the centralized `NON_PLAIN_FORMATS` list to automatically flag Parker comics as "Special" if their format is 'Annual', 'One-Shot', 'TPB', etc.
3.  **Virtual Volume Detection (Kavita Side):** We inspect the Kavita `Volume` table for the signature `100000` name or `0` number to identify items in the "Specials Bucket."
4.  **Result:** "Superman 6" maps to `superman|6|False` and "Superman Annual 6" maps to `superman|6|True`. Both import correctly with no data loss.