### PR TITLE
Fix OPDS feed URL and harden nested OPDS feeds for Chunky/Panels

### DIFF
--- a/app/routers/opds.py
+++ b/app/routers/opds.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter, Depends, Request, HTTPException
 from fastapi.responses import Response, FileResponse
-from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import joinedload
 from datetime import datetime, timezone
 from collections import defaultdict
@@ -10,14 +9,34 @@ from app.models import ComicCredit
 from app.models.library import Library
 from app.models.series import Series
 from app.models.comic import Comic, Volume
+from app.core.templates import templates
 from app.core.comic_helpers import (
     get_series_age_restriction,
     get_comic_age_restriction,
     get_age_rating_config, NON_PLAIN_FORMATS, get_thumbnail_url
 )
 
-templates = Jinja2Templates(directory="app/templates")
 router = APIRouter(prefix="/opds", tags=["opds"])
+
+
+def format_opds_datetime(value: datetime | None) -> str:
+    """Return an RFC 3339 UTC timestamp for OPDS feeds."""
+    if value is None:
+        value = datetime.now(timezone.utc)
+    elif value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def format_opds_issued(year: int | None, month: int | None, day: int | None) -> str | None:
+    """Return a safe ISO date string for partial comic dates."""
+    if not year:
+        return None
+    safe_month = month or 1
+    safe_day = day or 1
+    return f"{year:04d}-{safe_month:02d}-{safe_day:02d}"
 
 
 # Helper to render XML
@@ -59,7 +78,7 @@ async def opds_root(request: Request, user: OPDSUser, db: SessionDep):
         entries.append({
             "id": f"urn:parker:lib:{lib.id}",
             "title": lib.name,
-            "updated": datetime.now(timezone.utc).isoformat(),  # Libraries rarely change, using now() is acceptable for root
+            "updated": format_opds_datetime(datetime.now(timezone.utc)),  # Libraries rarely change, using now() is acceptable for root
             "link": f"/opds/libraries/{lib.id}",
             "summary": f"Library containing {len(lib.series)} series."
         })
@@ -67,7 +86,7 @@ async def opds_root(request: Request, user: OPDSUser, db: SessionDep):
     return render_xml(request, {
         "feed_id": "urn:parker:root",
         "feed_title": "Parker Library",
-        "updated_at": datetime.now(timezone.utc),
+        "updated_at": format_opds_datetime(datetime.now(timezone.utc)),
         "entries": entries,
         "books": []
     })
@@ -115,6 +134,7 @@ async def opds_library(library_id: int, request: Request, user: OPDSUser, db: Se
     for s in series_list:
 
         s_comics = series_map.get(s.id, [])
+        series_year = min((c.year for c in s_comics if c.year), default=None)
         cover_comic = None
         if s_comics:
             # Filter for standards
@@ -132,17 +152,17 @@ async def opds_library(library_id: int, request: Request, user: OPDSUser, db: Se
 
         entries.append({
             "id": f"urn:parker:series:{s.id}",
-            "title": f"{s.name} ({s.year})",
-            "updated": s.updated_at.isoformat(),
+            "title": f"{s.name} ({series_year})" if series_year else s.name,
+            "updated": format_opds_datetime(s.updated_at),
             "link": f"/opds/series/{s.id}",
-            "summary": s.description,
+            "summary": s.summary_override,
             "thumbnail": get_thumbnail_url(cover_comic.id, cover_comic.updated_at) if cover_comic else None,
         })
 
     return render_xml(request, {
         "feed_id": f"urn:parker:lib:{library_id}",
         "feed_title": library.name,
-        "updated_at": datetime.now(timezone.utc),
+        "updated_at": format_opds_datetime(datetime.now(timezone.utc)),
         "entries": entries,
         "books": []
     })
@@ -188,10 +208,14 @@ async def opds_series(series_id: int, request: Request, user: OPDSUser, db: Sess
     return render_xml(request, {
         "feed_id": f"urn:parker:series:{series_id}",
         "feed_title": feed_title,
-        "updated_at": datetime.now(timezone.utc),
+        "updated_at": format_opds_datetime(datetime.now(timezone.utc)),
         "entries": [],
         "books": comics
     })
+
+
+templates.env.globals["format_opds_datetime"] = format_opds_datetime
+templates.env.globals["format_opds_issued"] = format_opds_issued
 
 
 # 4. DOWNLOAD: Serve the file

--- a/app/templates/opds/feed.xml
+++ b/app/templates/opds/feed.xml
@@ -5,7 +5,7 @@
 
   <id>{{ feed_id }}</id>
   <title>{{ feed_title }}</title>
-  <updated>{{ updated_at.isoformat() }}Z</updated>
+  <updated>{{ updated_at }}</updated>
   <author>
     <name>Parker Media Server</name>
   </author>
@@ -15,7 +15,7 @@
   <entry>
     <title>{{ entry.title }}</title>
     <id>{{ entry.id }}</id>
-    <updated>{{ entry.updated }}Z</updated>
+    <updated>{{ entry.updated }}</updated>
     <content type="text">{{ entry.summary or "" }}</content>
 
     <link rel="subsection"
@@ -37,7 +37,7 @@
     <title>{{ book.volume.series.name }} #{{ book.number }} - {{ book.title }}</title>
 
     <id>urn:parker:comic:{{ book.id }}</id>
-    <updated>{{ book.updated_at.isoformat() }}Z</updated>
+    <updated>{{ format_opds_datetime(book.updated_at) }}</updated>
 
     {# 1. Authors / Credits #}
     {# FIX: Iterate through credits instead of 'writers' property (unless you defined that property on the model) #}
@@ -56,8 +56,9 @@
     <dcterms:publisher>{{ book.publisher }}</dcterms:publisher>
     {% endif %}
 
-    {% if book.year %}
-    <dcterms:issued>{{ book.year }}-{{ '%02d' % book.month|default(1) }}-{{ '%02d' % book.day|default(1) }}</dcterms:issued>
+    {% set issued_date = format_opds_issued(book.year, book.month, book.day) %}
+    {% if issued_date %}
+    <dcterms:issued>{{ issued_date }}</dcterms:issued>
     {% endif %}
 
     <dcterms:language>{{ book.language_iso or 'en' }}</dcterms:language>

--- a/app/templates/user/dashboard.html
+++ b/app/templates/user/dashboard.html
@@ -617,7 +617,7 @@
                         <p class="text-sm text-gray-400">Connect your e-reader or comics app</p>
                         <input id="opds-input"
                                readonly
-                               :value="`${window.location.origin}/api/opds/`"
+                               :value="`${window.location.origin}${window.parker.url('/opds/')}`"
                                class="w-full text-xs bg-gray-900 text-gray-300 px-3 py-2 rounded border border-gray-700 font-mono cursor-pointer"
                                @click="$event.target.select()">
                         <button @click="copyToClipboard($event.target.previousElementSibling.value)"

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -1,6 +1,10 @@
 import pytest
+import xml.etree.ElementTree as ET
 from app.services.settings_service import SettingsService
 from app.models.setting import SystemSetting
+from app.models.library import Library
+from app.models.series import Series
+from app.models.comic import Comic, Volume
 
 
 def test_opds_disabled_by_default(client, normal_user):
@@ -73,3 +77,90 @@ def test_opds_auth_flow(client, db, normal_user):
         assert "application/atom+xml" in response.headers["content-type"]
         assert "<feed" in response.text
         assert "Parker Library" in response.text
+
+
+def _enable_opds(db):
+    setting = db.query(SystemSetting).filter(SystemSetting.key == "server.opds_enabled").first()
+    if not setting:
+        setting = SystemSetting(
+            key="server.opds_enabled",
+            value="true",
+            category="server",
+            data_type="bool"
+        )
+        db.add(setting)
+    else:
+        setting.value = "true"
+    db.commit()
+
+
+def test_opds_library_feed_renders_series_entries(client, db, normal_user):
+    _enable_opds(db)
+
+    library = Library(name="OPDS Library", path="/tmp/opds-library")
+    series = Series(name="Alpha Flight", library=library, summary_override="Team book")
+    volume = Volume(series=series, volume_number=1)
+    comic = Comic(
+        volume=volume,
+        number="1",
+        title="First Issue",
+        filename="alpha-flight-001.cbz",
+        file_path="/tmp/alpha-flight-001.cbz",
+        updated_at=series.updated_at,
+    )
+    db.add_all([library, series, volume, comic])
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    from unittest.mock import patch
+
+    with patch("app.api.opds_deps.verify_password", return_value=True):
+        response = client.get(
+            f"/opds/libraries/{library.id}",
+            auth=(normal_user.username, "any_password")
+        )
+
+    assert response.status_code == 200
+    root = ET.fromstring(response.text)
+    ns = {"atom": "http://www.w3.org/2005/Atom"}
+    entries = root.findall("atom:entry", ns)
+    assert len(entries) == 1
+    assert entries[0].findtext("atom:title", namespaces=ns) == "Alpha Flight"
+    assert "Team book" in response.text
+
+
+def test_opds_series_feed_handles_missing_month_and_day(client, db, normal_user):
+    _enable_opds(db)
+
+    library = Library(name="Series Library", path="/tmp/opds-series-library")
+    series = Series(name="Beta Ray", library=library)
+    volume = Volume(series=series, volume_number=1)
+    comic = Comic(
+        volume=volume,
+        number="7",
+        title="Stormbreaker",
+        filename="beta-ray-007.cbz",
+        file_path="/tmp/beta-ray-007.cbz",
+        year=2024,
+        month=None,
+        day=None,
+        file_size=12345,
+    )
+    db.add_all([library, series, volume, comic])
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    from unittest.mock import patch
+
+    with patch("app.api.opds_deps.verify_password", return_value=True):
+        response = client.get(
+            f"/opds/series/{series.id}",
+            auth=(normal_user.username, "any_password")
+        )
+
+    assert response.status_code == 200
+    root = ET.fromstring(response.text)
+    ns = {"atom": "http://www.w3.org/2005/Atom", "dcterms": "http://purl.org/dc/terms/"}
+    entry = root.find("atom:entry", ns)
+    assert entry is not None
+    assert entry.findtext("dcterms:issued", namespaces=ns) == "2024-01-01"

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -59,6 +59,14 @@ def test_user_dashboard_returns_expected_sections(auth_client, db, normal_user):
     assert len(payload["continue_reading"]) == 1
 
 
+def test_user_dashboard_page_shows_base_aware_opds_url(auth_client):
+    response = auth_client.get("/user/dashboard")
+
+    assert response.status_code == 200
+    assert "window.parker.url('/opds/')" in response.text
+    assert "/api/opds/" not in response.text
+
+
 def test_get_and_update_preferences(auth_client):
     initial = auth_client.get("/api/users/me/preferences")
     assert initial.status_code == 200


### PR DESCRIPTION
First, the user dashboard was advertising the wrong OPDS URL. The profile/dashboard field was hardcoded to /api/opds/, but the OPDS router is actually mounted at /opds/. This meant users copying the displayed URL could end up with a non-working endpoint. The dashboard now builds the OPDS URL via the shared base-path-aware helper so it correctly resolves to /opds/ and still works when Parker is hosted under a subpath.

Second, this hardens the nested OPDS feeds used after a client opens a library folder. The library feed code was referencing Series fields that do not exist in the current model (description and year), which could break feed generation once a reader drilled into a library. That matches the reported behavior where Chunky/Panels could connect and list top-level folders, but failed when entering them with a Readium OPDS parser error. The feed logic now uses real series data, derives a display year from associated comics when available, and safely handles missing partial date fields in comic entries.


Changes

- Fixed the dashboard OPDS URL from /api/opds/ to the actual /opds/ route.
- Switched the dashboard OPDS URL generation to the shared base-URL helper.
- Removed invalid Series field usage from the OPDS library feed.
- Used summary_override for series summaries when present.
- Derived series year from comic data instead of assuming a Series.year field exists.
- Normalized OPDS timestamps to valid RFC 3339 UTC strings.
- Safely formatted issued dates when comic month/day metadata is missing.

Users reported that OPDS clients could authenticate and see the root library list, but failed when opening a folder. That symptom points to the nested library feed rather than auth or the root OPDS endpoint. This PR fixes the most likely cause of malformed or failed nested feed rendering and also corrects the URL Parker tells users to copy into their OPDS clients.

Tests
- Added a regression test to verify the dashboard no longer renders /api/opds/.
- Added OPDS regression tests covering:library feeds rendering valid series entries
series feeds handling missing month/day values
- Focused test runs passed locally:tests/api/test_users.py and tests/api/test_opds.py
- OPDS-focused run: 4 passed
- combined focused run: 16 passed