### PR TITLE
Add reader look ahead

### DIFF
--- a/app/templates/reader.html
+++ b/app/templates/reader.html
@@ -176,7 +176,7 @@
      x-on:touchstart="handleTouchStart($event)"
      x-on:touchend="handleTouchEnd($event)">
 
-    <div class="reader-toolbar">
+    <div class="reader-toolbar" :class="{'hidden': !shouldShowUI}">
 
         <!-- Left side close button + Comic information -->
         <div class="flex items-center space-x-4 max-w-[50%]">
@@ -203,6 +203,8 @@
 
         <!-- Right side icons -->
         <div class="flex items-center space-x-2">
+
+            <span class="text-gray-400 text-xs font-mono font-bold mr-3 hidden md:block" x-text="currentTime"></span>
 
             <button x-on:click="toggleUiLock()" class="p-2 rounded hover:bg-white/10 transition-colors"
                     :class="uiLocked ? 'text-blue-400' : 'text-gray-300'"
@@ -497,6 +499,9 @@
 <script>
 function reader() {
     return {
+
+        currentTime: '',
+
         // --- Core State ---
         comicId: {{ comic_id }},
         currentPage: 0,
@@ -523,6 +528,7 @@ function reader() {
         scrubberValue: 0,
         isScrubbing: false,  // True while dragging
         isHoveringScrubber: false,
+        tapVisible: false,
         uiLocked: false,  // If true, UI is always on
         isHoveringZone: false,  // If true, mouse is at the bottom
         isHoveringBar: false,  // The actual button bar
@@ -544,6 +550,12 @@ function reader() {
         },
 
         init() {
+
+            // Initialize Clock
+            this.updateClock();
+
+            // Start Timer (Update every minute is usually enough, but seconds works too)
+            setInterval(() => { this.updateClock(); }, 1000);
 
             // Load settings from local storage
             this.viewMode = localStorage.getItem('reader_viewMode') || 'single';
@@ -1040,8 +1052,9 @@ function reader() {
         // Computed property for visibility
         get shouldShowUI() {
 
-            return this.uiLocked
-                || this.isHoveringZone
+            return this.uiLocked        // Persistent Pin
+                || this.tapVisible      // Transient Tap
+                || this.isHoveringZone  // Mouse Hover
                 || this.showSettings
                 || this.showGoto
                 || this.isScrubbing
@@ -1100,7 +1113,16 @@ function reader() {
 
             // Center Tap: Toggle UI Visibility
             if (zone === 'center') {
-                this.toggleUiLock();
+
+                // If the UI is already pinned (Locked), tapping center does nothing
+                // (or you could make it unpin, but standard behavior is "Pin overrides all")
+                if (this.uiLocked) {
+                     window.comicServer.showToast("UI is Pinned. Use Eye icon to unlock.");
+                     return;
+                }
+
+                // Standard Toggle
+                this.tapVisible = !this.tapVisible;
                 return;
             }
 
@@ -1179,6 +1201,10 @@ function reader() {
             } else {
                 this.nextPage();
             }
+        },
+
+        updateClock() {
+            this.currentTime = new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
         },
 
     }


### PR DESCRIPTION

# Feature: Zero-Latency Reader, Smart Spreads & UX Overhaul

### 🚀 Summary
This PR introduces a "Zero-Latency" reading engine that preloads pages into the browser cache, eliminating white flashes between page turns. It also implements "Smart Double Spreads" (automatically detecting wide pages), full Manga Mode (RTL) support with correct spine alignment, and a suite of mobile-friendly UX enhancements like swipe navigation and center-tap controls.

### ✨ Key Features

**1. Zero-Latency Page Turning**
* **Preloader Engine:** Implemented a `preloadContext()` strategy that intelligently fetches the next 2-4 pages (depending on view mode) into the browser's disk cache.
* **Unified URL Strategy:** Refactored `getPageUrl` to ensure the preloader and the main display use identical URLs (removing timestamp cache-busters), ensuring 100% cache hit rates.

**2. Smart Double-Page Logic**
* **Landscape Detection:** The preloader now "sniffs" image dimensions on load. If a page is detected as Landscape (Width > Height), the reader marks it as a "Solo" page.
* **Smart Pairing:** The `pagesToDisplay` logic now refuses to split a wide image across two slots. It correctly renders wide spreads alone, even in Double Page mode.
* **Ghosting Fix:** Switched image rendering to use `x-for` with unique `:key` binding. This forces a DOM replacement on page turn, preventing the "stretching/morphing" visual glitch where the previous page would briefly render in the new page's container.

**3. Visual Polish & Immersion**
* **Magnetic Spine:** In Double Page mode, images now magnetically align to the center spine.
    * **Direction Aware:** The alignment logic now respects Manga Mode (RTL), swapping the "Left" and "Right" magnetic pull accordingly.
* **Book Fold Shadow:** Added a subtle, toggleable central gradient shadow to emulate the curve of a physical book spine.
* **Transitions Removed:** Stripped CSS layout transitions to ensure "snap" page turns without layout shifting or growing animations.

**4. Mobile & Tablet UX**
* **Swipe Navigation:** Added native touch event listeners (`touchstart`, `touchend`) to support natural swipe gestures.
    * **Context Aware:** Swipe direction automatically inverts when in Manga Mode (RTL).
* **Center Tap Zone:** Added a 20-80% "Center Zone". Tapping this transiently toggles the UI visibility without permanently "locking" it.
* **Top Bar Logic:** Fixed the top toolbar to correctly auto-hide along with the bottom controls.
* **Status Bar:** Added a digital clock to the top toolbar for full-screen reading convenience.

### 🛠 Technical Changes

* **Persistence:** All reader settings (`uiLocked`, `fitMode`, `doublePageOffset`, `showSpineShadow`) now persist to `localStorage` and correctly restore on load (using `JSON.parse` for booleans).
* **Navigation Logic:** Rewrote `prevPage()` to correctly handle looking back at potential solo/spread pages to prevent skipping pages when moving backward.
* **Progress Sync:** Fixed a regression where `updateProgress()` was not being called when navigating backward in Single Mode.
* **Refactor:** Consolidates `reader.html` Alpine logic into a more robust `reader()` object with dedicated helpers for `isPageSolo` and `imageClasses`.

### 🧪 Testing Instructions

**1. Zero Latency**
* Open a comic.
* Rapidly tap "Next" (Right Arrow).
* **Verify:** Images load instantly with no white flash or loading spinner.

**2. Smart Spreads**
* Find a comic with a double-page spread scanned as a single file.
* Enter **Double Mode (`d`)**.
* Navigate until you hit the spread.
* **Verify:** The spread displays centered on its own. The previous and next pages pair up correctly around it.

**3. Manga Mode**
* Open a comic and hit **Manga Mode (`m`)**.
* **Verify:**
    * "Next" button/arrow goes to the *Left* page.
    * Swiping *Right* goes to the next page.
    * In Double Mode, Page 1 appears on the *Right* side of the screen.

**4. UI & Persistence**
* Toggle "Book Shadow" on. Reload page. Verify it stays on.
* Tap the center of the screen. Verify UI appears. Tap again (or wait). Verify UI hides.
* Click the "Eye" icon (Lock). Reload page. Verify UI is still visible.