### PR TITLE
test: expand API coverage across core endpoints and remove deprecatio…

### DIFF
--- a/app/api/saved_searches.py
+++ b/app/api/saved_searches.py
@@ -54,7 +54,7 @@ async def save_search(
     saved = SavedSearch(
         user_id=current_user.id,
         name=data.name,
-        query_json=data.query.json()  # Serialize Pydantic model to JSON string
+        query_json=data.query.model_dump_json()  # Serialize Pydantic model to JSON string
     )
     db.add(saved)
     db.commit()

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -177,7 +177,7 @@ async def upload_avatar(
     content = await file.read()
     if len(content) > MAX_AVATAR_SIZE_BYTES:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail="File too large. Maximum size is 5MB."
         )
 

--- a/app/services/search.py
+++ b/app/services/search.py
@@ -59,7 +59,7 @@ class SearchService:
 
         # Get total count before pagination
         # Optimization: Count distinct IDs to handle joins correctly
-        total = query.distinct(Comic.id).count()
+        total = query.with_entities(func.count(func.distinct(Comic.id))).scalar()
 
         # Apply sorting
         query = self._apply_sorting(query, request.sort_by, request.sort_order)

--- a/tests/api/test_comics.py
+++ b/tests/api/test_comics.py
@@ -1,0 +1,409 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from app.api.comics import filter_by_user_access, natural_sort_key
+from app.models.collection import Collection, CollectionItem
+from app.models.comic import Comic, Volume
+from app.models.credits import ComicCredit, Person
+from app.models.library import Library
+from app.models.pull_list import PullList, PullListItem
+from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.reading_progress import ReadingProgress
+from app.models.series import Series
+from app.models.tags import Character, Genre, Location, Team
+
+
+def _create_graph(db, *, lib_name: str, series_name: str):
+    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    series = Series(name=series_name, library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([library, series, volume])
+    db.flush()
+    return library, series, volume
+
+
+def test_filter_by_user_access_and_natural_sort_key(db, admin_user, normal_user):
+    lib_a, _, vol_a = _create_graph(db, lib_name="comic-access-a", series_name="Access A")
+    lib_b, _, vol_b = _create_graph(db, lib_name="comic-access-b", series_name="Access B")
+
+    comic_a = Comic(
+        volume_id=vol_a.id,
+        number="1",
+        title="A #1",
+        filename="a-1.cbz",
+        file_path="/tmp/access-a-1.cbz",
+    )
+    comic_b = Comic(
+        volume_id=vol_b.id,
+        number="1",
+        title="B #1",
+        filename="b-1.cbz",
+        file_path="/tmp/access-b-1.cbz",
+    )
+    db.add_all([comic_a, comic_b])
+
+    normal_user.accessible_libraries.append(lib_a)
+    db.commit()
+
+    base = db.query(Comic).join(Volume).join(Series)
+
+    admin_visible = filter_by_user_access(base, admin_user).all()
+    user_visible = filter_by_user_access(base, normal_user).all()
+
+    assert {c.id for c in admin_visible} == {comic_a.id, comic_b.id}
+    assert [c.id for c in user_visible] == [comic_a.id]
+
+    assert sorted(["10", "2", "10a", "1"], key=natural_sort_key) == ["1", "2", "10", "10a"]
+
+
+def test_search_comics_delegates_to_search_service(auth_client):
+    expected = {
+        "total": 1,
+        "limit": 50,
+        "offset": 0,
+        "results": [
+            {
+                "id": 123,
+                "series": "Delegation Series",
+                "volume": 1,
+                "number": "1",
+                "title": "Delegation Issue",
+                "year": 2024,
+                "publisher": "Publisher",
+                "format": None,
+                "thumbnail_path": None,
+                "community_rating": None,
+                "progress_percentage": None,
+            }
+        ],
+    }
+
+    with patch("app.api.comics.SearchService") as mock_service_cls:
+        mock_service_cls.return_value.search.return_value = expected
+
+        response = auth_client.post(
+            "/api/comics/search",
+            json={
+                "match": "all",
+                "filters": [],
+                "sort_by": "created",
+                "sort_order": "desc",
+                "limit": 50,
+                "offset": 0,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == expected
+    mock_service_cls.return_value.search.assert_called_once()
+
+
+def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, db, normal_user):
+    library, series, volume = _create_graph(db, lib_name="comic-detail", series_name="Detail Saga")
+
+    comic = Comic(
+        volume_id=volume.id,
+        number="7",
+        title="Detail Issue",
+        summary="Issue summary",
+        page_count=20,
+        publisher="Detail Pub",
+        imprint="Detail Imprint",
+        age_rating="Teen",
+        language_iso="en",
+        filename="detail-7.cbz",
+        file_path="/tmp/detail-7.cbz",
+    )
+    db.add(comic)
+    db.flush()
+
+    writer = Person(name="Detail Writer")
+    penciller = Person(name="Detail Penciller")
+    hero = Character(name="Detail Hero")
+    team = Team(name="Detail Team")
+    location = Location(name="Detail City")
+    genre = Genre(name="Detail Genre")
+    db.add_all([writer, penciller, hero, team, location, genre])
+    db.flush()
+
+    db.add_all([
+        ComicCredit(comic_id=comic.id, person_id=writer.id, role="writer"),
+        ComicCredit(comic_id=comic.id, person_id=penciller.id, role="penciller"),
+    ])
+
+    comic.characters.append(hero)
+    comic.teams.append(team)
+    comic.locations.append(location)
+    comic.genres.append(genre)
+
+    normal_user.accessible_libraries.append(library)
+    db.flush()
+
+    db.add(
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=comic.id,
+            current_page=5,
+            total_pages=20,
+            completed=False,
+        )
+    )
+    db.commit()
+
+    response = auth_client.get(f"/api/comics/{comic.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == comic.id
+    assert payload["series_id"] == series.id
+    assert payload["library_id"] == library.id
+    assert payload["credits"] == {
+        "writer": ["Detail Writer"],
+        "penciller": ["Detail Penciller"],
+    }
+    assert payload["characters"] == ["Detail Hero"]
+    assert payload["teams"] == ["Detail Team"]
+    assert payload["locations"] == ["Detail City"]
+    assert payload["genres"] == ["Detail Genre"]
+    assert payload["read_status"] == "in_progress"
+
+
+def test_get_comic_detail_missing_or_hidden_returns_404(auth_client, db):
+    response = auth_client.get("/api/comics/999999")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Comic not found"}
+
+    library, _, volume = _create_graph(db, lib_name="comic-hidden", series_name="Hidden Saga")
+    comic = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="Hidden",
+        filename="hidden.cbz",
+        file_path="/tmp/hidden.cbz",
+    )
+    db.add_all([library, comic])
+    db.commit()
+
+    hidden = auth_client.get(f"/api/comics/{comic.id}")
+    assert hidden.status_code == 404
+    assert hidden.json() == {"detail": "Comic not found"}
+
+
+def test_get_comic_thumbnail_db_path_and_fallback_and_missing(client, db, tmp_path):
+    library, _, volume = _create_graph(db, lib_name="comic-thumb", series_name="Thumb Saga")
+
+    db_thumb = tmp_path / "db-thumb.webp"
+    db_thumb.write_bytes(b"db-thumb")
+
+    comic_db = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="DB Thumb",
+        thumbnail_path=str(db_thumb),
+        filename="db-thumb.cbz",
+        file_path="/tmp/db-thumb.cbz",
+    )
+    comic_std = Comic(
+        volume_id=volume.id,
+        number="2",
+        title="Std Thumb",
+        thumbnail_path=None,
+        filename="std-thumb.cbz",
+        file_path="/tmp/std-thumb.cbz",
+    )
+    comic_missing = Comic(
+        volume_id=volume.id,
+        number="3",
+        title="No Thumb",
+        thumbnail_path=None,
+        filename="no-thumb.cbz",
+        file_path="/tmp/no-thumb.cbz",
+    )
+    db.add_all([library, comic_db, comic_std, comic_missing])
+    db.commit()
+
+    db_resp = client.get(f"/api/comics/{comic_db.id}/thumbnail")
+    assert db_resp.status_code == 200
+    assert db_resp.headers["content-type"].startswith("image/webp")
+    assert "ETag" in db_resp.headers
+
+    standard_dir = Path("storage/cover")
+    standard_dir.mkdir(parents=True, exist_ok=True)
+    standard_path = standard_dir / f"comic_{comic_std.id}.webp"
+    standard_backup = standard_path.read_bytes() if standard_path.exists() else None
+    standard_path.write_bytes(b"standard-thumb")
+
+    try:
+        std_resp = client.get(f"/api/comics/{comic_std.id}/thumbnail")
+        assert std_resp.status_code == 200
+        assert std_resp.headers["content-type"].startswith("image/webp")
+    finally:
+        if standard_backup is None:
+            if standard_path.exists():
+                standard_path.unlink()
+        else:
+            standard_path.write_bytes(standard_backup)
+
+    missing_standard_path = standard_dir / f"comic_{comic_missing.id}.webp"
+    missing_backup = missing_standard_path.read_bytes() if missing_standard_path.exists() else None
+    if missing_standard_path.exists():
+        missing_standard_path.unlink()
+
+    try:
+        missing_resp = client.get(f"/api/comics/{comic_missing.id}/thumbnail")
+        assert missing_resp.status_code == 404
+        assert missing_resp.json() == {"detail": "Could not find thumbnail"}
+    finally:
+        if missing_backup is not None:
+            missing_standard_path.write_bytes(missing_backup)
+
+
+def test_random_backgrounds_handles_empty_and_limit(client, db):
+    empty = client.get("/api/comics/random/backgrounds?limit=3")
+    assert empty.status_code == 200
+    assert empty.json() == []
+
+    library, _, volume = _create_graph(db, lib_name="comic-random", series_name="Random Saga")
+    c1 = Comic(volume_id=volume.id, number="1", title="R1", thumbnail_path="/tmp/r1.webp", filename="r1.cbz", file_path="/tmp/r1.cbz")
+    c2 = Comic(volume_id=volume.id, number="2", title="R2", thumbnail_path="/tmp/r2.webp", filename="r2.cbz", file_path="/tmp/r2.cbz")
+    c3 = Comic(volume_id=volume.id, number="3", title="R3", thumbnail_path="/tmp/r3.webp", filename="r3.cbz", file_path="/tmp/r3.cbz")
+    db.add_all([library, c1, c2, c3])
+    db.commit()
+
+    with patch("app.api.comics.random.sample", side_effect=lambda rows, size: rows[:size]):
+        response = client.get("/api/comics/random/backgrounds?limit=2")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 2
+    assert payload[0].startswith(f"/api/comics/{c1.id}/thumbnail?v=")
+    assert payload[1].startswith(f"/api/comics/{c2.id}/thumbnail?v=")
+
+
+def test_cover_manifest_volume_and_series_reverse_sort(auth_client, db, normal_user):
+    library, series, volume = _create_graph(db, lib_name="comic-manifest-rev", series_name="Countdown")
+
+    issue_one = Comic(
+        volume_id=volume.id,
+        number="1",
+        year=2020,
+        title="Countdown #1",
+        thumbnail_path="/tmp/cd-1.webp",
+        filename="cd-1.cbz",
+        file_path="/tmp/cd-1.cbz",
+    )
+    issue_four = Comic(
+        volume_id=volume.id,
+        number="4",
+        year=2020,
+        title="Countdown #4",
+        thumbnail_path="/tmp/cd-4.webp",
+        filename="cd-4.cbz",
+        file_path="/tmp/cd-4.cbz",
+    )
+    db.add_all([issue_one, issue_four])
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    by_volume = auth_client.get(f"/api/comics/covers/manifest?context_type=volume&context_id={volume.id}")
+    assert by_volume.status_code == 200
+    assert [item["label"] for item in by_volume.json()["items"]] == ["Countdown #4", "Countdown #1"]
+
+    by_series = auth_client.get(f"/api/comics/covers/manifest?context_type=series&context_id={series.id}")
+    assert by_series.status_code == 200
+    assert [item["label"] for item in by_series.json()["items"]] == ["Countdown #4", "Countdown #1"]
+
+
+def test_cover_manifest_reading_list_pull_list_and_collection_ordering(auth_client, db, normal_user):
+    library, series, volume = _create_graph(db, lib_name="comic-manifest-order", series_name="Manifest Order")
+
+    c1 = Comic(
+        volume_id=volume.id,
+        number="2",
+        year=2022,
+        title="Order #2",
+        thumbnail_path="/tmp/order-2.webp",
+        filename="order-2.cbz",
+        file_path="/tmp/order-2.cbz",
+    )
+    c2 = Comic(
+        volume_id=volume.id,
+        number="1",
+        year=2020,
+        title="Order #1",
+        thumbnail_path="/tmp/order-1.webp",
+        filename="order-1.cbz",
+        file_path="/tmp/order-1.cbz",
+    )
+    c3 = Comic(
+        volume_id=volume.id,
+        number="3",
+        year=2021,
+        title="Order #3",
+        thumbnail_path="/tmp/order-3.webp",
+        filename="order-3.cbz",
+        file_path="/tmp/order-3.cbz",
+    )
+    db.add_all([c1, c2, c3])
+    db.flush()
+
+    reading_list = ReadingList(name="Manifest Reading", description="")
+    pull_list = PullList(user_id=normal_user.id, name="Manifest Pull")
+    collection = Collection(name="Manifest Collection", description="")
+    db.add_all([reading_list, pull_list, collection])
+    db.flush()
+
+    db.add_all([
+        ReadingListItem(reading_list_id=reading_list.id, comic_id=c1.id, position=2),
+        ReadingListItem(reading_list_id=reading_list.id, comic_id=c2.id, position=1),
+        PullListItem(pull_list_id=pull_list.id, comic_id=c1.id, sort_order=20),
+        PullListItem(pull_list_id=pull_list.id, comic_id=c3.id, sort_order=10),
+        CollectionItem(collection_id=collection.id, comic_id=c1.id),
+        CollectionItem(collection_id=collection.id, comic_id=c2.id),
+        CollectionItem(collection_id=collection.id, comic_id=c3.id),
+    ])
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    reading_resp = auth_client.get(
+        f"/api/comics/covers/manifest?context_type=reading_list&context_id={reading_list.id}"
+    )
+    assert reading_resp.status_code == 200
+    assert [i["comic_id"] for i in reading_resp.json()["items"]] == [c2.id, c1.id]
+
+    pull_resp = auth_client.get(
+        f"/api/comics/covers/manifest?context_type=pull_list&context_id={pull_list.id}"
+    )
+    assert pull_resp.status_code == 200
+    assert [i["comic_id"] for i in pull_resp.json()["items"]] == [c3.id, c1.id]
+
+    collection_resp = auth_client.get(
+        f"/api/comics/covers/manifest?context_type=collection&context_id={collection.id}"
+    )
+    assert collection_resp.status_code == 200
+    assert [i["comic_id"] for i in collection_resp.json()["items"]] == [c2.id, c3.id, c1.id]
+
+
+def test_cover_manifest_hides_items_outside_user_library(auth_client, db):
+    library, _, volume = _create_graph(db, lib_name="comic-manifest-hidden", series_name="Hidden Manifest")
+    comic = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="Hidden Manifest #1",
+        year=2024,
+        thumbnail_path="/tmp/hm-1.webp",
+        filename="hm-1.cbz",
+        file_path="/tmp/hm-1.cbz",
+    )
+    db.add_all([library, comic])
+    db.commit()
+
+    response = auth_client.get(f"/api/comics/covers/manifest?context_type=volume&context_id={volume.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 0
+    assert payload["items"] == []
+

--- a/tests/api/test_deps.py
+++ b/tests/api/test_deps.py
@@ -1,0 +1,218 @@
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+from jose import jwt
+from starlette.requests import Request
+
+from app.api import deps
+from app.config import settings
+from app.core.security import get_password_hash
+from app.models.comic import Comic, Volume
+from app.models.library import Library
+from app.models.series import Series
+from app.models.user import User
+
+
+def _make_request(cookie_header: str | None = None) -> Request:
+    headers = []
+    if cookie_header:
+        headers.append((b"cookie", cookie_header.encode("utf-8")))
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": headers,
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "scheme": "http",
+    }
+    return Request(scope)
+
+
+def _seed_graph(db):
+    library = Library(name="deps-lib", path="/tmp/deps-lib")
+    series = Series(name="Deps Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    comic = Comic(
+        volume=volume,
+        number="1",
+        title="Deps Comic",
+        filename="deps-comic.cbz",
+        file_path="/tmp/deps-comic.cbz",
+    )
+    db.add_all([library, series, volume, comic])
+    db.commit()
+    db.refresh(library)
+    db.refresh(series)
+    db.refresh(volume)
+    db.refresh(comic)
+    return library, series, volume, comic
+
+
+def _create_user(db, *, username: str, email: str, is_superuser: bool = False):
+    user = User(
+        username=username,
+        email=email,
+        hashed_password=get_password_hash("pass1234"),
+        is_superuser=is_superuser,
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_token(username: str) -> str:
+    return jwt.encode({"sub": username}, settings.secret_key, algorithm=settings.algorithm)
+
+
+def test_get_db_closes_session(monkeypatch):
+    events = []
+
+    class DummySession:
+        def close(self):
+            events.append("closed")
+
+    monkeypatch.setattr(deps, "SessionLocal", lambda: DummySession())
+
+    gen = deps.get_db()
+    session = next(gen)
+    assert isinstance(session, DummySession)
+
+    with pytest.raises(StopIteration):
+        next(gen)
+
+    assert events == ["closed"]
+
+
+def test_get_token_hybrid_header_cookie_and_missing():
+    from_header = asyncio.run(deps.get_token_hybrid(_make_request(), token_auth="header-token"))
+    assert from_header == "header-token"
+
+    from_cookie = asyncio.run(deps.get_token_hybrid(_make_request("access_token=cookie-token"), token_auth=""))
+    assert from_cookie == "cookie-token"
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(deps.get_token_hybrid(_make_request(), token_auth=""))
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "Not authenticated"
+
+
+def test_get_token_optional_paths():
+    assert asyncio.run(deps.get_token_optional(_make_request(), token_auth="header-token")) == "header-token"
+    assert asyncio.run(deps.get_token_optional(_make_request("access_token=cookie-token"), token_auth="")) == "cookie-token"
+    assert asyncio.run(deps.get_token_optional(_make_request(), token_auth="")) is None
+
+
+def test_get_current_user_valid_and_error_paths(db):
+    user = _create_user(db, username="deps-user", email="deps-user@example.com")
+
+    token = _make_token(user.username)
+    resolved = asyncio.run(deps.get_current_user(db=db, token=token))
+    assert resolved.id == user.id
+
+    bad_payload = jwt.encode({"foo": "bar"}, settings.secret_key, algorithm=settings.algorithm)
+    with pytest.raises(HTTPException) as missing_sub:
+        asyncio.run(deps.get_current_user(db=db, token=bad_payload))
+    assert missing_sub.value.status_code == 401
+
+    with pytest.raises(HTTPException) as invalid_token:
+        asyncio.run(deps.get_current_user(db=db, token="not-a-jwt"))
+    assert invalid_token.value.status_code == 401
+
+    ghost_token = _make_token("missing-user")
+    with pytest.raises(HTTPException) as missing_user:
+        asyncio.run(deps.get_current_user(db=db, token=ghost_token))
+    assert missing_user.value.status_code == 401
+
+
+def test_get_current_user_optional_paths(db):
+    user = _create_user(db, username="deps-optional", email="deps-optional@example.com")
+
+    assert asyncio.run(deps.get_current_user_optional(db=db, token=None)) is None
+    assert asyncio.run(deps.get_current_user_optional(db=db, token="not-a-jwt")) is None
+
+    no_sub = jwt.encode({"foo": "bar"}, settings.secret_key, algorithm=settings.algorithm)
+    assert asyncio.run(deps.get_current_user_optional(db=db, token=no_sub)) is None
+
+    token = _make_token(user.username)
+    resolved = asyncio.run(deps.get_current_user_optional(db=db, token=token))
+    assert resolved.id == user.id
+
+
+def test_get_current_active_superuser_guard(db):
+    admin = _create_user(db, username="deps-admin", email="deps-admin@example.com", is_superuser=True)
+    user = _create_user(db, username="deps-normal", email="deps-normal@example.com", is_superuser=False)
+
+    resolved = asyncio.run(deps.get_current_active_superuser(current_user=admin))
+    assert resolved.id == admin.id
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(deps.get_current_active_superuser(current_user=user))
+
+    assert exc.value.status_code == 400
+
+
+def test_get_secure_library_paths(db):
+    library, _, _, _ = _seed_graph(db)
+    admin = _create_user(db, username="deps-lib-admin", email="deps-lib-admin@example.com", is_superuser=True)
+    user = _create_user(db, username="deps-lib-user", email="deps-lib-user@example.com")
+
+    with pytest.raises(HTTPException) as missing_for_user:
+        asyncio.run(deps.get_secure_library(library_id=library.id, db=db, user=user))
+    assert missing_for_user.value.status_code == 404
+
+    user.accessible_libraries.append(library)
+    db.commit()
+
+    allowed = asyncio.run(deps.get_secure_library(library_id=library.id, db=db, user=user))
+    assert allowed.id == library.id
+
+    admin_allowed = asyncio.run(deps.get_secure_library(library_id=library.id, db=db, user=admin))
+    assert admin_allowed.id == library.id
+
+    with pytest.raises(HTTPException) as missing_library:
+        asyncio.run(deps.get_secure_library(library_id=999999, db=db, user=admin))
+    assert missing_library.value.status_code == 404
+
+
+def test_get_secure_series_volume_and_comic_paths(db):
+    library, series, volume, comic = _seed_graph(db)
+    user = _create_user(db, username="deps-sec-user", email="deps-sec-user@example.com")
+
+    with pytest.raises(HTTPException):
+        asyncio.run(deps.get_secure_series(series_id=series.id, db=db, user=user))
+    with pytest.raises(HTTPException):
+        asyncio.run(deps.get_secure_volume(volume_id=volume.id, db=db, user=user))
+    with pytest.raises(HTTPException):
+        asyncio.run(deps.get_secure_comic(comic_id=comic.id, db=db, user=user))
+
+    user.accessible_libraries.append(library)
+    db.commit()
+
+    resolved_series = asyncio.run(deps.get_secure_series(series_id=series.id, db=db, user=user))
+    resolved_volume = asyncio.run(deps.get_secure_volume(volume_id=volume.id, db=db, user=user))
+    resolved_comic = asyncio.run(deps.get_secure_comic(comic_id=comic.id, db=db, user=user))
+
+    assert resolved_series.id == series.id
+    assert resolved_volume.id == volume.id
+    assert resolved_comic.id == comic.id
+
+    with pytest.raises(HTTPException) as missing_series:
+        asyncio.run(deps.get_secure_series(series_id=999999, db=db, user=user))
+    assert missing_series.value.status_code == 404
+
+    with pytest.raises(HTTPException) as missing_volume:
+        asyncio.run(deps.get_secure_volume(volume_id=999999, db=db, user=user))
+    assert missing_volume.value.status_code == 404
+
+    with pytest.raises(HTTPException) as missing_comic:
+        asyncio.run(deps.get_secure_comic(comic_id=999999, db=db, user=user))
+    assert missing_comic.value.status_code == 404

--- a/tests/api/test_home.py
+++ b/tests/api/test_home.py
@@ -1,0 +1,398 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.api.home import _pick_best_cover, format_home_item
+from app.models.comic import Comic, Volume
+from app.models.library import Library
+from app.models.reading_progress import ReadingProgress
+from app.models.series import Series
+from app.models.user import User
+
+
+def _create_series_graph(db, *, lib_name: str, series_name: str):
+    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    series = Series(name=series_name, library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([library, series, volume])
+    db.flush()
+    return library, series, volume
+
+
+def _add_comic(db, volume: Volume, *, number: str, title: str, **kwargs):
+    comic = Comic(
+        volume_id=volume.id,
+        number=number,
+        title=title,
+        filename=f"{title.replace(' ', '-')}.cbz",
+        file_path=f"/tmp/{title.replace(' ', '-')}-{volume.id}-{number}.cbz",
+        **kwargs,
+    )
+    db.add(comic)
+    db.flush()
+    return comic
+
+
+def _add_user(db, *, username: str, email: str, share_progress_enabled: bool):
+    user = User(
+        username=username,
+        email=email,
+        hashed_password="x",
+        is_superuser=False,
+        is_active=True,
+        share_progress_enabled=share_progress_enabled,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def test_format_home_item_and_pick_best_cover_helpers():
+    comic = Comic(
+        id=11,
+        number="7",
+        title="Helper Comic",
+        year=2025,
+        publisher="Helper Pub",
+        page_count=10,
+        updated_at=None,
+    )
+    progress = ReadingProgress(user_id=1, comic_id=11, current_page=15, total_pages=10, completed=False)
+
+    item = format_home_item(comic, progress)
+    assert item["id"] == 11
+    assert item["series"] == "Unknown"
+    assert item["volume"] == 0
+    assert item["thumbnail_path"] == "/api/comics/11/thumbnail?v=0"
+    assert item["progress_percentage"] == 100.0
+
+    no_progress = format_home_item(comic)
+    assert no_progress["progress_percentage"] is None
+
+    assert _pick_best_cover(SimpleNamespace(name="Any"), []) is None
+
+    non_reverse = SimpleNamespace(name="Regular")
+    regular_pool = [
+        SimpleNamespace(number="A", format=None),
+        SimpleNamespace(number="3", format=None),
+        SimpleNamespace(number="2", format="annual"),
+    ]
+    picked_regular = _pick_best_cover(non_reverse, regular_pool)
+    assert picked_regular.number == "3"
+
+    issue_one_pool = [
+        SimpleNamespace(number="2", format=None),
+        SimpleNamespace(number="1", format=None),
+    ]
+    picked_issue_one = _pick_best_cover(non_reverse, issue_one_pool)
+    assert picked_issue_one.number == "1"
+
+    reverse = SimpleNamespace(name="Countdown")
+    reverse_pool = [
+        SimpleNamespace(number="1", format=None),
+        SimpleNamespace(number="4", format=None),
+    ]
+    picked_reverse = _pick_best_cover(reverse, reverse_pool)
+    assert picked_reverse.number == "4"
+
+
+def test_home_random_empty_and_skips_series_without_comics(auth_client, db):
+    empty = auth_client.get("/api/home/random?limit=10")
+    assert empty.status_code == 200
+    assert empty.json() == []
+
+    _, no_comics_series, _ = _create_series_graph(
+        db,
+        lib_name="home-random-empty-lib",
+        series_name="Home Random Empty",
+    )
+    _, full_series, full_volume = _create_series_graph(
+        db,
+        lib_name="home-random-full-lib",
+        series_name="Home Random Full",
+    )
+    first = _add_comic(
+        db,
+        full_volume,
+        number="1",
+        title="Home Random #1",
+        year=2022,
+        publisher="Random Pub",
+    )
+    db.commit()
+
+    response = auth_client.get("/api/home/random?limit=10")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert len(payload) == 1
+    assert payload[0]["id"] == full_series.id
+    assert payload[0]["name"] == "Home Random Full"
+    assert payload[0]["volume_count"] == 1
+    assert payload[0]["publisher"] == "Random Pub"
+    assert payload[0]["thumbnail_path"].startswith(f"/api/comics/{first.id}/thumbnail?v=")
+    assert no_comics_series.id not in [item["id"] for item in payload]
+
+
+def test_home_rated_orders_by_rating(auth_client, db):
+    _, _, volume = _create_series_graph(db, lib_name="home-rated-lib", series_name="Home Rated")
+
+    high = _add_comic(
+        db,
+        volume,
+        number="2",
+        title="Top Rated",
+        community_rating=4.9,
+    )
+    _add_comic(
+        db,
+        volume,
+        number="1",
+        title="Lower Rated",
+        community_rating=4.1,
+    )
+    _add_comic(
+        db,
+        volume,
+        number="0",
+        title="Below Threshold",
+        community_rating=3.9,
+    )
+    db.commit()
+
+    response = auth_client.get("/api/home/rated?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 2
+    assert payload[0]["id"] == high.id
+    assert payload[0]["community_rating"] == 4.9
+
+
+def test_home_resume_applies_staleness_and_progress_percentage(auth_client, db, normal_user):
+    _, _, volume = _create_series_graph(db, lib_name="home-resume-lib", series_name="Home Resume")
+
+    recent = _add_comic(db, volume, number="1", title="Recent Resume", page_count=10)
+    stale = _add_comic(db, volume, number="2", title="Stale Resume", page_count=20)
+
+    db.add_all([
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=recent.id,
+            current_page=15,
+            total_pages=10,
+            completed=False,
+            last_read_at=datetime.now(timezone.utc) - timedelta(days=2),
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=stale.id,
+            current_page=5,
+            total_pages=20,
+            completed=False,
+            last_read_at=datetime.now(timezone.utc) - timedelta(weeks=8),
+        ),
+    ])
+    db.commit()
+
+    with patch("app.api.home.get_cached_setting", return_value=1):
+        response = auth_client.get("/api/home/resume?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["id"] == recent.id
+    assert payload[0]["progress_percentage"] == 100.0
+
+
+def test_home_up_next_handles_duplicates_reverse_and_non_numeric(auth_client, db, normal_user):
+    _, _, standard_volume = _create_series_graph(
+        db,
+        lib_name="home-up-next-standard-lib",
+        series_name="Up Next Standard",
+    )
+    std1 = _add_comic(db, standard_volume, number="1", title="Std #1")
+    std2 = _add_comic(db, standard_volume, number="2", title="Std #2")
+    std3 = _add_comic(db, standard_volume, number="3", title="Std #3")
+
+    _, _, bad_volume = _create_series_graph(
+        db,
+        lib_name="home-up-next-bad-lib",
+        series_name="Up Next Bad",
+    )
+    bad = _add_comic(db, bad_volume, number="A", title="Bad #A")
+
+    _, _, reverse_volume = _create_series_graph(
+        db,
+        lib_name="home-up-next-reverse-lib",
+        series_name="Countdown",
+    )
+    rev3 = _add_comic(db, reverse_volume, number="3", title="Rev #3")
+    rev2 = _add_comic(db, reverse_volume, number="2", title="Rev #2")
+    _add_comic(db, reverse_volume, number="1", title="Rev #1")
+
+    now = datetime.now(timezone.utc)
+    db.add_all([
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=std2.id,
+            current_page=22,
+            total_pages=22,
+            completed=True,
+            last_read_at=now,
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=bad.id,
+            current_page=10,
+            total_pages=10,
+            completed=True,
+            last_read_at=now - timedelta(minutes=1),
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=std1.id,
+            current_page=20,
+            total_pages=20,
+            completed=True,
+            last_read_at=now - timedelta(minutes=2),
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=rev3.id,
+            current_page=24,
+            total_pages=24,
+            completed=True,
+            last_read_at=now - timedelta(minutes=3),
+        ),
+    ])
+    db.commit()
+
+    with patch("app.api.home.get_cached_setting", return_value=0):
+        response = auth_client.get("/api/home/up-next?limit=2")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 2
+    assert [item["id"] for item in payload] == [std3.id, rev2.id]
+
+
+def test_home_popular_returns_empty_below_threshold(auth_client, db, normal_user):
+    sharer = _add_user(
+        db,
+        username="popular-threshold-sharer",
+        email="popular-threshold-sharer@example.com",
+        share_progress_enabled=True,
+    )
+
+    comics = []
+    for idx in range(1, 4):
+        _, _, volume = _create_series_graph(
+            db,
+            lib_name=f"home-popular-threshold-lib-{idx}",
+            series_name=f"Home Popular Threshold {idx}",
+        )
+        comics.append(_add_comic(db, volume, number="1", title=f"Threshold #{idx}"))
+
+    for comic in comics:
+        db.add(
+            ReadingProgress(
+                user_id=sharer.id,
+                comic_id=comic.id,
+                current_page=5,
+                total_pages=10,
+                completed=True,
+            )
+        )
+
+    db.commit()
+
+    response = auth_client.get("/api/home/popular?limit=10")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_home_popular_secondary_guard_when_cover_picker_drops_items(auth_client, db):
+    sharer = _add_user(
+        db,
+        username="popular-cover-sharer",
+        email="popular-cover-sharer@example.com",
+        share_progress_enabled=True,
+    )
+
+    for idx in range(1, 5):
+        _, _, volume = _create_series_graph(
+            db,
+            lib_name=f"home-popular-cover-lib-{idx}",
+            series_name=f"Home Popular Cover {idx}",
+        )
+        comic = _add_comic(db, volume, number="1", title=f"Cover #{idx}")
+        db.add(
+            ReadingProgress(
+                user_id=sharer.id,
+                comic_id=comic.id,
+                current_page=5,
+                total_pages=10,
+                completed=True,
+            )
+        )
+
+    db.commit()
+
+    with patch("app.api.home._pick_best_cover", side_effect=lambda series_obj, comics_list: None if series_obj.name.endswith("4") else comics_list[0]):
+        response = auth_client.get("/api/home/popular?limit=10")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_home_popular_returns_series_when_enough_data(auth_client, db):
+    sharer_a = _add_user(
+        db,
+        username="popular-full-sharer-a",
+        email="popular-full-sharer-a@example.com",
+        share_progress_enabled=True,
+    )
+    sharer_b = _add_user(
+        db,
+        username="popular-full-sharer-b",
+        email="popular-full-sharer-b@example.com",
+        share_progress_enabled=True,
+    )
+
+    series_ids = []
+    for idx in range(1, 5):
+        _, series, volume = _create_series_graph(
+            db,
+            lib_name=f"home-popular-full-lib-{idx}",
+            series_name=f"Home Popular Full {idx}",
+        )
+        comic = _add_comic(db, volume, number="1", title=f"Full #{idx}", year=2020 + idx, publisher="Popular Pub")
+        series_ids.append(series.id)
+        db.add_all([
+            ReadingProgress(
+                user_id=sharer_a.id,
+                comic_id=comic.id,
+                current_page=5,
+                total_pages=10,
+                completed=True,
+            ),
+            ReadingProgress(
+                user_id=sharer_b.id,
+                comic_id=comic.id,
+                current_page=3,
+                total_pages=10,
+                completed=False,
+            ),
+        ])
+
+    db.commit()
+
+    response = auth_client.get("/api/home/popular?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 4
+    assert {row["id"] for row in payload} == set(series_ids)
+    assert all(row["publisher"] == "Popular Pub" for row in payload)

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -1,0 +1,132 @@
+from datetime import datetime, timedelta, timezone
+
+from app.models.job import JobStatus, JobType, ScanJob
+from app.models.library import Library
+
+
+def test_active_job_returns_inactive_when_none(client):
+    response = client.get("/api/jobs/active")
+
+    assert response.status_code == 200
+    assert response.json() == {"active": False}
+
+
+def test_active_job_returns_cleanup_placeholder_library_name(client, db):
+    now = datetime.now(timezone.utc)
+    running_job = ScanJob(
+        library_id=None,
+        job_type=JobType.CLEANUP,
+        status=JobStatus.RUNNING,
+        started_at=now - timedelta(minutes=2),
+        force_scan=False,
+    )
+    db.add(running_job)
+    db.commit()
+    db.refresh(running_job)
+
+    response = client.get("/api/jobs/active")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["active"] is True
+    assert payload["job_id"] == running_job.id
+    assert payload["library_name"] == "-"
+    assert payload["library_id"] is None
+
+
+def test_list_jobs_applies_filters_and_parses_summary(admin_client, db):
+    library = Library(name="Jobs-Lib", path="/tmp/jobs-lib")
+    db.add(library)
+    db.flush()
+
+    base_time = datetime.now(timezone.utc)
+    completed = ScanJob(
+        library_id=library.id,
+        job_type=JobType.SCAN,
+        status=JobStatus.COMPLETED,
+        created_at=base_time - timedelta(minutes=10),
+        started_at=base_time - timedelta(minutes=9),
+        completed_at=base_time - timedelta(minutes=4),
+        result_summary='{"issues_added": 12}',
+    )
+    deleted_library_job = ScanJob(
+        library_id=99999,
+        job_type=JobType.THUMBNAIL,
+        status=JobStatus.FAILED,
+        created_at=base_time - timedelta(minutes=2),
+        started_at=base_time - timedelta(minutes=2),
+        completed_at=base_time - timedelta(minutes=1),
+        error_message="Worker died",
+    )
+    db.add_all([completed, deleted_library_job])
+    db.commit()
+    db.refresh(completed)
+
+    filtered = admin_client.get("/api/jobs?status=completed&limit=5")
+    assert filtered.status_code == 200
+    filtered_payload = filtered.json()
+    assert len(filtered_payload) == 1
+    assert filtered_payload[0]["id"] == completed.id
+    assert filtered_payload[0]["library_name"] == "Jobs-Lib"
+    assert filtered_payload[0]["summary"] == {"issues_added": 12}
+    assert filtered_payload[0]["duration_seconds"] == 300.0
+
+    unfiltered = admin_client.get("/api/jobs?limit=5")
+    assert unfiltered.status_code == 200
+    unfiltered_payload = unfiltered.json()
+    assert len(unfiltered_payload) == 2
+    assert unfiltered_payload[0]["library_name"] == "Deleted Library"
+    assert unfiltered_payload[0]["error"] == "Worker died"
+
+
+def test_get_job_status_success_and_not_found(admin_client, db):
+    library = Library(name="Status-Lib", path="/tmp/status-lib")
+    db.add(library)
+    db.flush()
+
+    job = ScanJob(
+        library_id=library.id,
+        job_type=JobType.SCAN,
+        status=JobStatus.RUNNING,
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    response = admin_client.get(f"/api/jobs/status/{job.id}")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == job.id
+    assert payload["status"] == JobStatus.RUNNING
+    assert payload["job_type"] == JobType.SCAN
+
+    missing = admin_client.get("/api/jobs/status/999999")
+    assert missing.status_code == 404
+    assert missing.json() == {"detail": "Job not found"}
+
+
+def test_get_job_details_success_and_not_found(admin_client, db):
+    now = datetime.now(timezone.utc)
+    job = ScanJob(
+        library_id=None,
+        job_type=JobType.CLEANUP,
+        status=JobStatus.COMPLETED,
+        started_at=now - timedelta(minutes=5),
+        completed_at=now - timedelta(minutes=1),
+        result_summary='{"deleted_files": 4}',
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    response = admin_client.get(f"/api/jobs/{job.id}")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == job.id
+    assert payload["library_name"] == "-"
+    assert payload["summary"] == {"deleted_files": 4}
+    assert payload["force_scan"] is False
+
+    missing = admin_client.get("/api/jobs/999999")
+    assert missing.status_code == 404
+    assert missing.json() == {"detail": "Job not found"}

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -1,10 +1,101 @@
+from unittest.mock import patch
+
 from app.main import app
 from app.api.deps import get_current_user
+from app.models.comic import Comic, Volume
 from app.models.library import Library
+from app.models.reading_progress import ReadingProgress
+from app.models.series import Series
+
+
+def _create_library_series_fixture(db, *, lib_name: str):
+    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    series_alpha = Series(name="The Alpha", library=library)
+    series_beta = Series(name="Beta", library=library)
+    series_reverse = Series(name="Countdown", library=library)
+
+    vol_alpha = Volume(series=series_alpha, volume_number=1)
+    vol_beta = Volume(series=series_beta, volume_number=1)
+    vol_reverse = Volume(series=series_reverse, volume_number=1)
+
+    db.add_all([library, series_alpha, series_beta, series_reverse, vol_alpha, vol_beta, vol_reverse])
+    db.flush()
+
+    alpha_two = Comic(
+        volume_id=vol_alpha.id,
+        number="2",
+        title="The Alpha #2",
+        year=2002,
+        filename="alpha-2.cbz",
+        file_path=f"/tmp/{lib_name}-alpha-2.cbz",
+        page_count=20,
+    )
+    alpha_one = Comic(
+        volume_id=vol_alpha.id,
+        number="1",
+        title="The Alpha #1",
+        year=2001,
+        filename="alpha-1.cbz",
+        file_path=f"/tmp/{lib_name}-alpha-1.cbz",
+        page_count=20,
+    )
+
+    beta_five = Comic(
+        volume_id=vol_beta.id,
+        number="5",
+        title="Beta Annual",
+        year=2005,
+        format="annual",
+        filename="beta-5.cbz",
+        file_path=f"/tmp/{lib_name}-beta-5.cbz",
+        page_count=20,
+    )
+    beta_three = Comic(
+        volume_id=vol_beta.id,
+        number="3",
+        title="Beta Special",
+        year=2003,
+        format="one-shot",
+        filename="beta-3.cbz",
+        file_path=f"/tmp/{lib_name}-beta-3.cbz",
+        page_count=20,
+    )
+
+    reverse_one = Comic(
+        volume_id=vol_reverse.id,
+        number="1",
+        title="Countdown #1",
+        year=2001,
+        filename="countdown-1.cbz",
+        file_path=f"/tmp/{lib_name}-countdown-1.cbz",
+        page_count=20,
+    )
+    reverse_four = Comic(
+        volume_id=vol_reverse.id,
+        number="4",
+        title="Countdown #4",
+        year=2004,
+        filename="countdown-4.cbz",
+        file_path=f"/tmp/{lib_name}-countdown-4.cbz",
+        page_count=20,
+    )
+
+    db.add_all([alpha_two, alpha_one, beta_five, beta_three, reverse_one, reverse_four])
+    db.commit()
+
+    return {
+        "library": library,
+        "series_alpha": series_alpha,
+        "series_beta": series_beta,
+        "series_reverse": series_reverse,
+        "alpha_one": alpha_one,
+        "beta_three": beta_three,
+        "reverse_four": reverse_four,
+        "alpha_comics": [alpha_two, alpha_one],
+    }
 
 
 def test_admin_can_create_library(admin_client, db):
-    """Test that an admin can create a library via API"""
     payload = {"name": "Marvel Comics", "path": "/data/marvel"}
 
     response = admin_client.post("/api/libraries/", json=payload)
@@ -14,38 +105,191 @@ def test_admin_can_create_library(admin_client, db):
     assert data["name"] == "Marvel Comics"
     assert data["id"] is not None
 
-    # Verify DB
     lib = db.query(Library).first()
     assert lib.name == "Marvel Comics"
 
 
+def test_create_library_duplicate_name_returns_400(admin_client, db):
+    db.add(Library(name="Duplicate", path="/tmp/dup"))
+    db.commit()
+
+    response = admin_client.post("/api/libraries/", json={"name": "Duplicate", "path": "/tmp/other"})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Library name already exists"}
+
+
 def test_user_rls_security(client, db, admin_user, normal_user):
-    """
-    Complex Scenario:
-    1. Admin creates a Library.
-    2. Admin CAN see it.
-    3. Regular User (not assigned) CANNOT see it.
-    """
-    # 1. Setup Data directly in DB (faster than API calls)
     lib = Library(name="Secret Library", path="/tmp")
     db.add(lib)
     db.commit()
 
-    # ACT AS ADMIN
-    # Manually override the dependency to be the Admin
     app.dependency_overrides[get_current_user] = lambda: admin_user
 
-
-    # 2. Admin Check
     resp_admin = client.get("/api/libraries/")
     assert resp_admin.status_code == 200
     assert len(resp_admin.json()) == 1
 
-    # ACT AS USER
-    # Manually override the dependency to be the Normal User
     app.dependency_overrides[get_current_user] = lambda: normal_user
 
-    # 3. User Check (Should be empty list due to RLS)
     resp_user = client.get("/api/libraries/")
     assert resp_user.status_code == 200
     assert len(resp_user.json()) == 0
+
+
+def test_get_library_detail_requires_access(auth_client, db):
+    library = Library(name="Hidden", path="/tmp/hidden")
+    db.add(library)
+    db.commit()
+
+    response = auth_client.get(f"/api/libraries/{library.id}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Library not found"}
+
+
+def test_get_library_detail_as_admin(admin_client, db):
+    library = Library(name="Visible", path="/tmp/visible")
+    db.add(library)
+    db.commit()
+
+    response = admin_client.get(f"/api/libraries/{library.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == library.id
+    assert payload["name"] == "Visible"
+
+
+def test_get_library_series_sorts_and_computes_cover_and_read_state(auth_client, db, normal_user):
+    data = _create_library_series_fixture(db, lib_name="series-fixture")
+    normal_user.accessible_libraries.append(data["library"])
+    db.commit()
+
+    db.add_all([
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=data["alpha_comics"][0].id,
+            current_page=20,
+            total_pages=20,
+            completed=True,
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=data["alpha_comics"][1].id,
+            current_page=20,
+            total_pages=20,
+            completed=True,
+        ),
+    ])
+    db.commit()
+
+    response = auth_client.get(f"/api/libraries/{data['library'].id}/series?page=1&size=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["total"] == 3
+    assert payload["page"] == 1
+    assert payload["size"] == 10
+
+    items = payload["items"]
+    assert [item["id"] for item in items] == [
+        data["series_alpha"].id,
+        data["series_beta"].id,
+        data["series_reverse"].id,
+    ]
+    assert [item["start_year"] for item in items] == [2001, 2003, 2004]
+    assert [item["read"] for item in items] == [True, False, False]
+
+    assert items[0]["thumbnail_path"].startswith(f"/api/comics/{data['alpha_one'].id}/thumbnail?v=")
+    assert items[1]["thumbnail_path"].startswith(f"/api/comics/{data['beta_three'].id}/thumbnail?v=")
+    assert items[2]["thumbnail_path"].startswith(f"/api/comics/{data['reverse_four'].id}/thumbnail?v=")
+
+
+def test_get_library_series_empty_page_returns_empty_items(auth_client, db, normal_user):
+    library = Library(name="No-Series", path="/tmp/no-series")
+    db.add(library)
+    db.commit()
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.get(f"/api/libraries/{library.id}/series?page=1&size=5")
+
+    assert response.status_code == 200
+    assert response.json() == {"total": 0, "page": 1, "size": 5, "items": []}
+
+
+def test_update_library_applies_fields_and_refreshes_watches(admin_client, db):
+    library = Library(name="UpdateMe", path="/tmp/update-me", watch_mode=False)
+    db.add(library)
+    db.commit()
+
+    with patch("app.api.libraries.library_watcher.refresh_watches") as mock_refresh:
+        response = admin_client.patch(
+            f"/api/libraries/{library.id}",
+            json={"name": "Updated", "path": "/tmp/updated", "watch_mode": True},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["name"] == "Updated"
+    assert payload["path"] == "/tmp/updated"
+    assert payload["watch_mode"] is True
+    mock_refresh.assert_called_once()
+
+
+def test_update_library_rejects_duplicate_name(admin_client, db):
+    original = Library(name="Original", path="/tmp/original")
+    duplicate = Library(name="Taken", path="/tmp/taken")
+    db.add_all([original, duplicate])
+    db.commit()
+
+    response = admin_client.patch(f"/api/libraries/{original.id}", json={"name": "Taken"})
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Library name already exists"}
+
+
+def test_update_library_returns_404_for_missing_library(admin_client):
+    response = admin_client.patch("/api/libraries/999999", json={"name": "Nope"})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Library not found"}
+
+
+def test_delete_library_success_and_not_found(admin_client, db):
+    library = Library(name="DeleteMe", path="/tmp/delete-me")
+    db.add(library)
+    db.commit()
+
+    success = admin_client.delete(f"/api/libraries/{library.id}")
+    assert success.status_code == 200
+    assert success.json() == {"message": "Library deleted"}
+    assert db.query(Library).filter(Library.id == library.id).first() is None
+
+    missing = admin_client.delete("/api/libraries/999999")
+    assert missing.status_code == 404
+    assert missing.json() == {"detail": "Library not found"}
+
+
+def test_scan_library_passes_force_flag_to_scan_manager(admin_client, db):
+    library = Library(name="ScanMe", path="/tmp/scan-me")
+    db.add(library)
+    db.commit()
+
+    expected = {"status": "queued", "job_id": 55, "message": "Queued"}
+    with patch("app.api.libraries.scan_manager.add_task", return_value=expected) as mock_add_task:
+        response = admin_client.post(f"/api/libraries/{library.id}/scan?force=true")
+
+    assert response.status_code == 200
+    assert response.json() == expected
+    mock_add_task.assert_called_once_with(library.id, force=True)
+
+
+def test_scan_library_returns_404_for_missing_library(admin_client):
+    response = admin_client.post("/api/libraries/999999/scan")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Library not found"}

--- a/tests/api/test_progress.py
+++ b/tests/api/test_progress.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone, timedelta
+
 from app.models.comic import Comic, Volume
 from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
@@ -46,6 +48,65 @@ def _seed_progress_data(db, *, lib_name: str, series_name: str):
     }
 
 
+def _seed_age_filtered_progress_data(db, normal_user):
+    library = Library(name="progress-age-lib", path="/tmp/progress-age-lib")
+
+    safe_series = Series(name="Safe Progress Series", library=library)
+    safe_volume = Volume(series=safe_series, volume_number=1)
+    safe_comic = Comic(
+        volume=safe_volume,
+        number="1",
+        title="Safe Progress Comic",
+        age_rating="Teen",
+        filename="safe-progress.cbz",
+        file_path="/tmp/safe-progress.cbz",
+        page_count=10,
+    )
+
+    banned_series = Series(name="Banned Progress Series", library=library)
+    banned_volume = Volume(series=banned_series, volume_number=1)
+    banned_comic = Comic(
+        volume=banned_volume,
+        number="1",
+        title="Banned Progress Comic",
+        age_rating="Mature 17+",
+        filename="banned-progress.cbz",
+        file_path="/tmp/banned-progress.cbz",
+        page_count=10,
+    )
+
+    db.add_all([library, safe_series, safe_volume, safe_comic, banned_series, banned_volume, banned_comic])
+    db.flush()
+
+    db.add_all([
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=safe_comic.id,
+            current_page=3,
+            total_pages=10,
+            completed=False,
+            last_read_at=datetime.now(timezone.utc) - timedelta(days=1),
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=banned_comic.id,
+            current_page=4,
+            total_pages=10,
+            completed=False,
+            last_read_at=datetime.now(timezone.utc),
+        ),
+    ])
+
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    return {
+        "safe_comic": safe_comic,
+        "banned_comic": banned_comic,
+    }
+
+
 def test_get_comic_progress_returns_empty_when_missing(auth_client, db):
     data = _seed_progress_data(db, lib_name="progress-empty", series_name="Empty Progress")
 
@@ -77,6 +138,23 @@ def test_update_comic_progress_missing_comic_returns_404(auth_client):
     assert "not found" in response.json()["detail"].lower()
 
 
+def test_update_comic_progress_unexpected_error_returns_500(auth_client, db, monkeypatch):
+    data = _seed_progress_data(db, lib_name="progress-update-error", series_name="Update Error")
+
+    def _raise_runtime_error(*_args, **_kwargs):
+        raise RuntimeError("unexpected failure")
+
+    monkeypatch.setattr("app.api.progress.ReadingProgressService.update_progress", _raise_runtime_error)
+
+    response = auth_client.post(
+        f"/api/progress/{data['first'].id}",
+        json={"current_page": 1, "total_pages": 10},
+    )
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "unexpected failure"
+
+
 def test_mark_read_then_unread_flow(auth_client, db):
     data = _seed_progress_data(db, lib_name="progress-read", series_name="Read Flow")
 
@@ -96,6 +174,27 @@ def test_mark_read_then_unread_flow(auth_client, db):
     get_progress_after = auth_client.get(f"/api/progress/{data['second'].id}")
     assert get_progress_after.status_code == 200
     assert get_progress_after.json() == {"comic_id": data["second"].id, "has_progress": False}
+
+
+def test_mark_comic_as_read_missing_comic_returns_404(auth_client):
+    response = auth_client.post("/api/progress/99999/mark-read")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_mark_comic_as_unread_unexpected_error_returns_500(auth_client, db, monkeypatch):
+    data = _seed_progress_data(db, lib_name="progress-unread-error", series_name="Unread Error")
+
+    def _raise_runtime_error(*_args, **_kwargs):
+        raise RuntimeError("failed to mark unread")
+
+    monkeypatch.setattr("app.api.progress.ReadingProgressService.mark_as_unread", _raise_runtime_error)
+
+    response = auth_client.delete(f"/api/progress/{data['first'].id}")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "failed to mark unread"
 
 
 def test_recent_progress_filters_completed_and_in_progress(auth_client, db, normal_user):
@@ -161,3 +260,45 @@ def test_on_deck_only_returns_started_unfinished_items(auth_client, db, normal_u
     payload = response.json()
     assert len(payload) == 1
     assert payload[0]["comic_id"] == data["first"].id
+
+
+def test_on_deck_applies_age_filter_for_safe_items(auth_client, db, normal_user):
+    data = _seed_progress_data(db, lib_name="progress-age-deck", series_name="Age Deck")
+
+    data["first"].age_rating = "Teen"
+    data["second"].age_rating = "Teen"
+
+    db.add(
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=data["first"].id,
+            current_page=3,
+            total_pages=10,
+            completed=False,
+            last_read_at=datetime.now(timezone.utc),
+        )
+    )
+
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    response = auth_client.get("/api/progress/on-deck?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["comic_id"] == data["first"].id
+
+def test_recent_progress_excludes_age_restricted_series(auth_client, db, normal_user):
+    data = _seed_age_filtered_progress_data(db, normal_user)
+
+    response = auth_client.get("/api/progress/?filter=in_progress")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["filter"] == "in_progress"
+    assert payload["total"] == 1
+    assert payload["results"][0]["comic_id"] == data["safe_comic"].id
+
+

--- a/tests/api/test_reader.py
+++ b/tests/api/test_reader.py
@@ -1,0 +1,264 @@
+from unittest.mock import patch
+
+from app.api.reader import natural_sort_key
+from app.models.collection import Collection, CollectionItem
+from app.models.comic import Comic, Volume
+from app.models.library import Library
+from app.models.pull_list import PullList, PullListItem
+from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.series import Series
+
+
+def _create_graph(db, *, lib_name: str, series_name: str, volume_number: int = 1):
+    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    series = Series(name=series_name, library=library)
+    volume = Volume(series=series, volume_number=volume_number)
+    db.add_all([library, series, volume])
+    db.flush()
+    return library, series, volume
+
+
+def _add_comic(db, volume: Volume, *, number: str, title: str, **kwargs):
+    comic = Comic(
+        volume_id=volume.id,
+        number=number,
+        title=title,
+        filename=f"{title.replace(' ', '-')}.cbz",
+        file_path=f"/tmp/{title.replace(' ', '-')}-{volume.id}-{number}.cbz",
+        **kwargs,
+    )
+    db.add(comic)
+    db.flush()
+    return comic
+
+
+def test_reader_natural_sort_key():
+    values = ["10", "2", "10a", "1"]
+    assert sorted(values, key=natural_sort_key) == ["1", "2", "10", "10a"]
+
+
+def test_reader_init_default_volume_reverse_and_page_count_fallback(auth_client, db, normal_user):
+    library, _, volume = _create_graph(
+        db,
+        lib_name="reader-default-lib",
+        series_name="Countdown",
+    )
+
+    c1 = _add_comic(db, volume, number="1", title="Countdown One", page_count=0)
+    c2 = _add_comic(db, volume, number="2", title="Countdown Two", page_count=0)
+    c3 = _add_comic(db, volume, number="3", title="Countdown Three", page_count=0)
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    with patch("app.api.reader.ImageService.get_page_count", return_value=77):
+        response = auth_client.get(f"/api/reader/{c2.id}/read-init")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["comic_id"] == c2.id
+    assert payload["prev_comic_id"] == c3.id
+    assert payload["next_comic_id"] == c1.id
+    assert payload["page_count"] == 77
+    assert payload["context_type"] == "volume"
+    assert payload["context_total"] == 3
+    assert payload["context_position"] == 2
+    assert payload["context_label"] == "Countdown (vol 1)"
+
+
+def test_reader_init_access_and_age_restriction_guards(auth_client, db, normal_user):
+    library, _, volume = _create_graph(
+        db,
+        lib_name="reader-guard-lib",
+        series_name="Reader Guard",
+    )
+    comic = _add_comic(
+        db,
+        volume,
+        number="1",
+        title="Guarded Comic",
+        age_rating="Mature 17+",
+        page_count=12,
+    )
+    db.commit()
+
+    no_access = auth_client.get(f"/api/reader/{comic.id}/read-init")
+    assert no_access.status_code == 404
+    assert no_access.json() == {"detail": "Comic not found"}
+
+    normal_user.accessible_libraries.append(library)
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    restricted = auth_client.get(f"/api/reader/{comic.id}/read-init")
+    assert restricted.status_code == 403
+    assert restricted.json() == {"detail": "Content restricted by age rating"}
+
+
+def test_reader_init_pull_list_context_and_value_error_fallback(auth_client, db, normal_user):
+    library, _, volume = _create_graph(
+        db,
+        lib_name="reader-pull-lib",
+        series_name="Reader Pull",
+    )
+
+    safe = _add_comic(db, volume, number="1", title="Pull Safe", age_rating="Teen", page_count=20)
+    banned = _add_comic(db, volume, number="2", title="Pull Banned", age_rating="Mature 17+", page_count=20)
+
+    list_with_safe = PullList(user_id=normal_user.id, name="Pull With Safe")
+    list_without_safe = PullList(user_id=normal_user.id, name="Pull Without Safe")
+    db.add_all([list_with_safe, list_without_safe])
+    db.flush()
+
+    db.add_all([
+        PullListItem(pull_list_id=list_with_safe.id, comic_id=banned.id, sort_order=1),
+        PullListItem(pull_list_id=list_with_safe.id, comic_id=safe.id, sort_order=2),
+        PullListItem(pull_list_id=list_without_safe.id, comic_id=banned.id, sort_order=1),
+    ])
+
+    normal_user.accessible_libraries.append(library)
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    scoped = auth_client.get(
+        f"/api/reader/{safe.id}/read-init?context_type=pull_list&context_id={list_with_safe.id}"
+    )
+    assert scoped.status_code == 200
+    scoped_payload = scoped.json()
+    assert scoped_payload["context_label"] == "Pull With Safe"
+    assert scoped_payload["context_total"] == 1
+    assert scoped_payload["context_position"] == 1
+    assert scoped_payload["prev_comic_id"] is None
+    assert scoped_payload["next_comic_id"] is None
+
+    missing_membership = auth_client.get(
+        f"/api/reader/{safe.id}/read-init?context_type=pull_list&context_id={list_without_safe.id}"
+    )
+    assert missing_membership.status_code == 200
+    fallback_payload = missing_membership.json()
+    assert fallback_payload["context_label"] == "Pull Without Safe"
+    assert fallback_payload["context_total"] == 0
+    assert fallback_payload["context_position"] == 0
+    assert fallback_payload["prev_comic_id"] is None
+    assert fallback_payload["next_comic_id"] is None
+
+
+def test_reader_init_reading_list_collection_and_series_contexts(auth_client, db, normal_user):
+    library, alpha_series, alpha_volume = _create_graph(
+        db,
+        lib_name="reader-context-lib",
+        series_name="Alpha Line",
+        volume_number=1,
+    )
+
+    alpha1 = _add_comic(db, alpha_volume, number="1", title="Alpha One", year=2001, page_count=12)
+    alpha2 = _add_comic(db, alpha_volume, number="2", title="Alpha Two", year=2001, page_count=12)
+
+    _, reverse_series, reverse_volume = _create_graph(
+        db,
+        lib_name="reader-context-lib-2",
+        series_name="Countdown",
+        volume_number=1,
+    )
+    # Keep reverse series in same accessible library by reassigning.
+    reverse_series.library_id = library.id
+    db.flush()
+
+    rev1 = _add_comic(db, reverse_volume, number="1", title="Rev One", year=2010, page_count=12)
+    rev2 = _add_comic(db, reverse_volume, number="2", title="Rev Two", year=2010, page_count=12)
+    rev3 = _add_comic(db, reverse_volume, number="3", title="Rev Three", year=2010, page_count=12)
+
+    reading_list = ReadingList(name="Reader List", description="")
+    collection = Collection(name="Reader Collection", description="")
+    db.add_all([reading_list, collection])
+    db.flush()
+
+    db.add_all([
+        ReadingListItem(reading_list_id=reading_list.id, comic_id=alpha1.id, position=1),
+        ReadingListItem(reading_list_id=reading_list.id, comic_id=alpha2.id, position=2),
+        CollectionItem(collection_id=collection.id, comic_id=rev2.id),
+        CollectionItem(collection_id=collection.id, comic_id=alpha1.id),
+    ])
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    rl_resp = auth_client.get(
+        f"/api/reader/{alpha2.id}/read-init?context_type=reading_list&context_id={reading_list.id}"
+    )
+    assert rl_resp.status_code == 200
+    rl = rl_resp.json()
+    assert rl["context_label"] == "Reader List"
+    assert rl["prev_comic_id"] == alpha1.id
+    assert rl["next_comic_id"] is None
+    assert rl["context_total"] == 2
+    assert rl["context_position"] == 2
+
+    coll_resp = auth_client.get(
+        f"/api/reader/{rev2.id}/read-init?context_type=collection&context_id={collection.id}"
+    )
+    assert coll_resp.status_code == 200
+    coll = coll_resp.json()
+    assert coll["context_label"] == "Reader Collection"
+    assert coll["prev_comic_id"] == alpha1.id
+    assert coll["next_comic_id"] is None
+
+    series_resp = auth_client.get(
+        f"/api/reader/{rev2.id}/read-init?context_type=series&context_id={reverse_series.id}"
+    )
+    assert series_resp.status_code == 200
+    series_payload = series_resp.json()
+    assert series_payload["context_label"] == "Countdown"
+    assert series_payload["prev_comic_id"] == rev3.id
+    assert series_payload["next_comic_id"] == rev1.id
+
+
+def test_reader_page_endpoint_headers_and_errors(client, db):
+    _, _, volume = _create_graph(db, lib_name="reader-page-lib", series_name="Reader Pages")
+    comic = _add_comic(db, volume, number="1", title="Page Comic")
+    db.commit()
+
+    missing = client.get("/api/reader/999999/page/1")
+    assert missing.status_code == 404
+    assert missing.json() == {"detail": "Comic not found"}
+
+    with patch("app.api.reader.ImageService.get_page_image", return_value=(b"jpeg-bytes", True, "image/jpeg")) as mock_page:
+        jpeg = client.get(f"/api/reader/{comic.id}/page/1?sharpen=true&grayscale=true")
+
+    assert jpeg.status_code == 200
+    assert jpeg.headers["content-disposition"] == 'inline; filename="page_1.jpg"'
+    assert jpeg.headers["cache-control"] == "public, max-age=31536000"
+    mock_page.assert_called_once_with(
+        str(comic.file_path),
+        1,
+        sharpen=True,
+        grayscale=True,
+        transcode_webp=False,
+    )
+
+    with patch("app.api.reader.ImageService.get_page_image", return_value=(b"png-bytes", False, "image/png")):
+        png = client.get(f"/api/reader/{comic.id}/page/2")
+
+    assert png.status_code == 200
+    assert png.headers["content-disposition"] == 'inline; filename="page_2.png"'
+    assert png.headers["cache-control"] == "no-cache, no-store, must-revalidate"
+
+    with patch("app.api.reader.ImageService.get_page_image", return_value=(b"gif-bytes", False, "image/gif")):
+        gif = client.get(f"/api/reader/{comic.id}/page/3")
+
+    assert gif.status_code == 200
+    assert gif.headers["content-disposition"] == 'inline; filename="page_3.gif"'
+
+    with patch("app.api.reader.ImageService.get_page_image", return_value=(b"webp-bytes", True, "image/webp")):
+        webp = client.get(f"/api/reader/{comic.id}/page/4?webp=true")
+
+    assert webp.status_code == 200
+    assert webp.headers["content-disposition"] == 'inline; filename="page_4.webp"'
+
+    with patch("app.api.reader.ImageService.get_page_image", return_value=(None, False, "image/jpeg")):
+        no_page = client.get(f"/api/reader/{comic.id}/page/5")
+
+    assert no_page.status_code == 404
+    assert no_page.json() == {"detail": "Page not found"}

--- a/tests/api/test_saved_searches.py
+++ b/tests/api/test_saved_searches.py
@@ -1,0 +1,131 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+from app.models.saved_search import SavedSearch
+from app.models.user import User
+
+
+def _create_other_user(db):
+    user = User(
+        username="saved-search-other",
+        email="saved-search-other@example.com",
+        hashed_password="x",
+        is_superuser=False,
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _payload(name: str = "My Search"):
+    return {
+        "name": name,
+        "query": {
+            "match": "all",
+            "filters": [
+                {
+                    "field": "title",
+                    "operator": "contains",
+                    "value": "Batman",
+                }
+            ],
+            "sort_by": "created",
+            "sort_order": "desc",
+            "limit": 25,
+            "offset": 0,
+        },
+    }
+
+
+def test_list_saved_searches_only_returns_current_user_in_desc_order(auth_client, db, normal_user):
+    other_user = _create_other_user(db)
+
+    older = SavedSearch(
+        user_id=normal_user.id,
+        name="Older Search",
+        query_json=json.dumps(_payload("Older Search")["query"]),
+        created_at=datetime.now(timezone.utc) - timedelta(days=2),
+    )
+    newer = SavedSearch(
+        user_id=normal_user.id,
+        name="Newer Search",
+        query_json=json.dumps(_payload("Newer Search")["query"]),
+        created_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    foreign = SavedSearch(
+        user_id=other_user.id,
+        name="Foreign Search",
+        query_json=json.dumps(_payload("Foreign Search")["query"]),
+        created_at=datetime.now(timezone.utc),
+    )
+    db.add_all([older, newer, foreign])
+    db.commit()
+
+    response = auth_client.get("/api/saved-searches/")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [row["name"] for row in payload] == ["Newer Search", "Older Search"]
+    assert payload[0]["query"]["filters"][0]["value"] == "Batman"
+
+
+def test_create_saved_search_persists_record(auth_client, db, normal_user):
+    response = auth_client.post("/api/saved-searches/", json=_payload("Created Search"))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Created Search"
+    assert body["query"]["filters"][0]["field"] == "title"
+
+    row = db.query(SavedSearch).filter(SavedSearch.id == body["id"]).first()
+    assert row is not None
+    assert row.user_id == normal_user.id
+    assert json.loads(row.query_json)["sort_by"] == "created"
+
+
+def test_create_saved_search_rejects_invalid_query(auth_client):
+    bad_payload = _payload("Bad Search")
+    bad_payload["query"]["filters"][0]["field"] = "not_a_valid_field"
+
+    response = auth_client.post("/api/saved-searches/", json=bad_payload)
+
+    assert response.status_code == 422
+
+
+def test_delete_saved_search_success(auth_client, db, normal_user):
+    row = SavedSearch(
+        user_id=normal_user.id,
+        name="Delete Me",
+        query_json=json.dumps(_payload("Delete Me")["query"]),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+
+    response = auth_client.delete(f"/api/saved-searches/{row.id}")
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "Deleted"}
+    assert db.query(SavedSearch).filter(SavedSearch.id == row.id).first() is None
+
+
+def test_delete_saved_search_404_for_missing_or_foreign(auth_client, db, normal_user):
+    other_user = _create_other_user(db)
+    foreign = SavedSearch(
+        user_id=other_user.id,
+        name="Foreign",
+        query_json=json.dumps(_payload("Foreign")["query"]),
+    )
+    db.add(foreign)
+    db.commit()
+    db.refresh(foreign)
+
+    foreign_delete = auth_client.delete(f"/api/saved-searches/{foreign.id}")
+    assert foreign_delete.status_code == 404
+    assert foreign_delete.json() == {"detail": "Saved search not found"}
+
+    missing_delete = auth_client.delete("/api/saved-searches/999999")
+    assert missing_delete.status_code == 404
+    assert missing_delete.json() == {"detail": "Saved search not found"}

--- a/tests/api/test_search_api.py
+++ b/tests/api/test_search_api.py
@@ -1,0 +1,263 @@
+from app.api.search import _get_allowed_library_ids
+from app.models.collection import Collection, CollectionItem
+from app.models.comic import Comic, Volume
+from app.models.credits import ComicCredit, Person
+from app.models.library import Library
+from app.models.pull_list import PullList, PullListItem
+from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.series import Series
+from app.models.tags import Character, Location, Team
+from app.models.user import User
+
+
+def _seed_search_fixture(db, normal_user):
+    visible_lib = Library(name="FindMe Visible Library", path="/tmp/findme-visible")
+    hidden_lib = Library(name="FindMe Hidden Library", path="/tmp/findme-hidden")
+    db.add_all([visible_lib, hidden_lib])
+    db.flush()
+
+    safe_series = Series(name="FindMe Safe Series", library_id=visible_lib.id)
+    poisoned_series = Series(name="FindMe Banned Series", library_id=visible_lib.id)
+    hidden_series = Series(name="FindMe Hidden Series", library_id=hidden_lib.id)
+    db.add_all([safe_series, poisoned_series, hidden_series])
+    db.flush()
+
+    safe_vol = Volume(series_id=safe_series.id, volume_number=1)
+    poisoned_vol = Volume(series_id=poisoned_series.id, volume_number=1)
+    hidden_vol = Volume(series_id=hidden_series.id, volume_number=1)
+    db.add_all([safe_vol, poisoned_vol, hidden_vol])
+    db.flush()
+
+    safe1 = Comic(
+        volume_id=safe_vol.id,
+        number="1",
+        title="FindMe Safe #1",
+        publisher="FindMe Publisher",
+        format="mini-series",
+        imprint="FindMe Imprint",
+        age_rating="Teen",
+        language_iso="en",
+        filename="findme-safe-1.cbz",
+        file_path="/tmp/findme-safe-1.cbz",
+    )
+    safe2 = Comic(
+        volume_id=safe_vol.id,
+        number="2",
+        title="FindMe Safe #2",
+        publisher="FindMe Publisher",
+        format="mini-series",
+        imprint="FindMe Imprint",
+        age_rating="Teen",
+        language_iso="en",
+        filename="findme-safe-2.cbz",
+        file_path="/tmp/findme-safe-2.cbz",
+    )
+    banned = Comic(
+        volume_id=poisoned_vol.id,
+        number="1",
+        title="FindMe Banned",
+        publisher="FindMe Banned Publisher",
+        format="annual",
+        imprint="FindMe Bad Imprint",
+        age_rating="Mature 17+",
+        language_iso="jp",
+        filename="findme-banned.cbz",
+        file_path="/tmp/findme-banned.cbz",
+    )
+    hidden = Comic(
+        volume_id=hidden_vol.id,
+        number="1",
+        title="FindMe Hidden",
+        publisher="FindMe Hidden Publisher",
+        format="one-shot",
+        imprint="FindMe Hidden Imprint",
+        age_rating="Teen",
+        language_iso="fr",
+        filename="findme-hidden.cbz",
+        file_path="/tmp/findme-hidden.cbz",
+    )
+    db.add_all([safe1, safe2, banned, hidden])
+    db.flush()
+
+    safe_character = Character(name="FindMe Hero")
+    banned_character = Character(name="FindMe Villain")
+    safe_team = Team(name="FindMe Team")
+    banned_team = Team(name="FindMe Evil Team")
+    safe_location = Location(name="FindMe City")
+    banned_location = Location(name="FindMe Forbidden City")
+    db.add_all([
+        safe_character,
+        banned_character,
+        safe_team,
+        banned_team,
+        safe_location,
+        banned_location,
+    ])
+    db.flush()
+
+    safe1.characters.append(safe_character)
+    safe2.characters.append(safe_character)
+    banned.characters.append(banned_character)
+
+    safe1.teams.append(safe_team)
+    safe2.teams.append(safe_team)
+    banned.teams.append(banned_team)
+
+    safe1.locations.append(safe_location)
+    safe2.locations.append(safe_location)
+    banned.locations.append(banned_location)
+
+    safe_writer = Person(name="FindMe Writer")
+    banned_writer = Person(name="FindMe Banned Writer")
+    db.add_all([safe_writer, banned_writer])
+    db.flush()
+
+    db.add_all([
+        ComicCredit(comic_id=safe1.id, person_id=safe_writer.id, role="writer"),
+        ComicCredit(comic_id=safe2.id, person_id=safe_writer.id, role="writer"),
+        ComicCredit(comic_id=banned.id, person_id=banned_writer.id, role="writer"),
+    ])
+
+    safe_collection = Collection(name="FindMe Safe Collection", description="safe")
+    banned_collection = Collection(name="FindMe Banned Collection", description="banned")
+    hidden_collection = Collection(name="FindMe Hidden Collection", description="hidden")
+    db.add_all([safe_collection, banned_collection, hidden_collection])
+    db.flush()
+
+    db.add_all([
+        CollectionItem(collection_id=safe_collection.id, comic_id=safe1.id),
+        CollectionItem(collection_id=banned_collection.id, comic_id=banned.id),
+        CollectionItem(collection_id=hidden_collection.id, comic_id=hidden.id),
+    ])
+
+    safe_reading_list = ReadingList(name="FindMe Safe Reading List", description="safe")
+    banned_reading_list = ReadingList(name="FindMe Banned Reading List", description="banned")
+    hidden_reading_list = ReadingList(name="FindMe Hidden Reading List", description="hidden")
+    db.add_all([safe_reading_list, banned_reading_list, hidden_reading_list])
+    db.flush()
+
+    db.add_all([
+        ReadingListItem(reading_list_id=safe_reading_list.id, comic_id=safe1.id, position=1),
+        ReadingListItem(reading_list_id=banned_reading_list.id, comic_id=banned.id, position=1),
+        ReadingListItem(reading_list_id=hidden_reading_list.id, comic_id=hidden.id, position=1),
+    ])
+
+    other_user = User(
+        username="findme-other-user",
+        email="findme-other@example.com",
+        hashed_password="x",
+        is_superuser=False,
+        is_active=True,
+    )
+    db.add(other_user)
+    db.flush()
+
+    safe_pull = PullList(user_id=normal_user.id, name="FindMe Safe Pull", description="safe")
+    banned_pull = PullList(user_id=normal_user.id, name="FindMe Banned Pull", description="banned")
+    other_pull = PullList(user_id=other_user.id, name="FindMe Other Pull", description="other")
+    db.add_all([safe_pull, banned_pull, other_pull])
+    db.flush()
+
+    db.add_all([
+        PullListItem(pull_list_id=safe_pull.id, comic_id=safe1.id, sort_order=1),
+        PullListItem(pull_list_id=banned_pull.id, comic_id=banned.id, sort_order=1),
+        PullListItem(pull_list_id=other_pull.id, comic_id=safe1.id, sort_order=1),
+    ])
+
+    normal_user.accessible_libraries.append(visible_lib)
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+
+    db.commit()
+
+    return {
+        "visible_lib": visible_lib,
+        "safe_series": safe_series,
+        "poisoned_series": poisoned_series,
+        "hidden_series": hidden_series,
+    }
+
+
+def test_get_allowed_library_ids_helper(db, normal_user, admin_user):
+    lib = Library(name="search-helper-lib", path="/tmp/search-helper")
+    db.add(lib)
+    db.flush()
+
+    normal_user.accessible_libraries.append(lib)
+    db.commit()
+
+    assert _get_allowed_library_ids(admin_user) is None
+    assert _get_allowed_library_ids(normal_user) == [lib.id]
+
+
+def test_search_suggestions_respects_rls_age_and_field_routes(auth_client, db, normal_user):
+    _seed_search_fixture(db, normal_user)
+
+    def suggest(field, value):
+        response = auth_client.get(f"/api/search/suggestions?field={field}&query={value}")
+        assert response.status_code == 200
+        return response.json()
+
+    series = suggest("series", "FindMe")
+    assert "FindMe Safe Series" in series
+    assert "FindMe Banned Series" not in series
+    assert "FindMe Hidden Series" not in series
+
+    assert suggest("library", "FindMe") == ["FindMe Visible Library"]
+    assert suggest("publisher", "Publisher") == ["FindMe Publisher"]
+    assert suggest("character", "FindMe") == ["FindMe Hero"]
+    assert suggest("team", "FindMe") == ["FindMe Team"]
+    assert suggest("writer", "FindMe") == ["FindMe Writer"]
+    assert suggest("collection", "FindMe") == ["FindMe Safe Collection"]
+    assert suggest("location", "FindMe") == ["FindMe City"]
+    assert suggest("format", "mini") == ["mini-series"]
+    assert suggest("imprint", "FindMe") == ["FindMe Imprint"]
+    assert suggest("age_rating", "Teen") == ["Teen"]
+    assert suggest("language", "en") == ["en"]
+    assert suggest("reading_list", "FindMe") == ["FindMe Safe Reading List"]
+    assert suggest("pull_list", "FindMe") == ["FindMe Safe Pull"]
+    assert suggest("not-a-field", "FindMe") == []
+
+
+def test_search_suggestions_validation(auth_client):
+    response = auth_client.get("/api/search/suggestions?field=series&query=")
+    assert response.status_code == 422
+
+
+def test_quick_search_segments_and_scoping(auth_client, db, normal_user):
+    _seed_search_fixture(db, normal_user)
+
+    response = auth_client.get("/api/search/quick?q=FindMe")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert [row["name"] for row in payload["series"]] == ["FindMe Safe Series"]
+    assert [row["name"] for row in payload["collections"]] == ["FindMe Safe Collection"]
+
+    # Reading lists are intentionally global in this endpoint.
+    assert "FindMe Safe Reading List" in [row["name"] for row in payload["reading_lists"]]
+    assert "FindMe Banned Reading List" in [row["name"] for row in payload["reading_lists"]]
+
+    assert [row["name"] for row in payload["people"]] == ["FindMe Writer"]
+    assert [row["name"] for row in payload["characters"]] == ["FindMe Hero"]
+    assert [row["name"] for row in payload["teams"]] == ["FindMe Team"]
+    assert [row["name"] for row in payload["locations"]] == ["FindMe City"]
+    assert [row["name"] for row in payload["pull_lists"]] == ["FindMe Safe Pull"]
+
+
+def test_quick_search_validation_for_short_query(auth_client):
+    response = auth_client.get("/api/search/quick?q=f")
+    assert response.status_code == 422
+
+
+def test_quick_search_superuser_sees_all_series(admin_client, db, normal_user):
+    _seed_search_fixture(db, normal_user)
+
+    response = admin_client.get("/api/search/quick?q=FindMe")
+
+    assert response.status_code == 200
+    names = {row["name"] for row in response.json()["series"]}
+    assert "FindMe Safe Series" in names
+    assert "FindMe Banned Series" in names
+    assert "FindMe Hidden Series" in names

--- a/tests/api/test_series.py
+++ b/tests/api/test_series.py
@@ -1,8 +1,14 @@
+from datetime import datetime, timezone
+
+from app.models.collection import Collection, CollectionItem
 from app.models.comic import Comic, Volume
+from app.models.credits import ComicCredit, Person
 from app.models.interactions import UserSeries
 from app.models.library import Library
+from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
+from app.models.tags import Character, Location, Team
 
 
 def _create_series_with_volume(db, *, lib_name: str, series_name: str):
@@ -59,6 +65,116 @@ def _create_series_with_volume(db, *, lib_name: str, series_name: str):
         "series": series,
         "volume": volume,
         "comics": comics,
+    }
+
+
+def _create_series_detail_fixture(db):
+    library = Library(name="series-detail-lib", path="/tmp/series-detail-lib")
+    series = Series(name="Countdown", library=library, summary_override="Series override summary")
+    vol1 = Volume(series=series, volume_number=1)
+    vol2 = Volume(series=series, volume_number=2)
+    db.add_all([library, series, vol1, vol2])
+    db.flush()
+
+    issue_one = Comic(
+        volume_id=vol1.id,
+        number="1",
+        title="Countdown #1",
+        year=2000,
+        story_arc="Arc Prime",
+        page_count=20,
+        file_size=100,
+        publisher="Series Pub",
+        imprint="Series Imprint",
+        filename="countdown-1.cbz",
+        file_path="/tmp/series-countdown-1.cbz",
+    )
+    issue_four = Comic(
+        volume_id=vol1.id,
+        number="4",
+        title="Countdown #4",
+        year=2000,
+        story_arc="Arc Prime",
+        page_count=22,
+        file_size=110,
+        color_palette={"accent": "#123456"},
+        publisher="Series Pub",
+        imprint="Series Imprint",
+        filename="countdown-4.cbz",
+        file_path="/tmp/series-countdown-4.cbz",
+    )
+    issue_two = Comic(
+        volume_id=vol2.id,
+        number="2",
+        title="Countdown #2",
+        year=2000,
+        story_arc="Arc Prime",
+        page_count=18,
+        file_size=90,
+        publisher="Series Pub",
+        imprint="Series Imprint",
+        filename="countdown-2.cbz",
+        file_path="/tmp/series-countdown-2.cbz",
+    )
+    annual = Comic(
+        volume_id=vol2.id,
+        number="1",
+        title="Countdown Annual",
+        year=2001,
+        format="annual",
+        story_arc="Arc Side",
+        page_count=28,
+        file_size=120,
+        publisher="Series Pub",
+        imprint="Series Imprint",
+        filename="countdown-annual.cbz",
+        file_path="/tmp/series-countdown-annual.cbz",
+    )
+    db.add_all([issue_one, issue_four, issue_two, annual])
+    db.flush()
+
+    writer = Person(name="Series Writer")
+    penciller = Person(name="Series Penciller")
+    hero = Character(name="Series Hero")
+    team = Team(name="Series Team")
+    location = Location(name="Series Location")
+    db.add_all([writer, penciller, hero, team, location])
+    db.flush()
+
+    db.add_all([
+        ComicCredit(comic_id=issue_one.id, person_id=writer.id, role="writer"),
+        ComicCredit(comic_id=issue_two.id, person_id=writer.id, role="writer"),
+        ComicCredit(comic_id=issue_four.id, person_id=penciller.id, role="penciller"),
+    ])
+
+    issue_one.characters.append(hero)
+    issue_two.characters.append(hero)
+    issue_one.teams.append(team)
+    issue_one.locations.append(location)
+
+    collection = Collection(name="Series Detail Collection", description="Collection desc")
+    reading_list = ReadingList(name="Series Detail Reading List", description="Reading list desc")
+    db.add_all([collection, reading_list])
+    db.flush()
+
+    db.add_all([
+        CollectionItem(collection_id=collection.id, comic_id=issue_one.id),
+        ReadingListItem(reading_list_id=reading_list.id, comic_id=issue_two.id, position=1),
+    ])
+
+    db.commit()
+
+    return {
+        "library": library,
+        "series": series,
+        "vol1": vol1,
+        "vol2": vol2,
+        "issue_one": issue_one,
+        "issue_two": issue_two,
+        "issue_four": issue_four,
+        "annual": annual,
+        "collection": collection,
+        "reading_list": reading_list,
     }
 
 
@@ -143,3 +259,233 @@ def test_series_issues_filters_and_read_state(auth_client, db, normal_user):
     assert unread_payload["total"] == 2
     assert [item["number"] for item in unread_payload["items"]] == ["3", "2"]
     assert all(item["read"] is False for item in unread_payload["items"])
+
+
+def test_series_issues_filters_annual_and_special(auth_client, db, normal_user):
+    data = _create_series_with_volume(db, lib_name="issues-type-lib", series_name="Type Logic")
+    normal_user.accessible_libraries.append(data["library"])
+    db.commit()
+
+    annual_response = auth_client.get(
+        f"/api/series/{data['series'].id}/issues?type=annual&read_filter=all"
+    )
+    assert annual_response.status_code == 200
+    annual_payload = annual_response.json()
+    assert annual_payload["total"] == 1
+    assert len(annual_payload["items"]) == 1
+    assert annual_payload["items"][0]["id"] == data["comics"][1].id
+    assert annual_payload["items"][0]["number"] == "2"
+    assert annual_payload["items"][0]["read"] is False
+
+    special_response = auth_client.get(
+        f"/api/series/{data['series'].id}/issues?type=special&read_filter=all"
+    )
+    assert special_response.status_code == 200
+    special_payload = special_response.json()
+    assert special_payload["total"] == 1
+    assert len(special_payload["items"]) == 1
+    assert special_payload["items"][0]["id"] == data["comics"][2].id
+    assert special_payload["items"][0]["number"] == "3"
+    assert special_payload["items"][0]["read"] is False
+
+
+def test_series_detail_returns_enriched_payload(auth_client, db, normal_user):
+    data = _create_series_detail_fixture(db)
+
+    normal_user.accessible_libraries.append(data["library"])
+    db.flush()
+
+    db.add_all([
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=data["issue_one"].id,
+            current_page=20,
+            total_pages=20,
+            completed=True,
+            last_read_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=data["issue_four"].id,
+            current_page=22,
+            total_pages=22,
+            completed=True,
+            last_read_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=data["issue_two"].id,
+            current_page=5,
+            total_pages=18,
+            completed=False,
+            last_read_at=datetime(2026, 1, 3, tzinfo=timezone.utc),
+        ),
+        UserSeries(user_id=normal_user.id, series_id=data["series"].id, is_starred=True),
+    ])
+    db.commit()
+
+    response = auth_client.get(f"/api/series/{data['series'].id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["id"] == data["series"].id
+    assert payload["library_id"] == data["library"].id
+    assert payload["volume_count"] == 2
+    assert payload["total_issues"] == 3
+    assert payload["annual_count"] == 1
+    assert payload["special_count"] == 0
+    assert payload["is_standalone"] is False
+    assert payload["starred"] is True
+    assert payload["is_admin"] is False
+    assert payload["is_reverse_numbering"] is True
+    assert payload["first_issue_id"] == data["issue_four"].id
+    assert payload["first_issue_summary"] == "Series override summary"
+    assert payload["colors"] == {"accent": "#123456"}
+    assert payload["resume_to"] == {"comic_id": data["issue_two"].id, "status": "in_progress"}
+    assert payload["details"]["writers"] == ["Series Writer"]
+    assert payload["details"]["pencillers"] == ["Series Penciller"]
+    assert payload["details"]["characters"] == ["Series Hero"]
+    assert payload["details"]["teams"] == ["Series Team"]
+    assert payload["details"]["locations"] == ["Series Location"]
+    assert [arc["name"] for arc in payload["story_arcs"]] == ["Arc Prime", "Arc Side"]
+
+    assert payload["collections"] == [
+        {
+            "id": data["collection"].id,
+            "name": "Series Detail Collection",
+            "description": "Collection desc",
+        }
+    ]
+    assert payload["reading_lists"] == [
+        {
+            "id": data["reading_list"].id,
+            "name": "Series Detail Reading List",
+            "description": "Reading list desc",
+        }
+    ]
+
+    by_vol = {row["volume_id"]: row for row in payload["volumes"]}
+    assert by_vol[data["vol1"].id]["first_issue_id"] == data["issue_four"].id
+    assert by_vol[data["vol1"].id]["read"] is True
+    assert by_vol[data["vol2"].id]["first_issue_id"] == data["issue_two"].id
+    assert by_vol[data["vol2"].id]["read"] is False
+
+
+def test_series_detail_returns_empty_structure_when_no_volumes(auth_client, db, normal_user):
+    library = Library(name="empty-series-lib", path="/tmp/empty-series-lib")
+    series = Series(name="Empty Series", library=library)
+    db.add_all([library, series])
+    db.commit()
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.get(f"/api/series/{series.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == series.id
+    assert payload["volume_count"] == 0
+    assert payload["total_issues"] == 0
+    assert payload["volumes"] == []
+    assert payload["collections"] == []
+    assert payload["reading_lists"] == []
+
+
+def test_series_detail_blocks_age_restricted_content(auth_client, db, normal_user):
+    library = Library(name="restricted-series-lib", path="/tmp/restricted-series-lib")
+    series = Series(name="Restricted Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([library, series, volume])
+    db.flush()
+
+    db.add(
+        Comic(
+            volume_id=volume.id,
+            number="1",
+            title="Restricted Comic",
+            age_rating="Mature 17+",
+            filename="restricted-series.cbz",
+            file_path="/tmp/restricted-series.cbz",
+        )
+    )
+
+    normal_user.accessible_libraries.append(library)
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    response = auth_client.get(f"/api/series/{series.id}")
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Content restricted by age rating"}
+
+
+def test_series_list_can_sort_by_updated_desc(auth_client, db, normal_user):
+    first = _create_series_with_volume(db, lib_name="updated-lib-1", series_name="Updated One")
+    second = _create_series_with_volume(db, lib_name="updated-lib-2", series_name="Updated Two")
+
+    normal_user.accessible_libraries.extend([first["library"], second["library"]])
+    db.flush()
+
+    first["series"].updated_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    second["series"].updated_at = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    db.commit()
+
+    response = auth_client.get("/api/series/?sort_by=updated&sort_desc=true")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 2
+    assert [item["id"] for item in payload["items"]] == [second["series"].id, first["series"].id]
+
+
+def test_series_recommendations_returns_empty_when_series_missing(auth_client):
+    response = auth_client.get("/api/series/999999/recommendations")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_series_recommendations_includes_group_lane(auth_client, db, normal_user):
+    library = Library(name="rec-lib", path="/tmp/rec-lib")
+    source = Series(name="Source Series", library=library)
+    other = Series(name="Other Series", library=library)
+    source_vol = Volume(series=source, volume_number=1)
+    other_vol = Volume(series=other, volume_number=1)
+    db.add_all([library, source, other, source_vol, other_vol])
+    db.flush()
+
+    db.add_all([
+        Comic(
+            volume_id=source_vol.id,
+            number="1",
+            title="Source #1",
+            series_group="Shared Verse",
+            filename="source-1.cbz",
+            file_path="/tmp/source-1.cbz",
+        ),
+        Comic(
+            volume_id=other_vol.id,
+            number="1",
+            title="Other #1",
+            series_group="Shared Verse",
+            filename="other-1.cbz",
+            file_path="/tmp/other-1.cbz",
+        ),
+    ])
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.get(f"/api/series/{source.id}/recommendations?limit=10")
+
+    assert response.status_code == 200
+    lanes = response.json()
+    assert len(lanes) >= 1
+    assert any(lane["title"] == "More in 'Shared Verse'" for lane in lanes)
+    shared_lane = next(lane for lane in lanes if lane["title"] == "More in 'Shared Verse'")
+    assert len(shared_lane["items"]) == 1
+    assert shared_lane["items"][0]["id"] == other.id
+

--- a/tests/api/test_volumes.py
+++ b/tests/api/test_volumes.py
@@ -1,7 +1,11 @@
+from datetime import datetime, timezone
+
 from app.models.comic import Comic, Volume
+from app.models.credits import ComicCredit, Person
 from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
+from app.models.tags import Character, Location, Team
 
 
 def _create_volume_fixture(db, *, lib_name: str, series_name: str):
@@ -116,3 +120,218 @@ def test_volume_issues_filters_sorting_and_read_status(auth_client, db, normal_u
     assert read_payload["total"] == 1
     assert read_payload["items"][0]["id"] == data["comics"][1].id
     assert read_payload["items"][0]["read"] is True
+
+
+def test_volume_detail_reports_missing_zero_index_and_metadata(auth_client, db, normal_user):
+    library = Library(name="vol-detail-lib", path="/tmp/vol-detail-lib")
+    series = Series(name="Volume Detail Saga", library=library)
+    volume = Volume(series=series, volume_number=1, summary_override="Volume override summary")
+    db.add_all([library, series, volume])
+    db.flush()
+
+    issue_zero = Comic(
+        volume_id=volume.id,
+        number="0",
+        title="Issue Zero",
+        year=2000,
+        count=4,
+        story_arc="Alpha Arc",
+        page_count=18,
+        file_size=80,
+        publisher="Detail Pub",
+        imprint="Detail Imprint",
+        filename="issue-0.cbz",
+        file_path="/tmp/vol-detail-0.cbz",
+    )
+    issue_one = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="Issue One",
+        year=2001,
+        summary="Issue one summary",
+        count=4,
+        story_arc="Alpha Arc",
+        page_count=20,
+        file_size=100,
+        color_primary="#111111",
+        color_secondary="#222222",
+        publisher="Detail Pub",
+        imprint="Detail Imprint",
+        filename="issue-1.cbz",
+        file_path="/tmp/vol-detail-1.cbz",
+    )
+    issue_three = Comic(
+        volume_id=volume.id,
+        number="3",
+        title="Issue Three",
+        year=2003,
+        count=4,
+        story_arc="Alpha Arc",
+        page_count=22,
+        file_size=120,
+        publisher="Detail Pub",
+        imprint="Detail Imprint",
+        filename="issue-3.cbz",
+        file_path="/tmp/vol-detail-3.cbz",
+    )
+    annual = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="Annual",
+        format="annual",
+        year=2004,
+        story_arc="Omega Arc",
+        page_count=30,
+        file_size=140,
+        filename="annual.cbz",
+        file_path="/tmp/vol-detail-annual.cbz",
+    )
+    special = Comic(
+        volume_id=volume.id,
+        number="0.5",
+        title="Special",
+        format="one-shot",
+        year=2005,
+        story_arc="Omega Arc",
+        page_count=26,
+        file_size=90,
+        filename="special.cbz",
+        file_path="/tmp/vol-detail-special.cbz",
+    )
+    db.add_all([issue_zero, issue_one, issue_three, annual, special])
+    db.flush()
+
+    writer = Person(name="Writer A")
+    penciller = Person(name="Penciller A")
+    hero = Character(name="Hero A")
+    team = Team(name="Team A")
+    location = Location(name="Location A")
+    db.add_all([writer, penciller, hero, team, location])
+    db.flush()
+
+    db.add_all([
+        ComicCredit(comic_id=issue_one.id, person_id=writer.id, role="writer"),
+        ComicCredit(comic_id=issue_three.id, person_id=writer.id, role="writer"),
+        ComicCredit(comic_id=issue_one.id, person_id=penciller.id, role="penciller"),
+    ])
+
+    issue_one.characters.append(hero)
+    issue_three.characters.append(hero)
+    issue_one.teams.append(team)
+    issue_one.locations.append(location)
+
+    normal_user.accessible_libraries.append(library)
+    db.flush()
+
+    db.add(
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=issue_three.id,
+            current_page=5,
+            total_pages=22,
+            completed=False,
+            last_read_at=datetime.now(timezone.utc),
+        )
+    )
+    db.commit()
+
+    response = auth_client.get(f"/api/volumes/{volume.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["id"] == volume.id
+    assert payload["series_id"] == series.id
+    assert payload["library_id"] == library.id
+    assert payload["total_issues"] == 3
+    assert payload["annual_count"] == 1
+    assert payload["special_count"] == 1
+    assert payload["expected_count"] == 4
+    assert payload["status"] == "ended"
+    assert payload["is_completed"] is False
+    assert payload["is_standalone"] is False
+    assert payload["missing_issues"] == [2]
+    assert payload["first_issue_id"] == issue_one.id
+    assert payload["first_issue_summary"] == "Volume override summary"
+    assert payload["resume_to"] == {"comic_id": issue_three.id, "status": "in_progress"}
+    assert payload["colors"] == {"primary": "#111111", "secondary": "#222222"}
+    assert payload["details"]["writers"] == ["Writer A"]
+    assert payload["details"]["pencillers"] == ["Penciller A"]
+    assert payload["details"]["characters"] == ["Hero A"]
+    assert payload["details"]["teams"] == ["Team A"]
+    assert payload["details"]["locations"] == ["Location A"]
+    assert [arc["name"] for arc in payload["story_arcs"]] == ["Alpha Arc", "Omega Arc"]
+    assert payload["is_reverse_numbering"] is False
+
+
+def test_volume_detail_marks_standalone_without_plain_issues(auth_client, db, normal_user):
+    library = Library(name="vol-standalone-lib", path="/tmp/vol-standalone-lib")
+    series = Series(name="Standalone Volume", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([library, series, volume])
+    db.flush()
+
+    annual = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="Standalone Annual",
+        format="annual",
+        year=2020,
+        page_count=40,
+        file_size=150,
+        filename="standalone-annual.cbz",
+        file_path="/tmp/standalone-annual.cbz",
+    )
+    special = Comic(
+        volume_id=volume.id,
+        number="2",
+        title="Standalone Special",
+        format="one-shot",
+        year=2021,
+        page_count=35,
+        file_size=130,
+        filename="standalone-special.cbz",
+        file_path="/tmp/standalone-special.cbz",
+    )
+    db.add_all([annual, special])
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.get(f"/api/volumes/{volume.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_issues"] == 0
+    assert payload["annual_count"] == 1
+    assert payload["special_count"] == 1
+    assert payload["is_standalone"] is True
+    assert payload["status"] == "ended"
+    assert payload["is_completed"] is True
+    assert payload["missing_issues"] == []
+    assert payload["expected_count"] is None
+
+
+def test_volume_issues_returns_404_without_access(auth_client, db):
+    data = _create_volume_fixture(db, lib_name="hidden-issues-lib", series_name="Hidden Issues")
+
+    response = auth_client.get(f"/api/volumes/{data['volume'].id}/issues")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Volume not found"}
+
+
+def test_volume_issues_annual_unread_desc_filter(auth_client, db, normal_user):
+    data = _create_volume_fixture(db, lib_name="annual-issues-lib", series_name="Annual Issues")
+    normal_user.accessible_libraries.append(data["library"])
+    db.commit()
+
+    response = auth_client.get(
+        f"/api/volumes/{data['volume'].id}/issues?type=annual&read_filter=unread&sort_order=desc"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert payload["items"][0]["format"] == "annual"
+    assert payload["items"][0]["read"] is False


### PR DESCRIPTION
## Summary

This PR is a major API coverage expansion pass plus warning cleanup.

It adds broad endpoint test coverage across core API modules and resolves active deprecation/runtime warnings discovered during full-suite runs. The goal is to increase confidence in behavior while reducing noise from deprecated APIs.

## What Changed

### New API test modules
- tests/api/test_comics.py
- tests/api/test_deps.py
- tests/api/test_home.py
- tests/api/test_jobs.py
- tests/api/test_reader.py
- tests/api/test_saved_searches.py
- tests/api/test_search_api.py

### Expanded existing API test modules
- tests/api/test_libraries.py
- tests/api/test_progress.py
- tests/api/test_series.py
- tests/api/test_volumes.py

### Warning/deprecation fixes
- app/api/saved_searches.py
  - Replaced deprecated `data.query.json()` with `data.query.model_dump_json()`.
- app/api/users.py
  - Replaced deprecated `status.HTTP_413_REQUEST_ENTITY_TOO_LARGE` with `status.HTTP_413_CONTENT_TOO_LARGE`.
- app/services/search.py
  - Replaced `query.distinct(Comic.id).count()` with `COUNT(DISTINCT Comic.id)` style query to avoid SQLAlchemy `DISTINCT ON` warning behavior on non-Postgres backends.

## Notable Coverage Outcomes

- `app/api/progress.py` is now fully covered (100%).
- Added targeted tests for:
  - progress update/read/unread error paths
  - on-deck and recent progress filtering behavior
  - series issues annual/special type handling
  - multiple high-traffic API behaviors across home/search/reader/comics/jobs/deps/saved-searches

## Validation

- Full suite run: `193 passed, 1 skipped`.
- Coverage remained stable overall while adding substantial API-focused test depth.

## Risk / Notes

- Most changes are test additions and warning-level behavioral-equivalent refactors.
- No functional endpoint contract changes intended by warning fixes.
