### PR TITLE
Add 'Unknown Series' during a scan to the metadata health report

### DIFF
--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -218,6 +218,11 @@ async def get_metadata_health_report(db: SessionDep, user: AdminUser):
     # Each check is a tuple: (Label, SQLAlchemy Filter, Severity)
     checks = [
         (
+            "Unknown Series (Scan Fallback)",
+            Comic.volume.has(Volume.series.has(Series.name == "Unknown Series")),
+            "error"
+        ),
+        (
             "Missing Summary",
             or_(Comic.summary == None, Comic.summary == ""),
             "warning"

--- a/app/templates/admin/reports/metadata.html
+++ b/app/templates/admin/reports/metadata.html
@@ -72,7 +72,7 @@
 
                     <div class="flex items-center">
                         <a 
-                            :href="window.parker.route('pages.search', {}, `field=${getSearchField(item.label)}&operator=is_empty`)"
+                            :href="getSearchLink(item.label)"
                             class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded transition-colors whitespace-nowrap"
                         >
                             View All
@@ -116,14 +116,23 @@ function healthReport() {
             if(this.report.overall_score >= 70) return 'text-yellow-500';
             return 'text-red-500';
         },
+        getSearchLink(label) {
+            const baseUrl = window.parker.route('pages.search');
 
-        getSearchField(label) {
-            // Helper to map report labels to search query params
-            if(label.includes("Summary")) return "summary"; // Note: Search needs to support this field
-            if(label.includes("Year")) return "year";
-            if(label.includes("Publisher")) return "publisher";
-            if(label.includes("Web")) return "web";
-            return "title"; // Fallback
+            // 1. Special Case: Unknown Series (Value Match)
+            if (label === "Unknown Series (Scan Fallback)") {
+                return `${baseUrl}?field=series&operator=equal&value=Unknown Series`;
+            }
+
+            // 2. Default Case: Empty Field Checks
+            let field = "title";
+            if (label.includes("Summary")) field = "summary";
+            else if (label.includes("Year")) field = "year";
+            else if (label.includes("Publisher")) field = "publisher";
+            else if (label.includes("Web")) field = "web";
+            //else if (label.includes("Page Count")) field = "page_count"; // Future
+
+            return `${baseUrl}?field=${field}&operator=is_empty`;
         }
     }
 }


### PR DESCRIPTION

## 🚀 Summary
Following the recent update to the Scanner (which now defaults missing series metadata to "Unknown Series" instead of crashing), this PR adds a corresponding check to the **Metadata Health Report**.

Admins can now instantly see how many files fell into this fallback bucket and click "View All" to jump directly to those specific issues for manual fixing.

## ✨ Key Changes

### 1. Backend (`app/api/routes/reports.py`)
* **New Health Check:** Added a check to `Youtube_health_report` that flags comics belonging to a Series named `"Unknown Series"`.
* **Logic:** Uses SQLAlchemy's `has()` method to query across the relationship chain (`Comic -> Volume -> Series`).

### 2. Frontend (`app/templates/metadata.html`)
* **Smart Link Generation:** Updated the "View All" button logic. Previously, it assumed all health issues were "Empty Fields" (`operator=is_empty`).
* **Dynamic Routing:** The new `getSearchLink()` function now supports "Exact Match" routing, correctly directing the "Unknown Series" error to a search for `field=series&value=Unknown Series`.

## 📸 Workflow
1. **Scanner:** Encounters a file with no series name -> Imports it as "Unknown Series".
2. **Report:** Metadata Health shows "Unknown Series (Scan Fallback): 5 items".
3. **Action:** Clicking "View All" opens the Search page filtered to those 5 items.

## ✅ Checklist
- [x] Added "Unknown Series" check to backend report logic
- [x] Refactored frontend link generation to support value-based searches
- [x] Verified "View All" link correctly pre-fills the search filters