### PR TITLE
Add library metadata toggles with toggle-aware visibility and queued metadata rehydrate

### DIFF
--- a/alembic/versions/d2a3c1e79f4b_add_library_metadata_parse_flags.py
+++ b/alembic/versions/d2a3c1e79f4b_add_library_metadata_parse_flags.py
@@ -1,0 +1,39 @@
+"""Add library metadata parsing flags
+
+Revision ID: d2a3c1e79f4b
+Revises: 914418cc464c
+Create Date: 2026-03-15 14:20:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d2a3c1e79f4b"
+down_revision: Union[str, None] = "914418cc464c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "libraries",
+        sa.Column("parse_reading_lists", sa.Boolean(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "libraries",
+        sa.Column("parse_collections", sa.Boolean(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "libraries",
+        sa.Column("parse_story_arcs", sa.Boolean(), nullable=False, server_default="1"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("libraries", "parse_story_arcs")
+    op.drop_column("libraries", "parse_collections")
+    op.drop_column("libraries", "parse_reading_lists")

--- a/app/api/collections.py
+++ b/app/api/collections.py
@@ -6,6 +6,7 @@ from typing import List, Annotated
 from app.core.comic_helpers import (get_aggregated_metadata, get_series_age_restriction, get_thumbnail_url,
                                     get_banned_comic_condition, check_container_restriction)
 from app.api.deps import SessionDep, CurrentUser, AdminUser, PaginationParams, PaginatedResponse
+from app.models.library import Library
 from app.models.collection import Collection, CollectionItem
 from app.models.comic import Comic, Volume
 from app.models.series import Series
@@ -37,6 +38,8 @@ async def list_collections(current_user: CurrentUser,
         .join(Comic, item_alias.comic_id == Comic.id) \
         .join(Volume, Comic.volume_id == Volume.id) \
         .join(Series, Volume.series_id == Series.id) \
+        .join(Library, Series.library_id == Library.id) \
+        .where(Library.parse_collections == True) \
         .where(item_alias.collection_id == Collection.id)
 
     if not is_superuser:
@@ -123,9 +126,9 @@ async def get_collection(current_user: CurrentUser,
 
     # 1. Get Comics (Sorted Chronologically) (Scoped)
     # Sort: Year -> Series Name -> Issue Number
-    query = db.query(CollectionItem).join(Comic).join(Volume).join(Series) \
+    query = db.query(CollectionItem).join(Comic).join(Volume).join(Series).join(Library) \
         .options(joinedload(CollectionItem.comic).joinedload(Comic.volume).joinedload(Volume.series)) \
-        .filter(CollectionItem.collection_id == collection_id)
+        .filter(CollectionItem.collection_id == collection_id, Library.parse_collections == True)
 
     # Apply library scope Filter
     if allowed_ids is not None:

--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Annotated, Optional
 from pydantic import BaseModel
 from sqlalchemy import func, case
+import json
 
 from app.core.comic_helpers import get_thumbnail_url, NON_PLAIN_FORMATS, REVERSE_NUMBERING_SERIES, get_series_age_restriction
 from app.models.library import Library
@@ -28,52 +29,99 @@ def _has_library_access(library_id: int, current_user: CurrentUser) -> bool:
     return True
 
 
-def _library_comic_ids_query(db: SessionDep, library_id: int):
-    return (
-        db.query(Comic.id)
+def _rehydrate_library_metadata_from_cache(
+    db: SessionDep,
+    library_id: int,
+    rehydrate_reading_lists: bool,
+    rehydrate_collections: bool,
+    rehydrate_story_arcs: bool,
+):
+    summary = {
+        "comics_scanned": 0,
+        "source_metadata_missing": 0,
+        "source_metadata_invalid": 0,
+        "reading_lists_restored": 0,
+        "collections_restored": 0,
+        "story_arcs_restored": 0,
+        "force_scan_recommended": False,
+    }
+
+    if not any([rehydrate_reading_lists, rehydrate_collections, rehydrate_story_arcs]):
+        return summary
+
+    reading_list_service = ReadingListService(db) if rehydrate_reading_lists else None
+    collection_service = CollectionService(db) if rehydrate_collections else None
+
+    comics = (
+        db.query(Comic)
         .join(Volume, Comic.volume_id == Volume.id)
         .join(Series, Volume.series_id == Series.id)
         .filter(Series.library_id == library_id)
+        .all()
     )
 
+    for comic in comics:
+        summary["comics_scanned"] += 1
 
-def _clear_library_reading_list_metadata(db: SessionDep, library_id: int):
-    comic_ids_query = _library_comic_ids_query(db, library_id)
-    db.query(Comic).filter(Comic.id.in_(comic_ids_query)).update(
-        {
-            Comic.alternate_series: None,
-            Comic.alternate_number: None,
-        },
-        synchronize_session=False,
+        raw_metadata = {}
+        metadata_state = None
+
+        if not comic.metadata_json:
+            metadata_state = "missing"
+        else:
+            try:
+                parsed = json.loads(comic.metadata_json)
+                if isinstance(parsed, dict):
+                    raw_metadata = parsed
+                else:
+                    metadata_state = "invalid"
+            except (TypeError, ValueError):
+                metadata_state = "invalid"
+
+        if metadata_state == "missing":
+            summary["source_metadata_missing"] += 1
+        elif metadata_state == "invalid":
+            summary["source_metadata_invalid"] += 1
+
+        if rehydrate_reading_lists:
+            alternate_series = raw_metadata.get("alternate_series")
+            alternate_number = raw_metadata.get("alternate_number")
+            comic.alternate_series = alternate_series
+            comic.alternate_number = alternate_number
+            reading_list_service.update_comic_reading_lists(comic, alternate_series, alternate_number)
+            if alternate_series and alternate_number:
+                try:
+                    float(alternate_number)
+                    summary["reading_lists_restored"] += 1
+                except (TypeError, ValueError):
+                    pass
+
+        if rehydrate_collections:
+            series_group = raw_metadata.get("series_group")
+            comic.series_group = series_group
+            collection_service.update_comic_collections(comic, series_group)
+            if series_group:
+                summary["collections_restored"] += 1
+
+        if rehydrate_story_arcs:
+            story_arc = raw_metadata.get("story_arc")
+            comic.story_arc = story_arc
+            if story_arc:
+                summary["story_arcs_restored"] += 1
+
+    # Ensure newly added list/collection item rows are visible to cleanup queries.
+    db.flush()
+
+    if rehydrate_reading_lists:
+        reading_list_service.cleanup_empty_lists()
+    if rehydrate_collections:
+        collection_service.cleanup_empty_collections()
+
+    summary["force_scan_recommended"] = (
+        summary["source_metadata_missing"] > 0 or summary["source_metadata_invalid"] > 0
     )
 
-    reading_list_service = ReadingListService(db)
-    reading_list_service.remove_library_comics_from_all_lists(library_id)
-    reading_list_service.cleanup_empty_lists()
-
-
-def _clear_library_collection_metadata(db: SessionDep, library_id: int):
-    comic_ids_query = _library_comic_ids_query(db, library_id)
-    db.query(Comic).filter(Comic.id.in_(comic_ids_query)).update(
-        {
-            Comic.series_group: None,
-        },
-        synchronize_session=False,
-    )
-
-    collection_service = CollectionService(db)
-    collection_service.remove_library_comics_from_all_collections(library_id)
-    collection_service.cleanup_empty_collections()
-
-
-def _clear_library_story_arc_metadata(db: SessionDep, library_id: int):
-    comic_ids_query = _library_comic_ids_query(db, library_id)
-    db.query(Comic).filter(Comic.id.in_(comic_ids_query)).update(
-        {
-            Comic.story_arc: None,
-        },
-        synchronize_session=False,
-    )
+    return summary
 
 
 @router.get("/", name="list")
@@ -399,9 +447,9 @@ async def update_library(
     if updates.watch_mode is not None:
         library.watch_mode = updates.watch_mode
 
-    disable_reading_lists = updates.parse_reading_lists is False and library.parse_reading_lists
-    disable_collections = updates.parse_collections is False and library.parse_collections
-    disable_story_arcs = updates.parse_story_arcs is False and library.parse_story_arcs
+    enable_reading_lists = updates.parse_reading_lists is True and not library.parse_reading_lists
+    enable_collections = updates.parse_collections is True and not library.parse_collections
+    enable_story_arcs = updates.parse_story_arcs is True and not library.parse_story_arcs
 
     if updates.parse_reading_lists is not None:
         library.parse_reading_lists = updates.parse_reading_lists
@@ -412,12 +460,15 @@ async def update_library(
     if updates.parse_story_arcs is not None:
         library.parse_story_arcs = updates.parse_story_arcs
 
-    if disable_reading_lists:
-        _clear_library_reading_list_metadata(db, library.id)
-    if disable_collections:
-        _clear_library_collection_metadata(db, library.id)
-    if disable_story_arcs:
-        _clear_library_story_arc_metadata(db, library.id)
+    rehydration_summary = None
+    if enable_reading_lists or enable_collections or enable_story_arcs:
+        rehydration_summary = _rehydrate_library_metadata_from_cache(
+            db=db,
+            library_id=library.id,
+            rehydrate_reading_lists=enable_reading_lists,
+            rehydrate_collections=enable_collections,
+            rehydrate_story_arcs=enable_story_arcs,
+        )
 
     db.commit()
     db.refresh(library)
@@ -425,7 +476,24 @@ async def update_library(
     # Notify Watcher (Always refresh, covering both Enable and Disable cases)
     library_watcher.refresh_watches()
 
-    return library
+    response = {
+        "id": library.id,
+        "name": library.name,
+        "path": library.path,
+        "scan_on_startup": library.scan_on_startup,
+        "watch_mode": library.watch_mode,
+        "parse_reading_lists": library.parse_reading_lists,
+        "parse_collections": library.parse_collections,
+        "parse_story_arcs": library.parse_story_arcs,
+        "last_scanned": library.last_scanned,
+        "is_scanning": library.is_scanning,
+        "created_at": library.created_at,
+    }
+
+    if rehydration_summary is not None:
+        response["rehydration"] = rehydration_summary
+
+    return response
 
 @router.delete("/{library_id}", tags=["admin"], name="delete")
 async def delete_library(library_id: int,

--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Annotated, Optional
 from pydantic import BaseModel
 from sqlalchemy import func, case
-import json
+import logging
 
 from app.core.comic_helpers import get_thumbnail_url, NON_PLAIN_FORMATS, REVERSE_NUMBERING_SERIES, get_series_age_restriction
 from app.models.library import Library
@@ -11,11 +11,10 @@ from app.models.comic import Comic, Volume
 from app.models.reading_progress import ReadingProgress
 from app.services.scan_manager import scan_manager
 from app.services.watcher import library_watcher
-from app.services.reading_list import ReadingListService
-from app.services.collection import CollectionService
 from app.api.deps import PaginationParams, PaginatedResponse, SessionDep, CurrentUser, AdminUser, LibraryDep
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 def _has_library_access(library_id: int, current_user: CurrentUser) -> bool:
 
@@ -27,101 +26,6 @@ def _has_library_access(library_id: int, current_user: CurrentUser) -> bool:
         return False
 
     return True
-
-
-def _rehydrate_library_metadata_from_cache(
-    db: SessionDep,
-    library_id: int,
-    rehydrate_reading_lists: bool,
-    rehydrate_collections: bool,
-    rehydrate_story_arcs: bool,
-):
-    summary = {
-        "comics_scanned": 0,
-        "source_metadata_missing": 0,
-        "source_metadata_invalid": 0,
-        "reading_lists_restored": 0,
-        "collections_restored": 0,
-        "story_arcs_restored": 0,
-        "force_scan_recommended": False,
-    }
-
-    if not any([rehydrate_reading_lists, rehydrate_collections, rehydrate_story_arcs]):
-        return summary
-
-    reading_list_service = ReadingListService(db) if rehydrate_reading_lists else None
-    collection_service = CollectionService(db) if rehydrate_collections else None
-
-    comics = (
-        db.query(Comic)
-        .join(Volume, Comic.volume_id == Volume.id)
-        .join(Series, Volume.series_id == Series.id)
-        .filter(Series.library_id == library_id)
-        .all()
-    )
-
-    for comic in comics:
-        summary["comics_scanned"] += 1
-
-        raw_metadata = {}
-        metadata_state = None
-
-        if not comic.metadata_json:
-            metadata_state = "missing"
-        else:
-            try:
-                parsed = json.loads(comic.metadata_json)
-                if isinstance(parsed, dict):
-                    raw_metadata = parsed
-                else:
-                    metadata_state = "invalid"
-            except (TypeError, ValueError):
-                metadata_state = "invalid"
-
-        if metadata_state == "missing":
-            summary["source_metadata_missing"] += 1
-        elif metadata_state == "invalid":
-            summary["source_metadata_invalid"] += 1
-
-        if rehydrate_reading_lists:
-            alternate_series = raw_metadata.get("alternate_series")
-            alternate_number = raw_metadata.get("alternate_number")
-            comic.alternate_series = alternate_series
-            comic.alternate_number = alternate_number
-            reading_list_service.update_comic_reading_lists(comic, alternate_series, alternate_number)
-            if alternate_series and alternate_number:
-                try:
-                    float(alternate_number)
-                    summary["reading_lists_restored"] += 1
-                except (TypeError, ValueError):
-                    pass
-
-        if rehydrate_collections:
-            series_group = raw_metadata.get("series_group")
-            comic.series_group = series_group
-            collection_service.update_comic_collections(comic, series_group)
-            if series_group:
-                summary["collections_restored"] += 1
-
-        if rehydrate_story_arcs:
-            story_arc = raw_metadata.get("story_arc")
-            comic.story_arc = story_arc
-            if story_arc:
-                summary["story_arcs_restored"] += 1
-
-    # Ensure newly added list/collection item rows are visible to cleanup queries.
-    db.flush()
-
-    if rehydrate_reading_lists:
-        reading_list_service.cleanup_empty_lists()
-    if rehydrate_collections:
-        collection_service.cleanup_empty_collections()
-
-    summary["force_scan_recommended"] = (
-        summary["source_metadata_missing"] > 0 or summary["source_metadata_invalid"] > 0
-    )
-
-    return summary
 
 
 @router.get("/", name="list")
@@ -460,18 +364,16 @@ async def update_library(
     if updates.parse_story_arcs is not None:
         library.parse_story_arcs = updates.parse_story_arcs
 
-    rehydration_summary = None
-    if enable_reading_lists or enable_collections or enable_story_arcs:
-        rehydration_summary = _rehydrate_library_metadata_from_cache(
-            db=db,
-            library_id=library.id,
-            rehydrate_reading_lists=enable_reading_lists,
-            rehydrate_collections=enable_collections,
-            rehydrate_story_arcs=enable_story_arcs,
-        )
-
     db.commit()
     db.refresh(library)
+
+    rehydration_result = None
+    if enable_reading_lists or enable_collections or enable_story_arcs:
+        try:
+            rehydration_result = scan_manager.add_metadata_rehydrate_task(library.id)
+        except Exception as exc:
+            logger.error("Failed to queue metadata rehydrate for library %s: %s", library.id, exc)
+            rehydration_result = {"status": "failed", "message": "Failed to queue metadata rehydrate"}
 
     # Notify Watcher (Always refresh, covering both Enable and Disable cases)
     library_watcher.refresh_watches()
@@ -490,8 +392,8 @@ async def update_library(
         "created_at": library.created_at,
     }
 
-    if rehydration_summary is not None:
-        response["rehydration"] = rehydration_summary
+    if rehydration_result is not None:
+        response["rehydration"] = rehydration_result
 
     return response
 

--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -10,6 +10,8 @@ from app.models.comic import Comic, Volume
 from app.models.reading_progress import ReadingProgress
 from app.services.scan_manager import scan_manager
 from app.services.watcher import library_watcher
+from app.services.reading_list import ReadingListService
+from app.services.collection import CollectionService
 from app.api.deps import PaginationParams, PaginatedResponse, SessionDep, CurrentUser, AdminUser, LibraryDep
 
 router = APIRouter()
@@ -24,6 +26,54 @@ def _has_library_access(library_id: int, current_user: CurrentUser) -> bool:
         return False
 
     return True
+
+
+def _library_comic_ids_query(db: SessionDep, library_id: int):
+    return (
+        db.query(Comic.id)
+        .join(Volume, Comic.volume_id == Volume.id)
+        .join(Series, Volume.series_id == Series.id)
+        .filter(Series.library_id == library_id)
+    )
+
+
+def _clear_library_reading_list_metadata(db: SessionDep, library_id: int):
+    comic_ids_query = _library_comic_ids_query(db, library_id)
+    db.query(Comic).filter(Comic.id.in_(comic_ids_query)).update(
+        {
+            Comic.alternate_series: None,
+            Comic.alternate_number: None,
+        },
+        synchronize_session=False,
+    )
+
+    reading_list_service = ReadingListService(db)
+    reading_list_service.remove_library_comics_from_all_lists(library_id)
+    reading_list_service.cleanup_empty_lists()
+
+
+def _clear_library_collection_metadata(db: SessionDep, library_id: int):
+    comic_ids_query = _library_comic_ids_query(db, library_id)
+    db.query(Comic).filter(Comic.id.in_(comic_ids_query)).update(
+        {
+            Comic.series_group: None,
+        },
+        synchronize_session=False,
+    )
+
+    collection_service = CollectionService(db)
+    collection_service.remove_library_comics_from_all_collections(library_id)
+    collection_service.cleanup_empty_collections()
+
+
+def _clear_library_story_arc_metadata(db: SessionDep, library_id: int):
+    comic_ids_query = _library_comic_ids_query(db, library_id)
+    db.query(Comic).filter(Comic.id.in_(comic_ids_query)).update(
+        {
+            Comic.story_arc: None,
+        },
+        synchronize_session=False,
+    )
 
 
 @router.get("/", name="list")
@@ -89,6 +139,9 @@ async def list_libraries(db: SessionDep,
             "path": lib.path,
             "scan_on_startup": lib.scan_on_startup,
             "watch_mode": lib.watch_mode,
+            "parse_reading_lists": lib.parse_reading_lists,
+            "parse_collections": lib.parse_collections,
+            "parse_story_arcs": lib.parse_story_arcs,
             "last_scanned": lib.last_scanned,
             "is_scanning": lib.is_scanning,
             "created_at": lib.created_at,
@@ -276,6 +329,9 @@ class LibraryCreate(BaseModel):
     name: str
     path: str
     watch_mode: bool = False
+    parse_reading_lists: bool = True
+    parse_collections: bool = True
+    parse_story_arcs: bool = True
 
 @router.post("/", tags=["admin"], name="create")
 async def create_library(lib_in: LibraryCreate,
@@ -288,7 +344,14 @@ async def create_library(lib_in: LibraryCreate,
     if existing:
         raise HTTPException(status_code=400, detail="Library name already exists")
 
-    library = Library(name=lib_in.name, path=lib_in.path, watch_mode=lib_in.watch_mode)
+    library = Library(
+        name=lib_in.name,
+        path=lib_in.path,
+        watch_mode=lib_in.watch_mode,
+        parse_reading_lists=lib_in.parse_reading_lists,
+        parse_collections=lib_in.parse_collections,
+        parse_story_arcs=lib_in.parse_story_arcs,
+    )
 
     db.add(library)
     db.commit()
@@ -305,6 +368,9 @@ class LibraryUpdate(BaseModel):
     name: Optional[str] = None
     path: Optional[str] = None
     watch_mode: Optional[bool] = None
+    parse_reading_lists: Optional[bool] = None
+    parse_collections: Optional[bool] = None
+    parse_story_arcs: Optional[bool] = None
 
 @router.patch("/{library_id}", tags=["admin"], name="update")
 async def update_library(
@@ -332,6 +398,26 @@ async def update_library(
 
     if updates.watch_mode is not None:
         library.watch_mode = updates.watch_mode
+
+    disable_reading_lists = updates.parse_reading_lists is False and library.parse_reading_lists
+    disable_collections = updates.parse_collections is False and library.parse_collections
+    disable_story_arcs = updates.parse_story_arcs is False and library.parse_story_arcs
+
+    if updates.parse_reading_lists is not None:
+        library.parse_reading_lists = updates.parse_reading_lists
+
+    if updates.parse_collections is not None:
+        library.parse_collections = updates.parse_collections
+
+    if updates.parse_story_arcs is not None:
+        library.parse_story_arcs = updates.parse_story_arcs
+
+    if disable_reading_lists:
+        _clear_library_reading_list_metadata(db, library.id)
+    if disable_collections:
+        _clear_library_collection_metadata(db, library.id)
+    if disable_story_arcs:
+        _clear_library_story_arc_metadata(db, library.id)
 
     db.commit()
     db.refresh(library)

--- a/app/api/reading_lists.py
+++ b/app/api/reading_lists.py
@@ -9,6 +9,7 @@ from app.core.comic_helpers import (get_aggregated_metadata,
                                     check_container_restriction)
 from app.models.comic import Comic, Volume
 from app.models.series import Series
+from app.models.library import Library
 from app.models.tags import Character, Team, Location
 from app.models.credits import Person, ComicCredit
 from app.models.reading_list import ReadingList, ReadingListItem
@@ -41,6 +42,8 @@ async def list_reading_lists(db: SessionDep,
         .join(Comic, item_alias.comic_id == Comic.id) \
         .join(Volume, Comic.volume_id == Volume.id) \
         .join(Series, Volume.series_id == Series.id) \
+        .join(Library, Series.library_id == Library.id) \
+        .where(Library.parse_reading_lists == True) \
         .where(item_alias.reading_list_id == ReadingList.id)
 
     # Apply RLS to the count
@@ -119,9 +122,9 @@ async def get_reading_list(list_id: int, db: SessionDep, current_user: CurrentUs
 
     # 1. Get comics (Ordered by Position) (Scoped)
     # Eager load relationships to prevent N+1
-    query = db.query(ReadingListItem).join(Comic).join(Volume).join(Series) \
+    query = db.query(ReadingListItem).join(Comic).join(Volume).join(Series).join(Library) \
         .options(joinedload(ReadingListItem.comic).joinedload(Comic.volume).joinedload(Volume.series)) \
-        .filter(ReadingListItem.reading_list_id == list_id)
+        .filter(ReadingListItem.reading_list_id == list_id, Library.parse_reading_lists == True)
 
     if allowed_ids is not None:
         query = query.filter(Series.library_id.in_(allowed_ids))

--- a/app/api/search.py
+++ b/app/api/search.py
@@ -27,6 +27,26 @@ def _apply_security_scopes(query: SqlQuery, model, user: CurrentUser, allowed_id
     Applies both Library RLS and Age Rating restrictions dynamically. (non admins)
     """
 
+    # Apply metadata visibility toggles for container models (applies to all users)
+    if model == Collection:
+        query = (
+            query.join(CollectionItem)
+            .join(Comic)
+            .join(Volume)
+            .join(Series)
+            .join(Library)
+            .filter(Library.parse_collections == True)
+        )
+    elif model == ReadingList:
+        query = (
+            query.join(ReadingListItem)
+            .join(Comic)
+            .join(Volume)
+            .join(Series)
+            .join(Library)
+            .filter(Library.parse_reading_lists == True)
+        )
+
     if user.is_superuser:
         return query
 
@@ -57,14 +77,12 @@ def _apply_security_scopes(query: SqlQuery, model, user: CurrentUser, allowed_id
 
         # 5. Containers (Collection/ReadingList)
         elif model == Collection:
-            query = query.join(CollectionItem).join(Comic).join(Volume).join(Series).filter(
-                Series.library_id.in_(allowed_ids))
+            query = query.filter(Series.library_id.in_(allowed_ids))
 
         # Reading List Logic
         # Only show lists where the user can see at least one book.
         elif model == ReadingList:
-            query = query.join(ReadingListItem).join(Comic).join(Volume).join(Series).filter(
-                Series.library_id.in_(allowed_ids))
+            query = query.filter(Series.library_id.in_(allowed_ids))
 
     # 2. Apply Age Restrictions
     if user.max_age_rating:
@@ -223,8 +241,8 @@ async def quick_search(
     collections_objs = get_scoped_results(Collection, Collection.name)
     results["collections"] = [{"id": c.id, "name": c.name} for c in collections_objs]
 
-    # 3. Reading Lists (Global for now, or scope if strict RLS needed)
-    lists_objs = db.query(ReadingList).filter(ReadingList.name.ilike(q_str)).limit(limit).all()
+    # 3. Reading Lists
+    lists_objs = get_scoped_results(ReadingList, ReadingList.name)
     results["reading_lists"] = [{"id": l.id, "name": l.name} for l in lists_objs]
 
     # 4. People (Creators)

--- a/app/api/series.py
+++ b/app/api/series.py
@@ -15,6 +15,8 @@ from app.api.deps import PaginationParams, PaginatedResponse
 # Import related models
 from app.models.comic import Comic, Volume
 from app.models.series import Series
+from app.models.series import Series as SeriesModel
+from app.models.library import Library
 from app.models.collection import Collection, CollectionItem
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.credits import Person, ComicCredit
@@ -190,29 +192,45 @@ async def get_series_detail(series: SeriesDep, db: SessionDep, current_user: Cur
     is_standalone = (stats.plain_count == 0 and (stats.annual_count > 0 or stats.special_count > 0))
 
     # 3. Story Arcs
-    arc_issues = db.query(Comic.id, Comic.story_arc, Comic.number) \
-        .join(Volume) \
-        .filter(Comic.volume_id.in_(volume_ids)) \
-        .filter(Comic.story_arc != None, Comic.story_arc != "") \
-        .order_by(Volume.volume_number, func.cast(Comic.number, Float), Comic.number) \
-        .all()
+    story_arcs_data = []
+    if series.library.parse_story_arcs:
+        arc_issues = db.query(Comic.id, Comic.story_arc, Comic.number) \
+            .join(Volume) \
+            .filter(Comic.volume_id.in_(volume_ids)) \
+            .filter(Comic.story_arc != None, Comic.story_arc != "") \
+            .order_by(Volume.volume_number, func.cast(Comic.number, Float), Comic.number) \
+            .all()
 
-    # Process in Python
-    # Since we sorted via SQL, the first time we encounter an Arc, it is the first issue.
-    story_arcs_map = {}
+        # Process in Python
+        # Since we sorted via SQL, the first time we encounter an Arc, it is the first issue.
+        story_arcs_map = {}
 
-    for row in arc_issues:
-        if row.story_arc not in story_arcs_map:
-            story_arcs_map[row.story_arc] = {"name": row.story_arc, "first_issue_id": row.id, "count": 0}
-        story_arcs_map[row.story_arc]["count"] += 1
-    story_arcs_data = sorted(story_arcs_map.values(), key=lambda x: x['name'])
+        for row in arc_issues:
+            if row.story_arc not in story_arcs_map:
+                story_arcs_map[row.story_arc] = {"name": row.story_arc, "first_issue_id": row.id, "count": 0}
+            story_arcs_map[row.story_arc]["count"] += 1
+        story_arcs_data = sorted(story_arcs_map.values(), key=lambda x: x['name'])
 
     # 4. Related Content (Lightweight)
-    related_collections_query = db.query(Collection).join(CollectionItem).join(Comic).filter(
-        Comic.volume_id.in_(volume_ids))
+    related_collections_query = (
+        db.query(Collection)
+        .join(CollectionItem)
+        .join(Comic)
+        .join(Volume, Comic.volume_id == Volume.id)
+        .join(SeriesModel, Volume.series_id == SeriesModel.id)
+        .join(Library, SeriesModel.library_id == Library.id)
+        .filter(Comic.volume_id.in_(volume_ids), Library.parse_collections == True)
+    )
 
-    related_reading_lists_query = db.query(ReadingList).join(ReadingListItem).join(Comic).filter(
-        Comic.volume_id.in_(volume_ids))
+    related_reading_lists_query = (
+        db.query(ReadingList)
+        .join(ReadingListItem)
+        .join(Comic)
+        .join(Volume, Comic.volume_id == Volume.id)
+        .join(SeriesModel, Volume.series_id == SeriesModel.id)
+        .join(Library, SeriesModel.library_id == Library.id)
+        .filter(Comic.volume_id.in_(volume_ids), Library.parse_reading_lists == True)
+    )
 
     # --- AGE RATING FILTER (Poison Pill) ---
     banned_condition = get_banned_comic_condition(current_user)

--- a/app/api/volumes.py
+++ b/app/api/volumes.py
@@ -96,26 +96,28 @@ async def get_volume_detail(volume: VolumeDep, db: SessionDep, current_user: Cur
     # Story Arc Aggregation (Scoped to Volume)
     # 1. Fetch all issues in this volume that have a story_arc defined
     # 2. Sort by Number so we can identify the "First Issue" of the arc
-    arc_rows = db.query(Comic.id, Comic.story_arc, Comic.number) \
-        .filter(Comic.volume_id == volume.id) \
-        .filter(Comic.story_arc != None, Comic.story_arc != "") \
-        .order_by(func.cast(Comic.number, Float), Comic.number) \
-        .all()
+    story_arcs_data = []
+    if volume.series.library.parse_story_arcs:
+        arc_rows = db.query(Comic.id, Comic.story_arc, Comic.number) \
+            .filter(Comic.volume_id == volume.id) \
+            .filter(Comic.story_arc != None, Comic.story_arc != "") \
+            .order_by(func.cast(Comic.number, Float), Comic.number) \
+            .all()
 
-    # Group by Arc Name
-    story_arcs_map = {}
-    for row in arc_rows:
-        name = row.story_arc
-        if name not in story_arcs_map:
-            story_arcs_map[name] = {
-                "name": name,
-                "first_issue_id": row.id,  # First one encountered is the thumbnail/link
-                "count": 0
-            }
-        story_arcs_map[name]["count"] += 1
+        # Group by Arc Name
+        story_arcs_map = {}
+        for row in arc_rows:
+            name = row.story_arc
+            if name not in story_arcs_map:
+                story_arcs_map[name] = {
+                    "name": name,
+                    "first_issue_id": row.id,  # First one encountered is the thumbnail/link
+                    "count": 0
+                }
+            story_arcs_map[name]["count"] += 1
 
-    # Convert to list and sort alphabetically by Arc Name
-    story_arcs_data = sorted(story_arcs_map.values(), key=lambda x: x['name'])
+        # Convert to list and sort alphabetically by Arc Name
+        story_arcs_data = sorted(story_arcs_map.values(), key=lambda x: x['name'])
 
 
     # 2. Find Cover (Plain issues priority)

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -8,6 +8,7 @@ class JobType(str, enum.Enum):
     SCAN = "scan"
     THUMBNAIL = "thumbnail"
     CLEANUP = "cleanup"
+    METADATA_REHYDRATE = "metadata_rehydrate"
 
 class JobStatus(str, enum.Enum):
     PENDING = "pending"

--- a/app/models/library.py
+++ b/app/models/library.py
@@ -12,6 +12,9 @@ class Library(Base):
     path = Column(String, nullable=False)
     scan_on_startup = Column(Boolean, default=False)
     watch_mode = Column(Boolean, default=False)  # Real-time watching
+    parse_reading_lists = Column(Boolean, default=True, nullable=False)
+    parse_collections = Column(Boolean, default=True, nullable=False)
+    parse_story_arcs = Column(Boolean, default=True, nullable=False)
 
     last_scanned = Column(DateTime, nullable=True)
     is_scanning = Column(Boolean, default=False)

--- a/app/services/collection.py
+++ b/app/services/collection.py
@@ -2,7 +2,7 @@ import logging
 from sqlalchemy.orm import Session
 from typing import Optional, Dict
 
-from app.models import Collection, CollectionItem, Comic
+from app.models import Collection, CollectionItem, Comic, Volume, Series
 
 class CollectionService:
     def __init__(self, db: Session):
@@ -49,6 +49,17 @@ class CollectionService:
             CollectionItem.comic_id == comic_id
         ).delete()
         # No commit
+
+    def remove_library_comics_from_all_collections(self, library_id: int) -> int:
+        comic_ids_query = (
+            self.db.query(Comic.id)
+            .join(Volume, Comic.volume_id == Volume.id)
+            .join(Series, Volume.series_id == Series.id)
+            .filter(Series.library_id == library_id)
+        )
+        return self.db.query(CollectionItem).filter(
+            CollectionItem.comic_id.in_(comic_ids_query)
+        ).delete(synchronize_session=False)
 
     def update_comic_collections(self, comic: Comic, series_group: Optional[str]):
         self.remove_comic_from_all_collections(comic.id)

--- a/app/services/metadata.py
+++ b/app/services/metadata.py
@@ -1,5 +1,12 @@
 from lxml import etree
 from typing import Optional, Dict, Any
+import json
+
+from sqlalchemy.orm import Session
+
+from app.models import Comic, Volume, Series
+from app.services.reading_list import ReadingListService
+from app.services.collection import CollectionService
 
 
 def parse_comicinfo(xml_content: bytes) -> Dict[str, Any]:
@@ -86,3 +93,100 @@ def parse_comicinfo(xml_content: bytes) -> Dict[str, Any]:
     except Exception as e:
         print(f"Error parsing ComicInfo.xml: {e}")
         return {}
+
+
+def rehydrate_library_metadata_from_cache(
+    db: Session,
+    library_id: int,
+    *,
+    rehydrate_reading_lists: bool,
+    rehydrate_collections: bool,
+    rehydrate_story_arcs: bool,
+) -> Dict[str, Any]:
+    summary = {
+        "comics_scanned": 0,
+        "source_metadata_missing": 0,
+        "source_metadata_invalid": 0,
+        "reading_lists_restored": 0,
+        "collections_restored": 0,
+        "story_arcs_restored": 0,
+        "force_scan_recommended": False,
+    }
+
+    if not any([rehydrate_reading_lists, rehydrate_collections, rehydrate_story_arcs]):
+        return summary
+
+    reading_list_service = ReadingListService(db) if rehydrate_reading_lists else None
+    collection_service = CollectionService(db) if rehydrate_collections else None
+
+    comics = (
+        db.query(Comic)
+        .join(Volume, Comic.volume_id == Volume.id)
+        .join(Series, Volume.series_id == Series.id)
+        .filter(Series.library_id == library_id)
+        .all()
+    )
+
+    for comic in comics:
+        summary["comics_scanned"] += 1
+
+        raw_metadata = {}
+        metadata_state = None
+
+        if not comic.metadata_json:
+            metadata_state = "missing"
+        else:
+            try:
+                parsed = json.loads(comic.metadata_json)
+                if isinstance(parsed, dict):
+                    raw_metadata = parsed
+                else:
+                    metadata_state = "invalid"
+            except (TypeError, ValueError):
+                metadata_state = "invalid"
+
+        if metadata_state == "missing":
+            summary["source_metadata_missing"] += 1
+        elif metadata_state == "invalid":
+            summary["source_metadata_invalid"] += 1
+
+        if rehydrate_reading_lists:
+            alternate_series = raw_metadata.get("alternate_series")
+            alternate_number = raw_metadata.get("alternate_number")
+            comic.alternate_series = alternate_series
+            comic.alternate_number = alternate_number
+            reading_list_service.update_comic_reading_lists(comic, alternate_series, alternate_number)
+            if alternate_series and alternate_number:
+                try:
+                    float(alternate_number)
+                    summary["reading_lists_restored"] += 1
+                except (TypeError, ValueError):
+                    pass
+
+        if rehydrate_collections:
+            series_group = raw_metadata.get("series_group")
+            comic.series_group = series_group
+            collection_service.update_comic_collections(comic, series_group)
+            if series_group:
+                summary["collections_restored"] += 1
+
+        if rehydrate_story_arcs:
+            story_arc = raw_metadata.get("story_arc")
+            comic.story_arc = story_arc
+            if story_arc:
+                summary["story_arcs_restored"] += 1
+
+    db.flush()
+
+    if rehydrate_reading_lists:
+        reading_list_service.cleanup_empty_lists()
+    if rehydrate_collections:
+        collection_service.cleanup_empty_collections()
+
+    db.commit()
+
+    summary["force_scan_recommended"] = (
+        summary["source_metadata_missing"] > 0 or summary["source_metadata_invalid"] > 0
+    )
+
+    return summary

--- a/app/services/reading_list.py
+++ b/app/services/reading_list.py
@@ -1,7 +1,7 @@
 import logging
 from sqlalchemy.orm import Session
 from typing import Optional, Dict
-from app.models import ReadingList, ReadingListItem, Comic
+from app.models import ReadingList, ReadingListItem, Comic, Volume, Series
 from app.services.enrichment import EnrichmentService
 
 class ReadingListService:
@@ -64,6 +64,17 @@ class ReadingListService:
             ReadingListItem.comic_id == comic_id
         ).delete()
         # No commit
+
+    def remove_library_comics_from_all_lists(self, library_id: int) -> int:
+        comic_ids_query = (
+            self.db.query(Comic.id)
+            .join(Volume, Comic.volume_id == Volume.id)
+            .join(Series, Volume.series_id == Series.id)
+            .filter(Series.library_id == library_id)
+        )
+        return self.db.query(ReadingListItem).filter(
+            ReadingListItem.comic_id.in_(comic_ids_query)
+        ).delete(synchronize_session=False)
 
     def update_comic_reading_lists(self, comic: Comic, alternate_series: Optional[str],
                                    alternate_number: Optional[str]):

--- a/app/services/scan_manager.py
+++ b/app/services/scan_manager.py
@@ -15,6 +15,7 @@ from app.models.job import JobType, JobStatus
 from app.services.scanner import LibraryScanner
 from app.services.maintenance import MaintenanceService
 from app.services.thumbnailer import ThumbnailService
+from app.services.metadata import rehydrate_library_metadata_from_cache
 
 
 class ScanManager:
@@ -145,6 +146,34 @@ class ScanManager:
         finally:
             db.close()
 
+    def add_metadata_rehydrate_task(self, library_id: int) -> dict:
+        """Queue a metadata rehydrate job for a library."""
+        self.logger.debug(f"Adding METADATA_REHYDRATE job for library {library_id} to queue")
+
+        db = SessionLocal()
+        try:
+            existing = db.query(ScanJob).filter(
+                ScanJob.library_id == library_id,
+                ScanJob.job_type == JobType.METADATA_REHYDRATE,
+                ScanJob.status.in_([JobStatus.PENDING, JobStatus.RUNNING])
+            ).first()
+
+            if existing:
+                return {"status": "ignored", "job_id": existing.id, "message": "Metadata rehydrate active"}
+
+            job = ScanJob(
+                library_id=library_id,
+                job_type=JobType.METADATA_REHYDRATE,
+                status=JobStatus.PENDING
+            )
+            db.add(job)
+            db.commit()
+            db.refresh(job)
+
+            return {"status": "queued", "job_id": job.id, "message": "Metadata rehydrate queued"}
+        finally:
+            db.close()
+
     def _process_queue(self):
         """Poller loop"""
         self.logger.info("Database Job Worker Started")
@@ -153,7 +182,7 @@ class ScanManager:
         while not self._stop_event.is_set():
             db = SessionLocal()
             try:
-                # Priority: SCAN -> THUMBNAIL -> CLEANUP
+                # Priority: SCAN -> THUMBNAIL -> CLEANUP -> METADATA_REHYDRATE
                 job = db.query(ScanJob).filter(
                     ScanJob.status == JobStatus.PENDING,
                     ScanJob.job_type == JobType.SCAN
@@ -169,6 +198,12 @@ class ScanManager:
                     job = db.query(ScanJob).filter(
                         ScanJob.status == JobStatus.PENDING,
                         ScanJob.job_type == JobType.CLEANUP
+                    ).order_by(asc(ScanJob.created_at)).first()
+
+                if not job:
+                    job = db.query(ScanJob).filter(
+                        ScanJob.status == JobStatus.PENDING,
+                        ScanJob.job_type == JobType.METADATA_REHYDRATE
                     ).order_by(asc(ScanJob.created_at)).first()
 
                 if job:
@@ -204,6 +239,8 @@ class ScanManager:
                         self._run_thumbnail_job(job_data)
                     elif job_data['type'] == JobType.CLEANUP:
                         self._run_cleanup_job(job_data)
+                    elif job_data['type'] == JobType.METADATA_REHYDRATE:
+                        self._run_metadata_rehydrate_job(job_data)
 
                 else:
                     db.close()
@@ -408,6 +445,42 @@ class ScanManager:
             self._safe_job_update(job_id, JobStatus.COMPLETED, summary=stats)
 
         # 3. Reset Flag (Final Step)
+        if library_id:
+            self._set_library_scanning_status(library_id, False)
+
+    def _run_metadata_rehydrate_job(self, job_data):
+        job_id = job_data['id']
+        library_id = job_data['library_id']
+
+        summary = {}
+        error = None
+
+        db_rehydrate = SessionLocal()
+        try:
+            library = db_rehydrate.get(Library, library_id)
+            if not library:
+                error = "Library not found"
+            else:
+                self.logger.info(f"Starting METADATA_REHYDRATE job {job_id}")
+                summary = rehydrate_library_metadata_from_cache(
+                    db=db_rehydrate,
+                    library_id=library_id,
+                    rehydrate_reading_lists=bool(getattr(library, "parse_reading_lists", True)),
+                    rehydrate_collections=bool(getattr(library, "parse_collections", True)),
+                    rehydrate_story_arcs=bool(getattr(library, "parse_story_arcs", True)),
+                )
+        except Exception as e:
+            error = str(e)
+            self.logger.error(f"Metadata rehydrate failed: {e}")
+            traceback.print_exc()
+        finally:
+            db_rehydrate.close()
+
+        if error:
+            self._safe_job_update(job_id, JobStatus.FAILED, error=error)
+        else:
+            self._safe_job_update(job_id, JobStatus.COMPLETED, summary=summary)
+
         if library_id:
             self._set_library_scanning_status(library_id, False)
 

--- a/app/services/scanner.py
+++ b/app/services/scanner.py
@@ -102,6 +102,9 @@ class LibraryScanner:
         self.db.commit()
 
         summary = {"imported": 0, "updated": 0, "errors": 0, "skipped": 0}
+        parse_reading_lists = bool(getattr(self.library, "parse_reading_lists", True))
+        parse_collections = bool(getattr(self.library, "parse_collections", True))
+        parse_story_arcs = bool(getattr(self.library, "parse_story_arcs", True))
 
         if tasks:
             result_queue = Queue()
@@ -111,7 +114,12 @@ class LibraryScanner:
             writer_proc = multiprocessing.Process(
                 target=metadata_writer,
                 args=(result_queue, stats_queue, self.library.id),
-                kwargs={"batch_size": 50}
+                kwargs={
+                    "batch_size": 50,
+                    "parse_reading_lists": parse_reading_lists,
+                    "parse_collections": parse_collections,
+                    "parse_story_arcs": parse_story_arcs,
+                }
             )
             writer_proc.start()
 

--- a/app/services/search.py
+++ b/app/services/search.py
@@ -246,17 +246,30 @@ class SearchService:
     @staticmethod
     def _build_collection_condition(operator: str, value):
         """Build condition for collections"""
+        is_collection_metadata_enabled = Comic.volume.has(
+            Volume.series.has(Series.library.has(Library.parse_collections == True))
+        )
+
         if operator == 'equal':
-            return Comic.collection_items.any(
-                CollectionItem.collection.has(Collection.name == value)
+            return and_(
+                is_collection_metadata_enabled,
+                Comic.collection_items.any(
+                    CollectionItem.collection.has(Collection.name == value)
+                ),
             )
         elif operator == 'contains':
             if isinstance(value, list):
-                return Comic.collection_items.any(
-                    CollectionItem.collection.has(Collection.name.in_(value))
+                return and_(
+                    is_collection_metadata_enabled,
+                    Comic.collection_items.any(
+                        CollectionItem.collection.has(Collection.name.in_(value))
+                    ),
                 )
-            return Comic.collection_items.any(
-                CollectionItem.collection.has(Collection.name.ilike(f"%{value}%"))
+            return and_(
+                is_collection_metadata_enabled,
+                Comic.collection_items.any(
+                    CollectionItem.collection.has(Collection.name.ilike(f"%{value}%"))
+                ),
             )
 
         return None
@@ -264,17 +277,30 @@ class SearchService:
     @staticmethod
     def _build_reading_list_condition(operator: str, value):
         """Build condition for reading lists"""
+        is_reading_list_metadata_enabled = Comic.volume.has(
+            Volume.series.has(Series.library.has(Library.parse_reading_lists == True))
+        )
+
         if operator == 'equal':
-            return Comic.reading_list_items.any(
-                ReadingListItem.reading_list.has(ReadingList.name == value)
+            return and_(
+                is_reading_list_metadata_enabled,
+                Comic.reading_list_items.any(
+                    ReadingListItem.reading_list.has(ReadingList.name == value)
+                ),
             )
         elif operator == 'contains':
             if isinstance(value, list):
-                return Comic.reading_list_items.any(
-                    ReadingListItem.reading_list.has(ReadingList.name.in_(value))
+                return and_(
+                    is_reading_list_metadata_enabled,
+                    Comic.reading_list_items.any(
+                        ReadingListItem.reading_list.has(ReadingList.name.in_(value))
+                    ),
                 )
-            return Comic.reading_list_items.any(
-                ReadingListItem.reading_list.has(ReadingList.name.ilike(f"%{value}%"))
+            return and_(
+                is_reading_list_metadata_enabled,
+                Comic.reading_list_items.any(
+                    ReadingListItem.reading_list.has(ReadingList.name.ilike(f"%{value}%"))
+                ),
             )
 
         return None
@@ -304,9 +330,19 @@ class SearchService:
         elif field == 'location':
             return ~Comic.locations.any() if is_empty else Comic.locations.any()
         elif field == 'collection':
-            return ~Comic.collection_items.any() if is_empty else Comic.collection_items.any()
+            is_collection_metadata_enabled = Comic.volume.has(
+                Volume.series.has(Series.library.has(Library.parse_collections == True))
+            )
+            if is_empty:
+                return or_(~is_collection_metadata_enabled, ~Comic.collection_items.any())
+            return and_(is_collection_metadata_enabled, Comic.collection_items.any())
         elif field == 'reading_list':
-            return ~Comic.reading_list_items.any() if is_empty else Comic.reading_list_items.any()
+            is_reading_list_metadata_enabled = Comic.volume.has(
+                Volume.series.has(Series.library.has(Library.parse_reading_lists == True))
+            )
+            if is_empty:
+                return or_(~is_reading_list_metadata_enabled, ~Comic.reading_list_items.any())
+            return and_(is_reading_list_metadata_enabled, Comic.reading_list_items.any())
         elif field in ['writer', 'penciller', 'inker', 'colorist', 'letterer', 'cover_artist', 'editor']:
             if is_empty:
                 return ~Comic.credits.any(ComicCredit.role == field)

--- a/app/services/workers/metadata_writer.py
+++ b/app/services/workers/metadata_writer.py
@@ -98,11 +98,14 @@ def _apply_metadata_batch(
         comic.publisher = metadata.get("publisher")
         comic.imprint = metadata.get("imprint")
         comic.format = metadata.get("format")
-        comic.series_group = metadata.get("series_group") if parse_collections else None
+        if parse_collections:
+            comic.series_group = metadata.get("series_group")
         comic.scan_information = metadata.get("scan_information")
-        comic.alternate_series = metadata.get("alternate_series") if parse_reading_lists else None
-        comic.alternate_number = metadata.get("alternate_number") if parse_reading_lists else None
-        comic.story_arc = metadata.get("story_arc") if parse_story_arcs else None
+        if parse_reading_lists:
+            comic.alternate_series = metadata.get("alternate_series")
+            comic.alternate_number = metadata.get("alternate_number")
+        if parse_story_arcs:
+            comic.story_arc = metadata.get("story_arc")
         comic.count = int(metadata.get("count")) if metadata.get("count") else None
         comic.metadata_json = json.dumps(metadata.get("raw_metadata", {}))
         comic.updated_at = updated_at
@@ -139,8 +142,6 @@ def _apply_metadata_batch(
                 metadata.get("alternate_series"),
                 metadata.get("alternate_number")
             )
-        else:
-            reading_list_service.remove_comic_from_all_lists(comic.id)
 
         # --- Collections ---
         if parse_collections:
@@ -148,8 +149,6 @@ def _apply_metadata_batch(
                 comic,
                 metadata.get("series_group")
             )
-        else:
-            collection_service.remove_comic_from_all_collections(comic.id)
 
         # --- Touch Parent Series (Timestamp bubbling) ---
         series.updated_at = updated_at

--- a/app/services/workers/metadata_writer.py
+++ b/app/services/workers/metadata_writer.py
@@ -7,7 +7,10 @@ def _apply_metadata_batch(
     tag_service,
     credit_service,
     reading_list_service,
-    collection_service
+    collection_service,
+    parse_reading_lists=True,
+    parse_collections=True,
+    parse_story_arcs=True,
 ):
 
     from pathlib import Path
@@ -95,11 +98,11 @@ def _apply_metadata_batch(
         comic.publisher = metadata.get("publisher")
         comic.imprint = metadata.get("imprint")
         comic.format = metadata.get("format")
-        comic.series_group = metadata.get("series_group")
+        comic.series_group = metadata.get("series_group") if parse_collections else None
         comic.scan_information = metadata.get("scan_information")
-        comic.alternate_series = metadata.get("alternate_series")
-        comic.alternate_number = metadata.get("alternate_number")
-        comic.story_arc = metadata.get("story_arc")
+        comic.alternate_series = metadata.get("alternate_series") if parse_reading_lists else None
+        comic.alternate_number = metadata.get("alternate_number") if parse_reading_lists else None
+        comic.story_arc = metadata.get("story_arc") if parse_story_arcs else None
         comic.count = int(metadata.get("count")) if metadata.get("count") else None
         comic.metadata_json = json.dumps(metadata.get("raw_metadata", {}))
         comic.updated_at = updated_at
@@ -130,17 +133,23 @@ def _apply_metadata_batch(
             comic.genres = tag_service.get_or_create_genres(metadata["genre"])
 
         # --- Reading Lists ---
-        reading_list_service.update_comic_reading_lists(
-            comic,
-            metadata.get("alternate_series"),
-            metadata.get("alternate_number")
-        )
+        if parse_reading_lists:
+            reading_list_service.update_comic_reading_lists(
+                comic,
+                metadata.get("alternate_series"),
+                metadata.get("alternate_number")
+            )
+        else:
+            reading_list_service.remove_comic_from_all_lists(comic.id)
 
         # --- Collections ---
-        collection_service.update_comic_collections(
-            comic,
-            metadata.get("series_group")
-        )
+        if parse_collections:
+            collection_service.update_comic_collections(
+                comic,
+                metadata.get("series_group")
+            )
+        else:
+            collection_service.remove_comic_from_all_collections(comic.id)
 
         # --- Touch Parent Series (Timestamp bubbling) ---
         series.updated_at = updated_at
@@ -169,7 +178,15 @@ def _apply_metadata_batch(
         "error_details": error_details
     }
 
-def metadata_writer(queue, stats_queue, library_id, batch_size=50):
+def metadata_writer(
+    queue,
+    stats_queue,
+    library_id,
+    batch_size=50,
+    parse_reading_lists=True,
+    parse_collections=True,
+    parse_story_arcs=True,
+):
 
     try:
 
@@ -281,7 +298,10 @@ def metadata_writer(queue, stats_queue, library_id, batch_size=50):
                     db, batch, existing,
                     get_or_create_series, get_or_create_volume,
                     tag_service, credit_service,
-                    reading_list_service, collection_service
+                    reading_list_service, collection_service,
+                    parse_reading_lists=parse_reading_lists,
+                    parse_collections=parse_collections,
+                    parse_story_arcs=parse_story_arcs,
                 )
                 for key in ("imported", "updated", "errors", "skipped"):
                     processed[key] += stats.get(key, 0)
@@ -295,7 +315,10 @@ def metadata_writer(queue, stats_queue, library_id, batch_size=50):
             stats = _apply_metadata_batch(db, batch, existing,
                     get_or_create_series, get_or_create_volume,
                     tag_service, credit_service,
-                    reading_list_service, collection_service
+                    reading_list_service, collection_service,
+                    parse_reading_lists=parse_reading_lists,
+                    parse_collections=parse_collections,
+                    parse_story_arcs=parse_story_arcs,
             )
             for key in ("imported", "updated", "errors", "skipped"):
                 processed[key] += stats.get(key, 0)

--- a/app/templates/admin/jobs.html
+++ b/app/templates/admin/jobs.html
@@ -41,7 +41,8 @@
                                     :class="{
                                         'bg-blue-900/30 text-blue-200 border-blue-800': job.job_type === 'scan',
                                         'bg-purple-900/30 text-purple-200 border-purple-800': job.job_type === 'thumbnail',
-                                        'bg-orange-900/30 text-orange-200 border-orange-800': job.job_type === 'cleanup'
+                                        'bg-orange-900/30 text-orange-200 border-orange-800': job.job_type === 'cleanup',
+                                        'bg-cyan-900/30 text-cyan-200 border-cyan-800': job.job_type === 'metadata_rehydrate'
                                     }"
                                     x-text="job.job_type || 'scan'"
                                 ></span>
@@ -84,6 +85,12 @@
                                         <template x-if="job.job_type === 'cleanup'">
                                             <span class="text-orange-300">
                                                 <span x-text="getTotalCleaned(job.summary)"></span> cleaned
+                                            </span>
+                                        </template>
+
+                                        <template x-if="job.job_type === 'metadata_rehydrate'">
+                                            <span class="text-cyan-300">
+                                                <span x-text="(job.summary.reading_lists_restored || 0) + (job.summary.collections_restored || 0) + (job.summary.story_arcs_restored || 0)"></span> restored
                                             </span>
                                         </template>
 
@@ -178,6 +185,31 @@
                                          x-text="(selectedJob.summary.empty_lists || 0) + (selectedJob.summary.empty_collections || 0)">
                                     </div>
                                     <div class="text-[10px] text-gray-500 uppercase">Empty Lists</div>
+                                </div>
+                            </div>
+                        </template>
+
+                        <template x-if="selectedJob.job_type === 'metadata_rehydrate'">
+                            <div class="grid grid-cols-2 md:grid-cols-4 gap-3 text-center">
+                                <div class="bg-cyan-900/20 p-3 rounded border border-cyan-900/40">
+                                    <div class="text-xl font-bold text-cyan-300" x-text="selectedJob.summary.comics_scanned || 0"></div>
+                                    <div class="text-[10px] text-gray-400 uppercase">Comics Scanned</div>
+                                </div>
+                                <div class="bg-cyan-900/20 p-3 rounded border border-cyan-900/40">
+                                    <div class="text-xl font-bold text-cyan-300"
+                                         x-text="(selectedJob.summary.reading_lists_restored || 0) + (selectedJob.summary.collections_restored || 0) + (selectedJob.summary.story_arcs_restored || 0)">
+                                    </div>
+                                    <div class="text-[10px] text-gray-400 uppercase">Metadata Restored</div>
+                                </div>
+                                <div class="bg-gray-700/30 p-3 rounded border border-gray-700">
+                                    <div class="text-xl font-bold text-gray-300"
+                                         x-text="(selectedJob.summary.source_metadata_missing || 0) + (selectedJob.summary.source_metadata_invalid || 0)">
+                                    </div>
+                                    <div class="text-[10px] text-gray-500 uppercase">Missing/Invalid Source</div>
+                                </div>
+                                <div class="bg-gray-700/30 p-3 rounded border border-gray-700">
+                                    <div class="text-xl font-bold text-gray-300" x-text="selectedJob.summary.force_scan_recommended ? 'Yes' : 'No'"></div>
+                                    <div class="text-[10px] text-gray-500 uppercase">Force Scan Recommended</div>
                                 </div>
                             </div>
                         </template>

--- a/app/templates/admin/libraries.html
+++ b/app/templates/admin/libraries.html
@@ -226,6 +226,7 @@ function libraryManager() {
                 });
 
                 if (res.ok) {
+                    const body = await res.json();
                     this.showModal = false;
                     this.loadLibraries();
                     this.form = {
@@ -238,6 +239,16 @@ function libraryManager() {
                         parse_story_arcs: true,
                     };
                     window.parker.showToast("Library saved", 'success');
+
+                    const rehydration = body?.rehydration;
+                    if (rehydration?.force_scan_recommended) {
+                        window.parker.showToast(
+                            "Some cached metadata is missing. Run a force scan to fully repopulate metadata.",
+                            "warning"
+                        );
+                    } else if (rehydration) {
+                        window.parker.showToast("Metadata restored from cached scan data.", "info");
+                    }
                 } else {
                     const err = await res.json();
                     await window.parker.dialog.alert('Error', (err.detail || 'Operation Failed'));

--- a/app/templates/admin/libraries.html
+++ b/app/templates/admin/libraries.html
@@ -97,6 +97,35 @@
                         </div>
                     </label>
                 </div>
+                <div class="pt-2 border-t border-gray-700">
+                    <p class="text-sm text-gray-300 mb-2">Metadata Parsing</p>
+                    <div class="space-y-2">
+                        <label class="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                x-model="form.parse_reading_lists"
+                                class="rounded bg-gray-900 border-gray-700 text-blue-600 focus:ring-blue-500 w-4 h-4"
+                            >
+                            <span class="text-sm text-gray-300">Reading Lists (AlternateSeries / AlternateNumber)</span>
+                        </label>
+                        <label class="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                x-model="form.parse_collections"
+                                class="rounded bg-gray-900 border-gray-700 text-blue-600 focus:ring-blue-500 w-4 h-4"
+                            >
+                            <span class="text-sm text-gray-300">Collections (SeriesGroup)</span>
+                        </label>
+                        <label class="flex items-center gap-2 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                x-model="form.parse_story_arcs"
+                                class="rounded bg-gray-900 border-gray-700 text-blue-600 focus:ring-blue-500 w-4 h-4"
+                            >
+                            <span class="text-sm text-gray-300">Story Arcs (StoryArc)</span>
+                        </label>
+                    </div>
+                </div>
 
                 <div class="flex justify-end gap-2 mt-6">
                     <button x-on:click="showModal = false" class="text-gray-400 hover:text-white px-4 py-2 transition-colors">Cancel</button>
@@ -116,7 +145,15 @@ function libraryManager() {
         libraries: [],
         showModal: false,
         isEditing: false,
-        form: { id: null, name: '', path: '', watch_mode: false },
+        form: {
+            id: null,
+            name: '',
+            path: '',
+            watch_mode: false,
+            parse_reading_lists: true,
+            parse_collections: true,
+            parse_story_arcs: true,
+        },
         pollInterval: null,
 
         init() {
@@ -141,13 +178,29 @@ function libraryManager() {
 
         openAddModal() {
             this.isEditing = false;
-            this.form = { id: null, name: '', path: '' };
+            this.form = {
+                id: null,
+                name: '',
+                path: '',
+                watch_mode: false,
+                parse_reading_lists: true,
+                parse_collections: true,
+                parse_story_arcs: true,
+            };
             this.showModal = true;
         },
 
         openEditModal(lib) {
             this.isEditing = true;
-            this.form = { id: lib.id, name: lib.name, path: lib.path, watch_mode: lib.watch_mode };
+            this.form = {
+                id: lib.id,
+                name: lib.name,
+                path: lib.path,
+                watch_mode: lib.watch_mode,
+                parse_reading_lists: lib.parse_reading_lists ?? true,
+                parse_collections: lib.parse_collections ?? true,
+                parse_story_arcs: lib.parse_story_arcs ?? true,
+            };
             this.showModal = true;
         },
 
@@ -160,6 +213,9 @@ function libraryManager() {
                 name: this.form.name,
                 path: this.form.path,
                 watch_mode: this.form.watch_mode,
+                parse_reading_lists: this.form.parse_reading_lists,
+                parse_collections: this.form.parse_collections,
+                parse_story_arcs: this.form.parse_story_arcs,
             };
 
             try {
@@ -172,7 +228,15 @@ function libraryManager() {
                 if (res.ok) {
                     this.showModal = false;
                     this.loadLibraries();
-                    this.form = { id: null, name: '', path: '' };
+                    this.form = {
+                        id: null,
+                        name: '',
+                        path: '',
+                        watch_mode: false,
+                        parse_reading_lists: true,
+                        parse_collections: true,
+                        parse_story_arcs: true,
+                    };
                     window.parker.showToast("Library saved", 'success');
                 } else {
                     const err = await res.json();

--- a/app/templates/admin/libraries.html
+++ b/app/templates/admin/libraries.html
@@ -241,7 +241,13 @@ function libraryManager() {
                     window.parker.showToast("Library saved", 'success');
 
                     const rehydration = body?.rehydration;
-                    if (rehydration?.force_scan_recommended) {
+                    if (rehydration?.status === 'queued') {
+                        window.parker.showToast("Metadata rehydrate queued in background.", "info");
+                    } else if (rehydration?.status === 'ignored') {
+                        window.parker.showToast("Metadata rehydrate is already queued or running.", "info");
+                    } else if (rehydration?.status === 'failed') {
+                        window.parker.showToast("Library saved, but failed to queue metadata rehydrate.", "warning");
+                    } else if (rehydration?.force_scan_recommended) {
                         window.parker.showToast(
                             "Some cached metadata is missing. Run a force scan to fully repopulate metadata.",
                             "warning"

--- a/tests/api/test_collections.py
+++ b/tests/api/test_collections.py
@@ -103,6 +103,34 @@ def test_list_collections_applies_restrictions_and_poison_pill(auth_client, db, 
     assert payload["items"][0]["name"] == "Safe Collection"
 
 
+def test_list_collections_hides_entries_when_library_parsing_disabled(admin_client, db):
+    library, _, volume = _create_series_graph(
+        db,
+        lib_name="collections-parse-off-lib",
+        series_name="Collections Parse Off Series",
+        prefix="collections-parse-off",
+    )
+    library.parse_collections = False
+
+    comic = _create_comic(
+        db,
+        volume_id=volume.id,
+        prefix="collections-parse-off",
+        number="1",
+        year=2024,
+    )
+    collection = Collection(name="Parse Off Collection", auto_generated=0)
+    db.add(collection)
+    db.flush()
+    db.add(CollectionItem(collection_id=collection.id, comic_id=comic.id))
+    db.commit()
+
+    response = admin_client.get("/api/collections/?page=1&size=10")
+
+    assert response.status_code == 200
+    assert response.json()["items"] == []
+
+
 def test_get_collection_success_returns_sorted_comics_and_details(auth_client, db, normal_user):
     lib, _, vol = _create_series_graph(
         db,

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -3,7 +3,9 @@ from unittest.mock import patch
 from app.main import app
 from app.api.deps import get_current_user
 from app.models.comic import Comic, Volume
+from app.models.collection import Collection, CollectionItem
 from app.models.library import Library
+from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 
@@ -104,9 +106,15 @@ def test_admin_can_create_library(admin_client, db):
     data = response.json()
     assert data["name"] == "Marvel Comics"
     assert data["id"] is not None
+    assert data["parse_reading_lists"] is True
+    assert data["parse_collections"] is True
+    assert data["parse_story_arcs"] is True
 
     lib = db.query(Library).first()
     assert lib.name == "Marvel Comics"
+    assert lib.parse_reading_lists is True
+    assert lib.parse_collections is True
+    assert lib.parse_story_arcs is True
 
 
 def test_create_library_duplicate_name_returns_400(admin_client, db):
@@ -222,14 +230,28 @@ def test_get_library_series_empty_page_returns_empty_items(auth_client, db, norm
 
 
 def test_update_library_applies_fields_and_refreshes_watches(admin_client, db):
-    library = Library(name="UpdateMe", path="/tmp/update-me", watch_mode=False)
+    library = Library(
+        name="UpdateMe",
+        path="/tmp/update-me",
+        watch_mode=False,
+        parse_reading_lists=True,
+        parse_collections=True,
+        parse_story_arcs=True,
+    )
     db.add(library)
     db.commit()
 
     with patch("app.api.libraries.library_watcher.refresh_watches") as mock_refresh:
         response = admin_client.patch(
             f"/api/libraries/{library.id}",
-            json={"name": "Updated", "path": "/tmp/updated", "watch_mode": True},
+            json={
+                "name": "Updated",
+                "path": "/tmp/updated",
+                "watch_mode": True,
+                "parse_reading_lists": False,
+                "parse_collections": False,
+                "parse_story_arcs": False,
+            },
         )
 
     assert response.status_code == 200
@@ -237,7 +259,70 @@ def test_update_library_applies_fields_and_refreshes_watches(admin_client, db):
     assert payload["name"] == "Updated"
     assert payload["path"] == "/tmp/updated"
     assert payload["watch_mode"] is True
+    assert payload["parse_reading_lists"] is False
+    assert payload["parse_collections"] is False
+    assert payload["parse_story_arcs"] is False
     mock_refresh.assert_called_once()
+
+
+def test_update_library_disabling_metadata_flags_cleans_existing_metadata_rows(admin_client, db):
+    library = Library(
+        name="Cleanup Metadata",
+        path="/tmp/cleanup-metadata",
+        parse_reading_lists=True,
+        parse_collections=True,
+        parse_story_arcs=True,
+    )
+    series = Series(name="Cleanup Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    comic = Comic(
+        volume=volume,
+        number="1",
+        title="Cleanup Issue",
+        filename="cleanup.cbz",
+        file_path="/tmp/cleanup.cbz",
+        alternate_series="Event Alpha",
+        alternate_number="1",
+        series_group="Group Alpha",
+        story_arc="Arc Alpha",
+    )
+
+    reading_list = ReadingList(name="Event Alpha")
+    collection = Collection(name="Group Alpha")
+    db.add_all([library, series, volume, comic, reading_list, collection])
+    db.flush()
+
+    reading_list_item = ReadingListItem(reading_list_id=reading_list.id, comic_id=comic.id, position=1.0)
+    collection_item = CollectionItem(collection_id=collection.id, comic_id=comic.id)
+    db.add_all([reading_list_item, collection_item])
+    db.commit()
+
+    with patch("app.api.libraries.library_watcher.refresh_watches"):
+        response = admin_client.patch(
+            f"/api/libraries/{library.id}",
+            json={
+                "parse_reading_lists": False,
+                "parse_collections": False,
+                "parse_story_arcs": False,
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["parse_reading_lists"] is False
+    assert payload["parse_collections"] is False
+    assert payload["parse_story_arcs"] is False
+
+    db.refresh(comic)
+    assert comic.alternate_series is None
+    assert comic.alternate_number is None
+    assert comic.series_group is None
+    assert comic.story_arc is None
+
+    assert db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).count() == 0
+    assert db.query(CollectionItem).filter(CollectionItem.comic_id == comic.id).count() == 0
+    assert db.query(ReadingList).filter(ReadingList.name == "Event Alpha").count() == 0
+    assert db.query(Collection).filter(Collection.name == "Group Alpha").count() == 0
 
 
 def test_update_library_rejects_duplicate_name(admin_client, db):
@@ -468,5 +553,9 @@ def test_create_library_with_watch_mode_refreshes_watcher(admin_client):
         )
 
     assert response.status_code == 200
-    assert response.json()["watch_mode"] is True
+    payload = response.json()
+    assert payload["watch_mode"] is True
+    assert payload["parse_reading_lists"] is True
+    assert payload["parse_collections"] is True
+    assert payload["parse_story_arcs"] is True
     mock_refresh.assert_called_once()

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 from app.main import app
@@ -265,7 +266,7 @@ def test_update_library_applies_fields_and_refreshes_watches(admin_client, db):
     mock_refresh.assert_called_once()
 
 
-def test_update_library_disabling_metadata_flags_cleans_existing_metadata_rows(admin_client, db):
+def test_update_library_disabling_metadata_flags_preserves_existing_metadata_rows(admin_client, db):
     library = Library(
         name="Cleanup Metadata",
         path="/tmp/cleanup-metadata",
@@ -314,15 +315,105 @@ def test_update_library_disabling_metadata_flags_cleans_existing_metadata_rows(a
     assert payload["parse_story_arcs"] is False
 
     db.refresh(comic)
-    assert comic.alternate_series is None
-    assert comic.alternate_number is None
-    assert comic.series_group is None
-    assert comic.story_arc is None
+    assert comic.alternate_series == "Event Alpha"
+    assert comic.alternate_number == "1"
+    assert comic.series_group == "Group Alpha"
+    assert comic.story_arc == "Arc Alpha"
 
-    assert db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).count() == 0
-    assert db.query(CollectionItem).filter(CollectionItem.comic_id == comic.id).count() == 0
-    assert db.query(ReadingList).filter(ReadingList.name == "Event Alpha").count() == 0
-    assert db.query(Collection).filter(Collection.name == "Group Alpha").count() == 0
+    assert db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).count() == 1
+    assert db.query(CollectionItem).filter(CollectionItem.comic_id == comic.id).count() == 1
+    assert db.query(ReadingList).filter(ReadingList.name == "Event Alpha").count() == 1
+    assert db.query(Collection).filter(Collection.name == "Group Alpha").count() == 1
+
+
+def test_update_library_reenabling_metadata_flags_rehydrates_from_cached_metadata(admin_client, db):
+    library = Library(
+        name="Rehydrate Metadata",
+        path="/tmp/rehydrate-metadata",
+        parse_reading_lists=False,
+        parse_collections=False,
+        parse_story_arcs=False,
+    )
+
+    series = Series(name="Rehydrate Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+
+    restorable = Comic(
+        volume=volume,
+        number="1",
+        title="Restorable Issue",
+        filename="restorable.cbz",
+        file_path="/tmp/restorable.cbz",
+        metadata_json=json.dumps(
+            {
+                "alternate_series": "Event Beta",
+                "alternate_number": "5",
+                "series_group": "Group Beta",
+                "story_arc": "Arc Beta",
+            }
+        ),
+    )
+
+    missing_source = Comic(
+        volume=volume,
+        number="2",
+        title="Missing Source",
+        filename="missing-source.cbz",
+        file_path="/tmp/missing-source.cbz",
+        metadata_json=None,
+    )
+
+    db.add_all([library, series, volume, restorable, missing_source])
+    db.commit()
+
+    with patch("app.api.libraries.library_watcher.refresh_watches"):
+        response = admin_client.patch(
+            f"/api/libraries/{library.id}",
+            json={
+                "parse_reading_lists": True,
+                "parse_collections": True,
+                "parse_story_arcs": True,
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["parse_reading_lists"] is True
+    assert payload["parse_collections"] is True
+    assert payload["parse_story_arcs"] is True
+    assert payload["rehydration"]["comics_scanned"] == 2
+    assert payload["rehydration"]["reading_lists_restored"] == 1
+    assert payload["rehydration"]["collections_restored"] == 1
+    assert payload["rehydration"]["story_arcs_restored"] == 1
+    assert payload["rehydration"]["source_metadata_missing"] == 1
+    assert payload["rehydration"]["source_metadata_invalid"] == 0
+    assert payload["rehydration"]["force_scan_recommended"] is True
+
+    db.refresh(restorable)
+    db.refresh(missing_source)
+
+    assert restorable.alternate_series == "Event Beta"
+    assert restorable.alternate_number == "5"
+    assert restorable.series_group == "Group Beta"
+    assert restorable.story_arc == "Arc Beta"
+
+    assert missing_source.alternate_series is None
+    assert missing_source.alternate_number is None
+    assert missing_source.series_group is None
+    assert missing_source.story_arc is None
+
+    restored_list = db.query(ReadingList).filter(ReadingList.name == "Event Beta").first()
+    restored_collection = db.query(Collection).filter(Collection.name == "Group Beta").first()
+    assert restored_list is not None
+    assert restored_collection is not None
+    assert db.query(ReadingListItem).filter(
+        ReadingListItem.reading_list_id == restored_list.id,
+        ReadingListItem.comic_id == restorable.id
+    ).count() == 1
+    assert db.query(CollectionItem).filter(
+        CollectionItem.collection_id == restored_collection.id,
+        CollectionItem.comic_id == restorable.id
+    ).count() == 1
 
 
 def test_update_library_rejects_duplicate_name(admin_client, db):

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -326,7 +326,7 @@ def test_update_library_disabling_metadata_flags_preserves_existing_metadata_row
     assert db.query(Collection).filter(Collection.name == "Group Alpha").count() == 1
 
 
-def test_update_library_reenabling_metadata_flags_rehydrates_from_cached_metadata(admin_client, db):
+def test_update_library_reenabling_metadata_flags_queues_rehydrate_job(admin_client, db):
     library = Library(
         name="Rehydrate Metadata",
         path="/tmp/rehydrate-metadata",
@@ -366,7 +366,13 @@ def test_update_library_reenabling_metadata_flags_rehydrates_from_cached_metadat
     db.add_all([library, series, volume, restorable, missing_source])
     db.commit()
 
-    with patch("app.api.libraries.library_watcher.refresh_watches"):
+    with (
+        patch("app.api.libraries.library_watcher.refresh_watches"),
+        patch(
+            "app.api.libraries.scan_manager.add_metadata_rehydrate_task",
+            return_value={"status": "queued", "job_id": 321, "message": "Metadata rehydrate queued"},
+        ) as mock_queue,
+    ):
         response = admin_client.patch(
             f"/api/libraries/{library.id}",
             json={
@@ -381,39 +387,27 @@ def test_update_library_reenabling_metadata_flags_rehydrates_from_cached_metadat
     assert payload["parse_reading_lists"] is True
     assert payload["parse_collections"] is True
     assert payload["parse_story_arcs"] is True
-    assert payload["rehydration"]["comics_scanned"] == 2
-    assert payload["rehydration"]["reading_lists_restored"] == 1
-    assert payload["rehydration"]["collections_restored"] == 1
-    assert payload["rehydration"]["story_arcs_restored"] == 1
-    assert payload["rehydration"]["source_metadata_missing"] == 1
-    assert payload["rehydration"]["source_metadata_invalid"] == 0
-    assert payload["rehydration"]["force_scan_recommended"] is True
+    assert payload["rehydration"]["status"] == "queued"
+    assert payload["rehydration"]["job_id"] == 321
+    mock_queue.assert_called_once_with(library.id)
 
     db.refresh(restorable)
     db.refresh(missing_source)
 
-    assert restorable.alternate_series == "Event Beta"
-    assert restorable.alternate_number == "5"
-    assert restorable.series_group == "Group Beta"
-    assert restorable.story_arc == "Arc Beta"
+    assert restorable.alternate_series is None
+    assert restorable.alternate_number is None
+    assert restorable.series_group is None
+    assert restorable.story_arc is None
 
     assert missing_source.alternate_series is None
     assert missing_source.alternate_number is None
     assert missing_source.series_group is None
     assert missing_source.story_arc is None
 
-    restored_list = db.query(ReadingList).filter(ReadingList.name == "Event Beta").first()
-    restored_collection = db.query(Collection).filter(Collection.name == "Group Beta").first()
-    assert restored_list is not None
-    assert restored_collection is not None
-    assert db.query(ReadingListItem).filter(
-        ReadingListItem.reading_list_id == restored_list.id,
-        ReadingListItem.comic_id == restorable.id
-    ).count() == 1
-    assert db.query(CollectionItem).filter(
-        CollectionItem.collection_id == restored_collection.id,
-        CollectionItem.comic_id == restorable.id
-    ).count() == 1
+    assert db.query(ReadingList).filter(ReadingList.name == "Event Beta").count() == 0
+    assert db.query(Collection).filter(Collection.name == "Group Beta").count() == 0
+    assert db.query(ReadingListItem).filter(ReadingListItem.comic_id == restorable.id).count() == 0
+    assert db.query(CollectionItem).filter(CollectionItem.comic_id == restorable.id).count() == 0
 
 
 def test_update_library_rejects_duplicate_name(admin_client, db):

--- a/tests/api/test_reading_lists.py
+++ b/tests/api/test_reading_lists.py
@@ -131,6 +131,34 @@ def test_list_reading_lists_applies_library_and_banned_filters(auth_client, db, 
     assert payload["items"][0]["name"] == "Visible Reading List"
 
 
+def test_list_reading_lists_hides_entries_when_library_parsing_disabled(admin_client, db):
+    library, _, volume = _create_series_graph(
+        db,
+        lib_name="reading-lists-parse-off-lib",
+        series_name="Reading Lists Parse Off Series",
+        prefix="reading-lists-parse-off",
+    )
+    library.parse_reading_lists = False
+
+    comic = _create_comic(
+        db,
+        volume_id=volume.id,
+        prefix="reading-lists-parse-off",
+        number="1",
+        year=2024,
+    )
+    reading_list = ReadingList(name="Parse Off Reading List", auto_generated=0)
+    db.add(reading_list)
+    db.flush()
+    db.add(ReadingListItem(reading_list_id=reading_list.id, comic_id=comic.id, position=1))
+    db.commit()
+
+    response = admin_client.get("/api/reading-lists/?page=1&size=10")
+
+    assert response.status_code == 200
+    assert response.json()["items"] == []
+
+
 def test_get_reading_list_success_returns_position_order_and_details(auth_client, db, normal_user):
     lib, _, vol = _create_series_graph(
         db,

--- a/tests/api/test_search_api.py
+++ b/tests/api/test_search_api.py
@@ -234,16 +234,32 @@ def test_quick_search_segments_and_scoping(auth_client, db, normal_user):
 
     assert [row["name"] for row in payload["series"]] == ["FindMe Safe Series"]
     assert [row["name"] for row in payload["collections"]] == ["FindMe Safe Collection"]
-
-    # Reading lists are intentionally global in this endpoint.
-    assert "FindMe Safe Reading List" in [row["name"] for row in payload["reading_lists"]]
-    assert "FindMe Banned Reading List" in [row["name"] for row in payload["reading_lists"]]
+    assert [row["name"] for row in payload["reading_lists"]] == ["FindMe Safe Reading List"]
 
     assert [row["name"] for row in payload["people"]] == ["FindMe Writer"]
     assert [row["name"] for row in payload["characters"]] == ["FindMe Hero"]
     assert [row["name"] for row in payload["teams"]] == ["FindMe Team"]
     assert [row["name"] for row in payload["locations"]] == ["FindMe City"]
     assert [row["name"] for row in payload["pull_lists"]] == ["FindMe Safe Pull"]
+
+
+def test_search_suggestions_and_quick_respect_library_metadata_toggles(auth_client, db, normal_user):
+    data = _seed_search_fixture(db, normal_user)
+    data["visible_lib"].parse_collections = False
+    data["visible_lib"].parse_reading_lists = False
+    db.commit()
+
+    collection_suggest = auth_client.get("/api/search/suggestions?field=collection&query=FindMe")
+    reading_list_suggest = auth_client.get("/api/search/suggestions?field=reading_list&query=FindMe")
+    quick = auth_client.get("/api/search/quick?q=FindMe")
+
+    assert collection_suggest.status_code == 200
+    assert reading_list_suggest.status_code == 200
+    assert quick.status_code == 200
+    assert collection_suggest.json() == []
+    assert reading_list_suggest.json() == []
+    assert quick.json()["collections"] == []
+    assert quick.json()["reading_lists"] == []
 
 
 def test_quick_search_validation_for_short_query(auth_client):

--- a/tests/api/test_series.py
+++ b/tests/api/test_series.py
@@ -372,6 +372,24 @@ def test_series_detail_returns_enriched_payload(auth_client, db, normal_user):
     assert by_vol[data["vol2"].id]["read"] is False
 
 
+def test_series_detail_hides_story_arcs_and_related_containers_when_parsing_disabled(auth_client, db, normal_user):
+    data = _create_series_detail_fixture(db)
+    data["library"].parse_story_arcs = False
+    data["library"].parse_collections = False
+    data["library"].parse_reading_lists = False
+
+    normal_user.accessible_libraries.append(data["library"])
+    db.commit()
+
+    response = auth_client.get(f"/api/series/{data['series'].id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["story_arcs"] == []
+    assert payload["collections"] == []
+    assert payload["reading_lists"] == []
+
+
 def test_series_detail_returns_empty_structure_when_no_volumes(auth_client, db, normal_user):
     library = Library(name="empty-series-lib", path="/tmp/empty-series-lib")
     series = Series(name="Empty Series", library=library)

--- a/tests/api/test_volumes.py
+++ b/tests/api/test_volumes.py
@@ -264,6 +264,33 @@ def test_volume_detail_reports_missing_zero_index_and_metadata(auth_client, db, 
     assert payload["is_reverse_numbering"] is False
 
 
+def test_volume_detail_hides_story_arcs_when_parsing_disabled(auth_client, db, normal_user):
+    library = Library(name="vol-story-parse-off-lib", path="/tmp/vol-story-parse-off-lib", parse_story_arcs=False)
+    series = Series(name="Volume Story Off", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([library, series, volume])
+    db.flush()
+
+    db.add(
+        Comic(
+            volume_id=volume.id,
+            number="1",
+            title="Story Arc Off",
+            story_arc="Hidden Arc",
+            filename="story-off.cbz",
+            file_path="/tmp/story-off.cbz",
+        )
+    )
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.get(f"/api/volumes/{volume.id}")
+
+    assert response.status_code == 200
+    assert response.json()["story_arcs"] == []
+
+
 def test_volume_detail_marks_standalone_without_plain_issues(auth_client, db, normal_user):
     library = Library(name="vol-standalone-lib", path="/tmp/vol-standalone-lib")
     series = Series(name="Standalone Volume", library=library)

--- a/tests/services/test_metadata_service.py
+++ b/tests/services/test_metadata_service.py
@@ -1,0 +1,84 @@
+import json
+
+from app.models.comic import Comic, Volume
+from app.models.collection import Collection, CollectionItem
+from app.models.library import Library
+from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.series import Series
+from app.services.metadata import rehydrate_library_metadata_from_cache
+
+
+def test_rehydrate_library_metadata_from_cache_restores_expected_metadata(db):
+    library = Library(name="metadata-rehydrate-lib", path="/tmp/metadata-rehydrate-lib")
+    series = Series(name="Metadata Rehydrate Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+
+    restorable = Comic(
+        volume=volume,
+        number="1",
+        title="Restorable Issue",
+        filename="restorable.cbz",
+        file_path="/tmp/restorable.cbz",
+        metadata_json=json.dumps(
+            {
+                "alternate_series": "Event Gamma",
+                "alternate_number": "3",
+                "series_group": "Group Gamma",
+                "story_arc": "Arc Gamma",
+            }
+        ),
+    )
+
+    missing_source = Comic(
+        volume=volume,
+        number="2",
+        title="Missing Source",
+        filename="missing-source.cbz",
+        file_path="/tmp/missing-source.cbz",
+        metadata_json=None,
+    )
+
+    db.add_all([library, series, volume, restorable, missing_source])
+    db.commit()
+
+    summary = rehydrate_library_metadata_from_cache(
+        db=db,
+        library_id=library.id,
+        rehydrate_reading_lists=True,
+        rehydrate_collections=True,
+        rehydrate_story_arcs=True,
+    )
+
+    assert summary["comics_scanned"] == 2
+    assert summary["reading_lists_restored"] == 1
+    assert summary["collections_restored"] == 1
+    assert summary["story_arcs_restored"] == 1
+    assert summary["source_metadata_missing"] == 1
+    assert summary["source_metadata_invalid"] == 0
+    assert summary["force_scan_recommended"] is True
+
+    db.refresh(restorable)
+    db.refresh(missing_source)
+
+    assert restorable.alternate_series == "Event Gamma"
+    assert restorable.alternate_number == "3"
+    assert restorable.series_group == "Group Gamma"
+    assert restorable.story_arc == "Arc Gamma"
+
+    assert missing_source.alternate_series is None
+    assert missing_source.alternate_number is None
+    assert missing_source.series_group is None
+    assert missing_source.story_arc is None
+
+    reading_list = db.query(ReadingList).filter(ReadingList.name == "Event Gamma").first()
+    collection = db.query(Collection).filter(Collection.name == "Group Gamma").first()
+    assert reading_list is not None
+    assert collection is not None
+    assert db.query(ReadingListItem).filter(
+        ReadingListItem.reading_list_id == reading_list.id,
+        ReadingListItem.comic_id == restorable.id,
+    ).count() == 1
+    assert db.query(CollectionItem).filter(
+        CollectionItem.collection_id == collection.id,
+        CollectionItem.comic_id == restorable.id,
+    ).count() == 1

--- a/tests/services/test_metadata_writer.py
+++ b/tests/services/test_metadata_writer.py
@@ -248,11 +248,9 @@ def test_apply_metadata_batch_disables_optional_metadata_flows(db):
     credit_service = SimpleNamespace(add_credits_to_comic=MagicMock())
     reading_list_service = SimpleNamespace(
         update_comic_reading_lists=MagicMock(),
-        remove_comic_from_all_lists=MagicMock(),
     )
     collection_service = SimpleNamespace(
         update_comic_collections=MagicMock(),
-        remove_comic_from_all_collections=MagicMock(),
     )
 
     batch = [{
@@ -284,14 +282,12 @@ def test_apply_metadata_batch_disables_optional_metadata_flows(db):
     )
 
     db.refresh(comic)
-    assert comic.alternate_series is None
-    assert comic.alternate_number is None
-    assert comic.series_group is None
-    assert comic.story_arc is None
+    assert comic.alternate_series == "Old List"
+    assert comic.alternate_number == "1"
+    assert comic.series_group == "Old Group"
+    assert comic.story_arc == "Old Arc"
     reading_list_service.update_comic_reading_lists.assert_not_called()
     collection_service.update_comic_collections.assert_not_called()
-    reading_list_service.remove_comic_from_all_lists.assert_called_once_with(comic.id)
-    collection_service.remove_comic_from_all_collections.assert_called_once_with(comic.id)
 
 
 def test_metadata_writer_batches_and_emits_summary(monkeypatch, tmp_path):

--- a/tests/services/test_metadata_writer.py
+++ b/tests/services/test_metadata_writer.py
@@ -206,6 +206,94 @@ def test_apply_metadata_batch_import_update_and_error_paths(db):
     assert collection_service.update_comic_collections.call_count == 2
 
 
+def test_apply_metadata_batch_disables_optional_metadata_flows(db):
+    library = Library(name="writer-disable-lib", path="/tmp/writer-disable-lib")
+    db.add(library)
+    db.flush()
+
+    series = Series(name="Series A", library_id=library.id)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    existing_path = "/tmp/disable-existing.cbz"
+    comic = Comic(
+        volume_id=volume.id,
+        filename="disable-existing.cbz",
+        file_path=existing_path,
+        page_count=10,
+        number="1",
+        alternate_series="Old List",
+        alternate_number="1",
+        series_group="Old Group",
+        story_arc="Old Arc",
+    )
+    db.add(comic)
+    db.commit()
+
+    existing_map = {existing_path: comic}
+
+    def get_or_create_series(name: str):
+        return db.query(Series).filter_by(name=name, library_id=library.id).first()
+
+    def get_or_create_volume(series_obj, volume_num: int, _file_path: str):
+        return db.query(Volume).filter_by(series_id=series_obj.id, volume_number=volume_num).first()
+
+    tag_service = SimpleNamespace(
+        get_or_create_characters=MagicMock(return_value=[]),
+        get_or_create_teams=MagicMock(return_value=[]),
+        get_or_create_locations=MagicMock(return_value=[]),
+        get_or_create_genres=MagicMock(return_value=[]),
+    )
+    credit_service = SimpleNamespace(add_credits_to_comic=MagicMock())
+    reading_list_service = SimpleNamespace(
+        update_comic_reading_lists=MagicMock(),
+        remove_comic_from_all_lists=MagicMock(),
+    )
+    collection_service = SimpleNamespace(
+        update_comic_collections=MagicMock(),
+        remove_comic_from_all_collections=MagicMock(),
+    )
+
+    batch = [{
+        "file_path": existing_path,
+        "mtime": 111.0,
+        "size": 222,
+        "metadata": _metadata(
+            series_group="Event",
+            alternate_series="Alt",
+            alternate_number="1",
+            story_arc="Arc",
+        ),
+        "error": False,
+    }]
+
+    metadata_writer_module._apply_metadata_batch(
+        db,
+        batch,
+        existing_map,
+        get_or_create_series,
+        get_or_create_volume,
+        tag_service,
+        credit_service,
+        reading_list_service,
+        collection_service,
+        parse_reading_lists=False,
+        parse_collections=False,
+        parse_story_arcs=False,
+    )
+
+    db.refresh(comic)
+    assert comic.alternate_series is None
+    assert comic.alternate_number is None
+    assert comic.series_group is None
+    assert comic.story_arc is None
+    reading_list_service.update_comic_reading_lists.assert_not_called()
+    collection_service.update_comic_collections.assert_not_called()
+    reading_list_service.remove_comic_from_all_lists.assert_called_once_with(comic.id)
+    collection_service.remove_comic_from_all_collections.assert_called_once_with(comic.id)
+
+
 def test_metadata_writer_batches_and_emits_summary(monkeypatch, tmp_path):
     fake_db = _FakeDB(str(tmp_path / "lib"))
     applied_batches = []

--- a/tests/services/test_scan_manager.py
+++ b/tests/services/test_scan_manager.py
@@ -1,7 +1,7 @@
 import json
 import threading
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, ANY
 
 import pytest
 from sqlalchemy.exc import OperationalError
@@ -208,6 +208,12 @@ def test_add_cleanup_task_and_add_thumbnail_task(monkeypatch, db):
 
     thumb_ignored = manager.add_thumbnail_task(10, force=False)
     assert thumb_ignored["status"] == "ignored"
+
+    rehydrate_queued = manager.add_metadata_rehydrate_task(10)
+    assert rehydrate_queued["status"] == "queued"
+
+    rehydrate_ignored = manager.add_metadata_rehydrate_task(10)
+    assert rehydrate_ignored["status"] == "ignored"
 
 
 def test_fix_stuck_libraries_resets_only_without_running_job(monkeypatch, db):
@@ -435,6 +441,80 @@ def test_run_cleanup_job_failure_marks_failed(monkeypatch, db):
     manager._set_library_scanning_status.assert_called_once_with(88, False)
 
 
+def test_run_metadata_rehydrate_job_success(monkeypatch, db):
+    manager = _manager()
+    monkeypatch.setattr(sm, "SessionLocal", _session_local_factory(db))
+
+    lib = Library(
+        name="rehydrate-lib",
+        path="/tmp/rehydrate-lib",
+        parse_reading_lists=True,
+        parse_collections=False,
+        parse_story_arcs=True,
+    )
+    db.add(lib)
+    db.commit()
+
+    expected_summary = {"comics_scanned": 12, "reading_lists_restored": 3}
+    rehydrate = MagicMock(return_value=expected_summary)
+    monkeypatch.setattr(sm, "rehydrate_library_metadata_from_cache", rehydrate)
+
+    manager._safe_job_update = MagicMock()
+    manager._set_library_scanning_status = MagicMock()
+
+    manager._run_metadata_rehydrate_job({"id": 31, "library_id": lib.id})
+
+    rehydrate.assert_called_once_with(
+        db=ANY,
+        library_id=lib.id,
+        rehydrate_reading_lists=True,
+        rehydrate_collections=False,
+        rehydrate_story_arcs=True,
+    )
+    manager._safe_job_update.assert_called_once_with(31, JobStatus.COMPLETED, summary=expected_summary)
+    manager._set_library_scanning_status.assert_called_once_with(lib.id, False)
+
+
+def test_run_metadata_rehydrate_job_missing_library(monkeypatch, db):
+    manager = _manager()
+    monkeypatch.setattr(sm, "SessionLocal", _session_local_factory(db))
+
+    manager._safe_job_update = MagicMock()
+    manager._set_library_scanning_status = MagicMock()
+
+    manager._run_metadata_rehydrate_job({"id": 32, "library_id": 999999})
+
+    manager._safe_job_update.assert_called_once_with(32, JobStatus.FAILED, error="Library not found")
+    manager._set_library_scanning_status.assert_called_once_with(999999, False)
+
+
+def test_run_metadata_rehydrate_job_failure_marks_failed(monkeypatch, db):
+    manager = _manager()
+    monkeypatch.setattr(sm, "SessionLocal", _session_local_factory(db))
+
+    lib = Library(name="rehydrate-fail", path="/tmp/rehydrate-fail")
+    db.add(lib)
+    db.commit()
+
+    monkeypatch.setattr(
+        sm,
+        "rehydrate_library_metadata_from_cache",
+        MagicMock(side_effect=RuntimeError("rehydrate fail")),
+    )
+    monkeypatch.setattr(sm.traceback, "print_exc", MagicMock())
+
+    manager._safe_job_update = MagicMock()
+    manager._set_library_scanning_status = MagicMock()
+
+    manager._run_metadata_rehydrate_job({"id": 33, "library_id": lib.id})
+
+    call = manager._safe_job_update.call_args
+    assert call.args[0] == 33
+    assert call.args[1] == JobStatus.FAILED
+    assert "rehydrate fail" in call.kwargs["error"]
+    manager._set_library_scanning_status.assert_called_once_with(lib.id, False)
+
+
 def test_process_queue_dispatches_scan_job(monkeypatch):
     manager = _manager()
 
@@ -517,10 +597,64 @@ def test_process_queue_dispatches_non_scan_jobs(monkeypatch, job_type, runner_na
     manager._run_scan_job = MagicMock()
     manager._run_thumbnail_job = MagicMock()
     manager._run_cleanup_job = MagicMock()
+    manager._run_metadata_rehydrate_job = MagicMock()
 
     manager._process_queue()
 
     getattr(manager, runner_name).assert_called_once()
+    manager._run_metadata_rehydrate_job.assert_not_called()
+
+
+def test_process_queue_dispatches_metadata_rehydrate_job(monkeypatch):
+    manager = _manager()
+
+    job = SimpleNamespace(id=7, library_id=12, job_type=JobType.METADATA_REHYDRATE, force_scan=False)
+
+    scan_q = MagicMock()
+    scan_q.filter.return_value = scan_q
+    scan_q.order_by.return_value = scan_q
+    scan_q.first.return_value = None
+
+    thumb_q = MagicMock()
+    thumb_q.filter.return_value = thumb_q
+    thumb_q.order_by.return_value = thumb_q
+    thumb_q.first.return_value = None
+
+    cleanup_q = MagicMock()
+    cleanup_q.filter.return_value = cleanup_q
+    cleanup_q.order_by.return_value = cleanup_q
+    cleanup_q.first.return_value = None
+
+    metadata_q = MagicMock()
+    metadata_q.filter.return_value = metadata_q
+    metadata_q.order_by.return_value = metadata_q
+    metadata_q.first.return_value = job
+
+    claim = MagicMock()
+    claim.filter.return_value = claim
+    claim.update.return_value = 1
+
+    db = MagicMock()
+    db.query.side_effect = [scan_q, thumb_q, cleanup_q, metadata_q, claim]
+
+    manager._stop_event = MagicMock()
+    manager._stop_event.is_set.side_effect = [False, True]
+
+    monkeypatch.setattr(sm, "SessionLocal", lambda: db)
+    monkeypatch.setattr(sm.time, "sleep", MagicMock())
+
+    manager._set_library_scanning_status = MagicMock()
+    manager._run_scan_job = MagicMock()
+    manager._run_thumbnail_job = MagicMock()
+    manager._run_cleanup_job = MagicMock()
+    manager._run_metadata_rehydrate_job = MagicMock()
+
+    manager._process_queue()
+
+    manager._set_library_scanning_status.assert_called_once_with(12, True)
+    manager._run_metadata_rehydrate_job.assert_called_once_with(
+        {"id": 7, "library_id": 12, "type": JobType.METADATA_REHYDRATE, "force": False}
+    )
 
 
 def test_process_queue_no_job_triggers_integrity_check(monkeypatch):

--- a/tests/services/test_scanner_parallel.py
+++ b/tests/services/test_scanner_parallel.py
@@ -166,6 +166,9 @@ def test_scan_parallel_orchestrates_pool_writer_and_summary(monkeypatch, tmp_pat
     assert len(FakeProcess.instances) == 1
     assert FakeProcess.instances[0].started is True
     assert FakeProcess.instances[0].joined is True
+    assert FakeProcess.instances[0].kwargs["parse_reading_lists"] is True
+    assert FakeProcess.instances[0].kwargs["parse_collections"] is True
+    assert FakeProcess.instances[0].kwargs["parse_story_arcs"] is True
 
     assert FakePool.last_processes == 3
 
@@ -397,3 +400,46 @@ def test_scan_parallel_swallows_sentinel_put_error_during_failure_cleanup(monkey
     writer_proc = FakeProcess.instances[0]
     assert writer_proc.joined is True
     assert writer_proc.terminated is False
+
+
+def test_scan_parallel_passes_library_metadata_flags_to_writer(monkeypatch, tmp_path):
+    library_path = tmp_path / "library"
+    _create_file(library_path / "new.cbz")
+
+    db = DummyDB(existing=[])
+    library = SimpleNamespace(
+        path=str(library_path),
+        name="Flagged",
+        id=104,
+        last_scanned=None,
+        parse_reading_lists=False,
+        parse_collections=False,
+        parse_story_arcs=False,
+    )
+    scanner = LibraryScanner(library, db)
+
+    scanner._reconcile_sidecars = lambda *_args, **_kwargs: None
+    scanner._cleanup_missing_files = lambda *_args, **_kwargs: 0
+    _disable_container_cleanup(scanner)
+
+    result_queue = FakeQueue()
+    stats_queue = FakeQueue([
+        {"summary": True, "imported": 1, "updated": 0, "errors": 0, "skipped": 0}
+    ])
+    queues = [result_queue, stats_queue]
+
+    FakePool.last_processes = None
+    FakeProcess.instances = []
+
+    monkeypatch.setattr(scanner_module, "Queue", lambda: queues.pop(0))
+    monkeypatch.setattr(scanner_module, "metadata_worker", fake_worker)
+    monkeypatch.setattr(scanner_module.multiprocessing, "Process", FakeProcess)
+    monkeypatch.setattr(scanner_module.multiprocessing, "Pool", FakePool)
+    monkeypatch.setattr(scanner_module, "get_cached_setting", lambda _key, default=0: default)
+
+    scanner.scan_parallel(force=False, worker_limit=1)
+
+    writer_kwargs = FakeProcess.instances[0].kwargs
+    assert writer_kwargs["parse_reading_lists"] is False
+    assert writer_kwargs["parse_collections"] is False
+    assert writer_kwargs["parse_story_arcs"] is False


### PR DESCRIPTION
## Summary
This PR adds per-library controls for optional metadata parsing and threads those controls through the parallel metadata scanning pipeline, API surface, and UI.

It also addresses the repopulation problem when metadata toggles are turned back on by introducing a dedicated low-priority background rehydrate job (metadata_rehydrate) that restores metadata from cached Comic.metadata_json instead of requiring an immediate force scan.

## What Changed

### 1. Library-level parse toggles
- Added library flags for:
  - parse_reading_lists (AlternateSeries/AlternateNumber)
  - parse_collections (SeriesGroup)
  - parse_story_arcs (StoryArc)
- Added migration for new library fields.
- Wired flags through create/update/list library APIs and admin library settings UI.

### 2. Parallel metadata scan integration
- Parallel metadata writer now receives parse-toggle flags and only writes reading-list/collection/story-arc fields when enabled.
- Scanner path passes library parse flags into the metadata writer process.

### 3. Non-destructive disable behavior
- Disabling toggles no longer deletes historical data rows.
- Instead, visibility is filtered at query-time so disabled metadata is hidden for that library.
- Applied to reading lists, collections, story arcs, and their series/volume surfaces.

### 4. Search integration
- Search endpoints/services now respect per-library metadata toggles.
- Reading-list/collection search results are scoped to libraries where those metadata types are enabled.

### 5. New queued metadata rehydrate job
- Added new job type: METADATA_REHYDRATE / metadata_rehydrate.
- Queue priority is now:
  1. scan
  2. thumbnail
  3. cleanup
  4. metadata_rehydrate (lowest)
- Added scan manager support:
  - _add_metadata_rehydrate_task(library_id) with duplicate protection
  - _run_metadata_rehydrate_job(...)
- Rehydrate runs in the existing scan worker pipeline and uses existing contention-safe job/library update helpers (_safe_job_update, _set_library_scanning_status).

### 6. Library update flow changes
- Rehydration is no longer run inline inside PATCH /api/libraries/{id} transactions.
- On False -> True toggle transitions, API now queues metadata_rehydrate and returns queue status in 
ehydration response payload.
- Admin library UI now shows queued/ignored/failed toasts for rehydrate queueing.

### 7. Jobs UI support
- Admin jobs page recognizes and renders metadata_rehydrate jobs with appropriate styling and summary fields.

## Why this approach
- Avoids destructive data loss when users temporarily disable metadata categories.
- Avoids requiring force scans for common re-enable workflows by restoring from cached metadata.
- Reduces SQLite write contention risk by running rehydrate in the same serialized worker model as other scan jobs, rather than inline during library save requests.

## Testing
Added/updated tests across API and services, including:
- library toggle API behavior
- scan manager queueing/dispatch for metadata rehydrate
- metadata rehydrate restoration logic from cached metadata
- toggle-aware behavior in search/reading-list/collection/series/volume endpoints
- scanner parallel metadata writer flag propagation

Focused suite run for the new queued rehydrate path:
- tests/services/test_scan_manager.py
- tests/services/test_metadata_service.py
- tests/api/test_libraries.py

Result: all passed locally.

## Notes
- If cached raw metadata is missing/invalid for some comics, job summaries include orce_scan_recommended so admins can decide whether to run a force scan for full repopulation.