### PR TITLE
Add Phase 1 Insights with Creator Chemistry drill-downs

### DIFF
--- a/app/api/insights.py
+++ b/app/api/insights.py
@@ -1,0 +1,201 @@
+from typing import Literal, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import desc, func
+from sqlalchemy.orm import aliased
+
+from app.api.deps import CurrentUser, SessionDep
+from app.core.comic_helpers import get_series_age_restriction
+from app.models.comic import Comic, Volume
+from app.models.credits import ComicCredit, Person
+from app.models.series import Series
+
+router = APIRouter()
+
+CreatorRole = Literal["writer", "penciller", "inker", "colorist", "letterer", "editor", "cover_artist"]
+
+
+def _ensure_library_access(library_id: int, user: CurrentUser) -> None:
+    if user.is_superuser:
+        return
+
+    allowed_ids = {lib.id for lib in user.accessible_libraries}
+    if library_id not in allowed_ids:
+        raise HTTPException(status_code=404, detail="Library not found")
+
+
+@router.get("/creator-collaborations", name="creator_collaborations")
+async def get_creator_collaborations(
+    db: SessionDep,
+    current_user: CurrentUser,
+    role_a: CreatorRole = Query("writer"),
+    role_b: CreatorRole = Query("penciller"),
+    library_id: Optional[int] = Query(None, ge=1),
+    min_shared: int = Query(2, ge=1, le=100),
+    limit: int = Query(12, ge=2, le=15, description="Maximum creators shown per axis"),
+):
+    """
+    Aggregates creator-to-creator collaboration pairs for heatmap-style insights.
+    """
+    if library_id is not None:
+        _ensure_library_access(library_id, current_user)
+
+    credit_a = aliased(ComicCredit)
+    credit_b = aliased(ComicCredit)
+    person_a = aliased(Person)
+    person_b = aliased(Person)
+
+    shared_issue_count = func.count(func.distinct(Comic.id))
+    shared_series_count = func.count(func.distinct(Series.id))
+
+    query = (
+        db.query(
+            person_a.id.label("person_a_id"),
+            person_a.name.label("person_a"),
+            person_b.id.label("person_b_id"),
+            person_b.name.label("person_b"),
+            shared_issue_count.label("shared_issues"),
+            shared_series_count.label("shared_series"),
+            func.min(Series.name).label("sample_series"),
+        )
+        .select_from(Comic)
+        .join(Volume, Comic.volume_id == Volume.id)
+        .join(Series, Volume.series_id == Series.id)
+        .join(credit_a, credit_a.comic_id == Comic.id)
+        .join(person_a, person_a.id == credit_a.person_id)
+        .join(credit_b, credit_b.comic_id == Comic.id)
+        .join(person_b, person_b.id == credit_b.person_id)
+        .filter(credit_a.role == role_a, credit_b.role == role_b)
+    )
+
+    if role_a == role_b:
+        query = query.filter(credit_a.person_id < credit_b.person_id)
+
+    if not current_user.is_superuser:
+        allowed_ids = [lib.id for lib in current_user.accessible_libraries]
+        query = query.filter(Series.library_id.in_(allowed_ids))
+
+    if library_id is not None:
+        query = query.filter(Series.library_id == library_id)
+
+    age_filter = get_series_age_restriction(current_user)
+    if age_filter is not None:
+        query = query.filter(age_filter)
+
+    pair_cap = max(limit * limit * 2, 50)
+
+    pairs = (
+        query.group_by(person_a.id, person_a.name, person_b.id, person_b.name)
+        .having(shared_issue_count >= min_shared)
+        .order_by(desc("shared_issues"), person_a.name.asc(), person_b.name.asc())
+        .limit(pair_cap)
+        .all()
+    )
+
+    if not pairs:
+        return {
+            "role_a": role_a,
+            "role_b": role_b,
+            "library_id": library_id,
+            "min_shared": min_shared,
+            "limit": limit,
+            "pair_count": 0,
+            "max_shared_issues": 0,
+            "rows": [],
+            "columns": [],
+            "pairs": [],
+            "top_collaborations": [],
+        }
+
+    row_totals = {}
+    col_totals = {}
+    for pair in pairs:
+        row_key = (pair.person_a_id, pair.person_a)
+        col_key = (pair.person_b_id, pair.person_b)
+        row_totals[row_key] = row_totals.get(row_key, 0) + pair.shared_issues
+        col_totals[col_key] = col_totals.get(col_key, 0) + pair.shared_issues
+
+    row_rankings = [
+        {"id": person_id, "name": name, "total_shared": total_shared}
+        for (person_id, name), total_shared in sorted(
+            row_totals.items(),
+            key=lambda item: (-item[1], item[0][1].lower(), item[0][0]),
+        )[:limit]
+    ]
+    column_rankings = [
+        {"id": person_id, "name": name, "total_shared": total_shared}
+        for (person_id, name), total_shared in sorted(
+            col_totals.items(),
+            key=lambda item: (-item[1], item[0][1].lower(), item[0][0]),
+        )[:limit]
+    ]
+
+    row_id_set = {entry["id"] for entry in row_rankings}
+    column_id_set = {entry["id"] for entry in column_rankings}
+    filtered_pairs = [
+        pair for pair in pairs if pair.person_a_id in row_id_set and pair.person_b_id in column_id_set
+    ]
+
+    if not filtered_pairs:
+        top_pair = pairs[0]
+        row_rankings = [{"id": top_pair.person_a_id, "name": top_pair.person_a, "total_shared": top_pair.shared_issues}]
+        column_rankings = [{"id": top_pair.person_b_id, "name": top_pair.person_b, "total_shared": top_pair.shared_issues}]
+        filtered_pairs = [top_pair]
+
+    visible_row_totals = {}
+    visible_col_totals = {}
+    for pair in filtered_pairs:
+        visible_row_totals[pair.person_a_id] = visible_row_totals.get(pair.person_a_id, 0) + pair.shared_issues
+        visible_col_totals[pair.person_b_id] = visible_col_totals.get(pair.person_b_id, 0) + pair.shared_issues
+
+    row_entries = [
+        {
+            "id": entry["id"],
+            "name": entry["name"],
+            "total_shared": visible_row_totals.get(entry["id"], 0),
+        }
+        for entry in row_rankings
+    ]
+    column_entries = [
+        {
+            "id": entry["id"],
+            "name": entry["name"],
+            "total_shared": visible_col_totals.get(entry["id"], 0),
+        }
+        for entry in column_rankings
+    ]
+
+    max_shared_issues = max(pair.shared_issues for pair in filtered_pairs)
+
+    serialized_pairs = [
+        {
+            "person_a_id": pair.person_a_id,
+            "person_a": pair.person_a,
+            "person_b_id": pair.person_b_id,
+            "person_b": pair.person_b,
+            "shared_issues": pair.shared_issues,
+            "shared_series": pair.shared_series,
+            "sample_series": pair.sample_series,
+            "intensity": round(pair.shared_issues / max_shared_issues, 4) if max_shared_issues else 0,
+        }
+        for pair in filtered_pairs
+    ]
+
+    top_collaborations = sorted(
+        serialized_pairs,
+        key=lambda item: (-item["shared_issues"], item["person_a"].lower(), item["person_b"].lower()),
+    )[:10]
+
+    return {
+        "role_a": role_a,
+        "role_b": role_b,
+        "library_id": library_id,
+        "min_shared": min_shared,
+        "limit": limit,
+        "pair_count": len(serialized_pairs),
+        "max_shared_issues": max_shared_issues,
+        "rows": row_entries,
+        "columns": column_entries,
+        "pairs": serialized_pairs,
+        "top_collaborations": top_collaborations,
+    }

--- a/app/core/templates.py
+++ b/app/core/templates.py
@@ -1,5 +1,6 @@
 import re
 from datetime import datetime
+from pathlib import Path
 from fastapi.templating import Jinja2Templates
 from app.config import settings
 from app.core.settings_loader import get_cached_setting
@@ -28,11 +29,23 @@ def url_builder(path: str) -> str:
     return f"{base}/{clean_path}" if base else f"/{clean_path}"
 
 
+def asset_version(path: str) -> str:
+    """
+    Returns a lightweight cache-busting version for a local asset.
+    Falls back to the application version if the file is missing.
+    """
+    try:
+        return str(int(Path(path).stat().st_mtime))
+    except OSError:
+        return settings.version
+
+
 templates.env.globals["app_version"] = settings.version
 templates.env.globals["app_name"] = settings.app_name
 
 # Inject URL data into Templates
 templates.env.globals["url"] = url_builder
+templates.env.globals["asset_version"] = asset_version
 templates.env.globals["base_url"] = settings.clean_base_url
 templates.env.globals["routes"] = route_map_injector
 templates.env.globals["get_system_setting"] = get_cached_setting

--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ from app.api import reports
 from app.api import migration
 from app.api import batch
 from app.api import home
+from app.api import insights
 
 # Frontend Routes (HTML)
 from app.routers import pages, admin
@@ -227,6 +228,7 @@ app.include_router(collections.router, prefix="/api/collections", tags=["collect
 app.include_router(progress.router, prefix="/api/progress", tags=["progress"])
 app.include_router(batch.router, prefix="/api/batch", tags=["batch"])
 app.include_router(search.router, prefix="/api/search", tags=["search"])
+app.include_router(insights.router, prefix="/api/insights", tags=["insights"])
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(users.router, prefix="/api/users", tags=["users"])
 app.include_router(settings_api.router, prefix="/api/settings", tags=["settings"])

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -31,6 +31,11 @@ async def search(request: Request, user: CurrentUser):
     """Search page"""
     return templates.TemplateResponse(request=request, name="search.html")
 
+@router.get("/insights", response_class=HTMLResponse, name="insights")
+async def insights(request: Request, user: CurrentUser):
+    """Metadata insights page"""
+    return templates.TemplateResponse(request=request, name="insights.html")
+
 @router.get("/collections", response_class=HTMLResponse, name="collections")
 async def collections_view(request: Request, user: CurrentUser):
     """Collections page"""

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -19,7 +19,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="{{ url('static/css/style.css') }}">
+    <link rel="stylesheet" href="{{ url('static/css/style.css') }}?v={{ asset_version('static/css/style.css') }}">
     <style>
         [x-cloak] { display: none !important; }
 
@@ -67,6 +67,7 @@
 
                     <div class="hidden lg:flex items-center space-x-1">
                         <a href="{{ url('/user/dashboard') }}" class="px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800 transition-colors">Dashboard</a>
+                        <a href="{{ url('/insights') }}" class="px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800 transition-colors">Insights</a>
                         <div class="relative group" x-data="{ open: false, libs: [] }" x-init="libs = await (await fetch(window.parker.route('libraries.list', {}, 'limit=5'))).json()">
 
                             <button class="px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800 transition-colors flex items-center gap-1">
@@ -156,6 +157,7 @@
                 class="lg:hidden border-t border-gray-800 py-4 space-y-1"
             >
                 <a href="{{ url('/user/dashboard') }}" class="block px-4 py-2 text-base font-medium text-gray-300 hover:text-white hover:bg-gray-800 rounded-md">Dashboard</a>
+                <a href="{{ url('/insights') }}" class="block px-4 py-2 text-base font-medium text-gray-300 hover:text-white hover:bg-gray-800 rounded-md">Insights</a>
                 <a href="{{ url('/libraries') }}" class="block px-4 py-2 text-base font-medium text-gray-300 hover:text-white hover:bg-gray-800 rounded-md">Libraries</a>
                 <a href="{{ url('/collections') }}" class="block px-4 py-2 text-base font-medium text-gray-300 hover:text-white hover:bg-gray-800 rounded-md">Collections</a>
                 <a href="{{ url('/reading-lists') }}" class="block px-4 py-2 text-base font-medium text-gray-300 hover:text-white hover:bg-gray-800 rounded-md">Reading Lists</a>
@@ -184,7 +186,7 @@
 
     {% include "partials/footer.html" %}
 
-    <script src="{{ url('/static/js/app.js') }}?v={{ app_version }}"></script>
+    <script src="{{ url('/static/js/app.js') }}?v={{ asset_version('static/js/app.js') }}"></script>
 
     <script>
         document.addEventListener('alpine:init', () => {

--- a/app/templates/insights.html
+++ b/app/templates/insights.html
@@ -1,0 +1,413 @@
+{% extends "base.html" %}
+
+{% block title %}Insights - Parker{% endblock %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto space-y-8" x-data="creatorChemistry()">
+    <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
+        <div class="max-w-3xl">
+            <p class="text-xs font-bold uppercase tracking-[0.3em] text-blue-300">Insights</p>
+            <h1 class="mt-2 text-4xl font-black text-white tracking-tight">Creator Chemistry</h1>
+            <p class="mt-3 text-gray-400 text-sm md:text-base">
+                Explore which creators show up together most often in your library. Click any highlighted cell to jump straight into Advanced Search with those creator filters applied.
+            </p>
+        </div>
+
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-3 lg:w-auto">
+            <div class="bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 shadow-lg">
+                <div class="text-[10px] uppercase tracking-wider text-gray-500">Visible Pairs</div>
+                <div class="mt-1 text-2xl font-bold text-white" x-text="data?.pair_count || 0"></div>
+            </div>
+            <div class="bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 shadow-lg">
+                <div class="text-[10px] uppercase tracking-wider text-gray-500">Strongest Pair</div>
+                <div class="mt-1 text-sm font-bold text-blue-300 truncate" x-text="topPairLabel()"></div>
+            </div>
+            <div class="bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 shadow-lg col-span-2 md:col-span-1">
+                <div class="text-[10px] uppercase tracking-wider text-gray-500">Peak Shared Issues</div>
+                <div class="mt-1 text-2xl font-bold text-white" x-text="data?.max_shared_issues || 0"></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="bg-gray-800/90 border border-gray-700 rounded-2xl shadow-2xl overflow-hidden">
+        <div class="px-4 md:px-6 py-5 border-b border-gray-700 bg-gradient-to-r from-gray-900 via-gray-800 to-gray-900">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4">
+                <div>
+                    <label class="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">Role A</label>
+                    <select x-model="roleA" class="w-full bg-gray-900 text-white rounded-lg px-3 py-2.5 border border-gray-600 outline-none">
+                        <template x-for="role in roles" :key="`a-${role.value}`">
+                            <option :value="role.value" :selected="role.value === roleA" x-text="role.label"></option>
+                        </template>
+                    </select>
+                </div>
+
+                <div>
+                    <label class="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">Role B</label>
+                    <select x-model="roleB" class="w-full bg-gray-900 text-white rounded-lg px-3 py-2.5 border border-gray-600 outline-none">
+                        <template x-for="role in roles" :key="`b-${role.value}`">
+                            <option :value="role.value" :selected="role.value === roleB" x-text="role.label"></option>
+                        </template>
+                    </select>
+                </div>
+
+                <div>
+                    <label class="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">Library</label>
+                    <select x-model="selectedLibraryId" class="w-full bg-gray-900 text-white rounded-lg px-3 py-2.5 border border-gray-600 outline-none">
+                        <option value="">All Visible Libraries</option>
+                        <template x-for="library in libraries" :key="library.id">
+                            <option :value="String(library.id)" x-text="library.name"></option>
+                        </template>
+                    </select>
+                </div>
+
+                <div>
+                    <label class="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">Minimum Shared Issues</label>
+                    <input type="number" min="1" max="100" x-model="minShared" class="w-full bg-gray-900 text-white rounded-lg px-3 py-2.5 border border-gray-600 outline-none">
+                </div>
+
+                <div>
+                    <label class="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">Top Creators Per Axis</label>
+                    <div class="flex gap-2">
+                        <input
+                            type="number"
+                            min="2"
+                            max="15"
+                            x-model="limit"
+                            x-on:blur="normalizeLimit()"
+                            x-on:change="normalizeLimit()"
+                            class="w-full bg-gray-900 text-white rounded-lg px-3 py-2.5 border border-gray-600 outline-none"
+                        >
+                        <button
+                            x-on:click="loadInsights()"
+                            class="shrink-0 bg-blue-600 hover:bg-blue-500 text-white font-bold px-4 rounded-lg transition-colors flex items-center justify-center min-w-[92px]"
+                        >
+                            <span x-show="loading">Working</span>
+                            <span x-show="!loading">Refresh</span>
+                        </button>
+                    </div>
+                    <p x-show="showDensityWarning()" x-cloak class="mt-2 text-[11px] leading-5 text-amber-300">
+                        Larger axes get dense fast. Parker will cap this view at 15 creators per side.
+                    </p>
+                </div>
+            </div>
+
+            <p class="mt-4 text-xs text-gray-500">
+                Stronger cells mean more shared issues. Empty cells do not have enough overlap for the current threshold.
+            </p>
+        </div>
+
+        <div x-show="loading" class="px-6 py-16 text-center text-gray-400">
+            <div class="inline-flex items-center gap-3">
+                <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-400"></div>
+                <span>Mapping creator collaborations...</span>
+            </div>
+        </div>
+
+        <div x-show="errorMessage" x-cloak class="px-6 py-10 text-center">
+            <div class="inline-block bg-red-900/30 border border-red-700 text-red-200 rounded-xl px-5 py-4" x-text="errorMessage"></div>
+        </div>
+
+        <div x-show="!loading && !errorMessage && data && data.pair_count === 0" x-cloak class="px-6 py-20 text-center">
+            <div class="max-w-xl mx-auto">
+                <h2 class="text-2xl font-bold text-white">No creator pairs matched this view</h2>
+                <p class="mt-3 text-gray-400">
+                    Try lowering the shared-issue threshold, changing roles, or broadening the library scope.
+                </p>
+            </div>
+        </div>
+
+        <div x-show="!loading && !errorMessage && data && data.pair_count > 0" x-cloak class="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_320px]">
+            <div class="px-4 md:px-6 pt-4 md:pt-5 pb-6">
+                <div class="mb-4 rounded-xl border border-gray-700 bg-gray-900/50 px-4 py-3">
+                    <div class="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-center md:justify-between">
+                        <div class="text-sm text-gray-300">
+                            <span class="font-bold text-white">Rows:</span>
+                            <span x-text="roleLabel(roleA)"></span>
+                            <span class="mx-2 text-gray-600">&middot;</span>
+                            <span class="font-bold text-white">Columns:</span>
+                            <span x-text="roleLabel(roleB)"></span>
+                        </div>
+                        <div class="text-sm text-blue-300">
+                            Tap a center cell to open the matching books.
+                        </div>
+                    </div>
+                    <div class="mt-2 text-xs text-gray-500">
+                        Header cards show visible totals for each creator in this matrix. Only the center intersection cells are drill-down links.
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-between gap-3 mb-3 xl:hidden">
+                    <div class="text-xs uppercase tracking-[0.2em] text-gray-500">Heatmap</div>
+                    <div class="text-[11px] text-blue-300 bg-blue-950/40 border border-blue-900/60 rounded-full px-3 py-1">
+                        Swipe sideways to explore
+                    </div>
+                </div>
+
+                <div class="max-h-[70vh] overflow-auto overscroll-contain touch-pan-x touch-pan-y pb-2">
+                    <table class="table-fixed min-w-[640px] md:min-w-[720px] border-separate [border-spacing:0.5rem]">
+                        <thead>
+                            <tr>
+                                <th class="sticky top-0 left-0 z-30 w-[190px] min-w-[190px] align-top bg-gray-900/95 backdrop-blur py-3 px-3 rounded-lg border border-gray-700 shadow-lg text-left">
+                                    <div class="text-[11px] uppercase tracking-wider text-gray-500">Rows</div>
+                                    <div class="mt-1 text-sm font-bold text-white" x-text="roleLabel(roleA)"></div>
+                                    <div class="mt-3 text-[11px] uppercase tracking-wider text-gray-500">Columns</div>
+                                    <div class="mt-1 text-xs font-bold text-gray-300" x-text="roleLabel(roleB)"></div>
+                                </th>
+
+                                <template x-for="column in (data?.columns || [])" :key="`head-${column.id}`">
+                                    <th class="sticky top-0 z-20 w-[104px] min-w-[104px] align-top py-3 px-3 text-center rounded-lg border border-gray-700 bg-gray-900/95 backdrop-blur shadow-lg">
+                                        <div class="text-[11px] uppercase tracking-wider text-gray-500" x-text="roleLabel(roleB)"></div>
+                                        <div class="mt-1 text-xs font-bold text-gray-200 leading-tight" x-text="column.name"></div>
+                                        <div class="mt-1 text-[11px] text-gray-500" x-text="`${column.total_shared} visible total`"></div>
+                                    </th>
+                                </template>
+                            </tr>
+                        </thead>
+
+                        <tbody>
+                            <template x-for="row in (matrixRows() || [])" :key="`row-${row.id}`">
+                                <tr>
+                                    <th scope="row" class="sticky left-0 z-10 w-[190px] min-w-[190px] h-[176px] align-top bg-gray-800/95 backdrop-blur py-3 px-3 rounded-lg border border-gray-700 text-left">
+                                        <div class="text-[11px] uppercase tracking-wider text-gray-500" x-text="roleLabel(roleA)"></div>
+                                        <div class="mt-1 text-sm font-bold text-white leading-tight" x-text="row.name"></div>
+                                        <div class="mt-1 text-[11px] text-gray-500" x-text="`${row.total_shared} visible total`"></div>
+                                    </th>
+
+                                    <template x-for="cell in row.cells" :key="`${row.id}-${cell.person_b_id}`">
+                                        <td class="w-[104px] min-w-[104px] h-[176px] align-top">
+                                            <div class="h-[176px] min-h-[176px]">
+                                                <button
+                                                    x-show="cell.shared_issues > 0"
+                                                    x-on:click="openSearch(cell)"
+                                                    class="w-full h-full min-h-[176px] overflow-hidden rounded-xl border text-left px-3 py-3 transition-all hover:-translate-y-0.5 hover:shadow-lg"
+                                                    :style="cellStyle(cell)"
+                                                    :title="cell.sample_series"
+                                                >
+                                                    <div class="text-2xl font-black text-white" x-text="cell.shared_issues"></div>
+                                                    <div class="mt-1 text-xs text-white/85">
+                                                        <span x-text="cell.shared_series"></span> shared series
+                                                    </div>
+                                                    <div class="mt-2 text-[11px] uppercase tracking-wider text-white/60">Pair Total</div>
+                                                    <div class="mt-1 max-w-[80px] overflow-hidden text-ellipsis whitespace-nowrap text-[11px] text-white/70" x-text="cell.sample_series"></div>
+                                                </button>
+
+                                                <div
+                                                    x-show="cell.shared_issues === 0"
+                                                    class="w-full h-full min-h-[176px] rounded-xl border border-dashed border-gray-700 bg-gray-900/40"
+                                                ></div>
+                                            </div>
+                                        </td>
+                                    </template>
+                                </tr>
+                            </template>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <aside class="border-t xl:border-t-0 xl:border-l border-gray-700 bg-gray-900/40 p-4 md:p-6">
+                <div class="flex items-center justify-between mb-4">
+                    <h2 class="text-lg font-bold text-white">Top Collaborations</h2>
+                    <span class="text-xs uppercase tracking-wider text-gray-500">click to drill down</span>
+                </div>
+
+                <div class="space-y-3 md:grid md:grid-cols-2 md:gap-3 md:space-y-0 xl:grid-cols-1">
+                    <template x-for="pair in (data?.top_collaborations || [])" :key="`${pair.person_a_id}-${pair.person_b_id}`">
+                        <button
+                            x-on:click="openSearch(pair)"
+                            class="w-full text-left rounded-xl border border-gray-700 bg-gray-800/80 hover:bg-gray-750 hover:border-blue-500/50 p-4 transition-all shadow-lg"
+                        >
+                            <div class="flex items-start justify-between gap-3">
+                                <div>
+                                    <div class="text-sm font-bold text-white" x-text="pair.person_a"></div>
+                                    <div class="text-xs text-blue-300 mt-0.5" x-text="pair.person_b"></div>
+                                </div>
+                                <div class="text-right">
+                                    <div class="text-xl font-black text-white" x-text="pair.shared_issues"></div>
+                                    <div class="text-[11px] uppercase tracking-wider text-gray-500">issues</div>
+                                </div>
+                            </div>
+                            <div class="mt-3 flex items-center justify-between text-xs text-gray-400">
+                                <span x-text="`${pair.shared_series} series`"></span>
+                                <span class="truncate ml-3 text-right" x-text="pair.sample_series"></span>
+                            </div>
+                        </button>
+                    </template>
+                </div>
+
+                <div class="mt-6 md:mt-4 xl:mt-6 rounded-xl border border-gray-700 bg-gray-800/60 p-4 md:col-span-2 xl:col-span-1">
+                    <h3 class="text-sm font-bold text-white">Why this view works</h3>
+                    <p class="mt-2 text-xs leading-6 text-gray-400">
+                        Search is still the precise tool. Insights helps you notice patterns first, then jump into the exact books behind them.
+                    </p>
+                </div>
+            </aside>
+        </div>
+    </div>
+</div>
+
+<script>
+function creatorChemistry() {
+    return {
+        roles: [
+            { value: 'writer', label: 'Writer' },
+            { value: 'penciller', label: 'Penciller' },
+            { value: 'inker', label: 'Inker' },
+            { value: 'colorist', label: 'Colorist' },
+            { value: 'letterer', label: 'Letterer' },
+            { value: 'editor', label: 'Editor' },
+            { value: 'cover_artist', label: 'Cover Artist' },
+        ],
+        libraries: [],
+        data: null,
+        loading: true,
+        errorMessage: '',
+        roleA: 'writer',
+        roleB: 'penciller',
+        selectedLibraryId: '',
+        minShared: 2,
+        limit: 12,
+        pairMap: {},
+
+        async init() {
+            await this.loadLibraries();
+            await this.loadInsights();
+        },
+
+        normalizeLimit() {
+            const parsed = parseInt(this.limit, 10);
+            if (Number.isNaN(parsed)) {
+                this.limit = 12;
+                return this.limit;
+            }
+
+            this.limit = Math.min(15, Math.max(2, parsed));
+            return this.limit;
+        },
+
+        showDensityWarning() {
+            const parsed = parseInt(this.limit, 10);
+            if (Number.isNaN(parsed)) return false;
+            return parsed > 12;
+        },
+
+        async loadLibraries() {
+            try {
+                const res = await fetch(window.parker.route('libraries.list'));
+                if (res.ok) {
+                    this.libraries = await res.json();
+                }
+            } catch (error) {
+                console.error('Failed to load libraries', error);
+            }
+        },
+
+        async loadInsights() {
+            this.loading = true;
+            this.errorMessage = '';
+
+            try {
+                const normalizedLimit = this.normalizeLimit();
+                const query = new URLSearchParams({
+                    role_a: this.roleA,
+                    role_b: this.roleB,
+                    min_shared: String(parseInt(this.minShared, 10) || 1),
+                    limit: String(normalizedLimit),
+                });
+
+                if (this.selectedLibraryId) {
+                    query.set('library_id', this.selectedLibraryId);
+                }
+
+                const res = await fetch(window.parker.route('insights.creator_collaborations', {}, query.toString()));
+                if (!res.ok) {
+                    const payload = await res.json().catch(() => ({}));
+                    throw new Error(payload.detail || 'Failed to load insights');
+                }
+
+                this.data = await res.json();
+                this.buildPairMap();
+            } catch (error) {
+                console.error(error);
+                this.errorMessage = error.message || 'Failed to load insights';
+                this.data = null;
+                this.pairMap = {};
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        buildPairMap() {
+            this.pairMap = {};
+            for (const pair of (this.data?.pairs || [])) {
+                this.pairMap[`${pair.person_a_id}__${pair.person_b_id}`] = pair;
+            }
+        },
+
+        matrixRows() {
+            if (!this.data) return [];
+
+            return this.data.rows.map((row) => ({
+                ...row,
+                cells: this.data.columns.map((column) => this.pairMap[`${row.id}__${column.id}`] || {
+                    person_a_id: row.id,
+                    person_a: row.name,
+                    person_b_id: column.id,
+                    person_b: column.name,
+                    shared_issues: 0,
+                    shared_series: 0,
+                    sample_series: '',
+                    intensity: 0,
+                }),
+            }));
+        },
+
+        roleLabel(roleValue) {
+            return this.roles.find((role) => role.value === roleValue)?.label || roleValue;
+        },
+
+        topPairLabel() {
+            const pair = this.data?.top_collaborations?.[0];
+            if (!pair) return 'None yet';
+            return `${pair.person_a} + ${pair.person_b}`;
+        },
+
+        cellStyle(cell) {
+            const alpha = 0.18 + (cell.intensity * 0.62);
+            const borderAlpha = 0.12 + (cell.intensity * 0.45);
+            return `background: linear-gradient(160deg, rgba(37, 99, 235, ${alpha}) 0%, rgba(30, 41, 59, 0.92) 100%); border-color: rgba(96, 165, 250, ${borderAlpha});`;
+        },
+
+        buildSearchUrl(pair) {
+            const payload = {
+                match: 'all',
+                libraryId: this.selectedLibraryId || null,
+                filters: [
+                    { field: this.roleA, operator: 'contains', value: [pair.person_a] },
+                    { field: this.roleB, operator: 'contains', value: [pair.person_b] },
+                ]
+            };
+
+            if (window.parker?.searchHandoff?.buildUrl) {
+                return window.parker.searchHandoff.buildUrl(payload);
+            }
+
+            const query = new URLSearchParams({
+                match: payload.match,
+                filters: JSON.stringify(payload.filters),
+            });
+
+            if (payload.libraryId) {
+                query.set('library_id', String(payload.libraryId));
+            }
+
+            return window.parker.route('pages.search', {}, query.toString());
+        },
+
+        openSearch(pair) {
+            window.location.href = this.buildSearchUrl(pair);
+        },
+    };
+}
+</script>
+{% endblock %}

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -421,6 +421,19 @@ document.addEventListener('alpine:init', () => {
             this.checkUrlParams();
         },
 
+        applyHydratedFilters(filters) {
+            if (!Array.isArray(filters) || filters.length === 0) return false;
+
+            this.rules = filters.map((filter, index) => ({
+                id: Date.now() + index + Math.random(),
+                field: filter.field,
+                operator: filter.operator || 'contains',
+                value: filter.value ?? []
+            }));
+
+            return true;
+        },
+
         checkUrlParams() {
 
             const params = new URLSearchParams(window.location.search);
@@ -443,22 +456,76 @@ document.addEventListener('alpine:init', () => {
             // 1. Handle Sorting overrides
             if (params.has('sort_by')) {
                 this.sortBy = params.get('sort_by');
-                // Optional: Handle sort order if you passed it (e.g. &sort_order=asc)
-                // We default to 'desc' in the model, but you could read it here if needed.
                 shouldSearch = true;
             }
 
             if (params.has('sort_order')) {
-                // You might need to add `sortOrder` to your Alpine data object if it isn't there,
-                // or just pass it directly to the API payload if UI doesn't have a toggle for it.
-                // The current UI relies on hardcoded 'desc' in performSearch or API defaults.
                 this.sortOrder = params.get('sort_order');
+            }
+
+            if (params.has('state_key') && window.parker.searchHandoff) {
+                const hydrated = window.parker.searchHandoff.load(params.get('state_key'));
+                if (hydrated) {
+                    if (hydrated.match) {
+                        this.match = hydrated.match;
+                    }
+
+                    if (hydrated.sortBy) {
+                        this.sortBy = hydrated.sortBy;
+                        shouldSearch = true;
+                    }
+
+                    if (hydrated.sortOrder) {
+                        this.sortOrder = hydrated.sortOrder;
+                    }
+
+                    if (hydrated.limit) {
+                        const hydratedLimit = parseInt(hydrated.limit, 10);
+                        if (!Number.isNaN(hydratedLimit) && hydratedLimit > 0) {
+                            this.limit = hydratedLimit;
+                        }
+                    }
+
+                    if (hydrated.libraryId) {
+                        this.contextLibraryId = parseInt(hydrated.libraryId, 10);
+                        if (!Number.isNaN(this.contextLibraryId)) {
+                            this.fetchLibraryName(this.contextLibraryId);
+                            shouldSearch = true;
+                        }
+                    }
+
+                    if (this.applyHydratedFilters(hydrated.filters)) {
+                        shouldSearch = true;
+                    }
+                }
+            }
+
+            if (params.has('match')) {
+                this.match = params.get('match');
+            }
+
+            if (params.has('limit')) {
+                const urlLimit = parseInt(params.get('limit'), 10);
+                if (!Number.isNaN(urlLimit) && urlLimit > 0) {
+                    this.limit = urlLimit;
+                }
+            }
+
+            if (params.has('filters')) {
+                try {
+                    const parsedFilters = JSON.parse(params.get('filters'));
+                    if (this.applyHydratedFilters(parsedFilters)) {
+                        shouldSearch = true;
+                    }
+                } catch (error) {
+                    console.error('Failed to parse search filters from URL', error);
+                }
             }
 
             // 2. Handle Filters (Deep Linking)
             // Allow search if 'field' exists AND ('value' OR 'operator' exists)
             // This supports ?field=summary&operator=is_empty
-            if (params.has('field') && (params.has('value') || params.has('operator'))) {
+            if (!params.has('filters') && params.has('field') && (params.has('value') || params.has('operator'))) {
                 const field = params.get('field');
                 const value = params.get('value');
                 // Default to 'contains' if not specified

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -498,6 +498,123 @@ document.addEventListener('error', function(e) {
         setFitMode(mode) { storage.set('fitMode', mode); }
     };
 
+    const SEARCH_HANDOFF_PREFIX = 'parker.searchHandoff.';
+    const SEARCH_HANDOFF_MAX_QUERY_LENGTH = 1800;
+    const SEARCH_HANDOFF_TTL_MS = 1000 * 60 * 60 * 6;
+
+    const safeSessionStorage = {
+        get(key) {
+            try {
+                return window.sessionStorage.getItem(key);
+            } catch (e) {
+                console.error('Error reading from sessionStorage:', e);
+                return null;
+            }
+        },
+        set(key, value) {
+            try {
+                window.sessionStorage.setItem(key, value);
+                return true;
+            } catch (e) {
+                console.error('Error writing to sessionStorage:', e);
+                return false;
+            }
+        },
+        remove(key) {
+            try {
+                window.sessionStorage.removeItem(key);
+            } catch (e) {
+                console.error('Error removing from sessionStorage:', e);
+            }
+        },
+        keys() {
+            try {
+                return Object.keys(window.sessionStorage);
+            } catch (e) {
+                console.error('Error listing sessionStorage keys:', e);
+                return [];
+            }
+        }
+    };
+
+    const searchHandoff = {
+        maxQueryLength: SEARCH_HANDOFF_MAX_QUERY_LENGTH,
+
+        cleanup() {
+            const now = Date.now();
+            safeSessionStorage.keys()
+                .filter(key => key.startsWith(SEARCH_HANDOFF_PREFIX))
+                .forEach((key) => {
+                    try {
+                        const raw = safeSessionStorage.get(key);
+                        if (!raw) {
+                            safeSessionStorage.remove(key);
+                            return;
+                        }
+
+                        const payload = JSON.parse(raw);
+                        if (!payload.createdAt || (now - payload.createdAt) > SEARCH_HANDOFF_TTL_MS) {
+                            safeSessionStorage.remove(key);
+                        }
+                    } catch (e) {
+                        safeSessionStorage.remove(key);
+                    }
+                });
+        },
+
+        buildUrl(payload = {}) {
+            const query = new URLSearchParams();
+
+            if (payload.match) query.set('match', payload.match);
+            if (payload.sortBy) query.set('sort_by', payload.sortBy);
+            if (payload.sortOrder) query.set('sort_order', payload.sortOrder);
+            if (payload.limit) query.set('limit', String(payload.limit));
+            if (payload.libraryId) query.set('library_id', String(payload.libraryId));
+            if (payload.filters && payload.filters.length > 0) {
+                query.set('filters', JSON.stringify(payload.filters));
+            }
+
+            const rawQuery = query.toString();
+            if (rawQuery.length <= this.maxQueryLength) {
+                return window.parker.route('pages.search', {}, rawQuery);
+            }
+
+            this.cleanup();
+
+            const key = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+            const stored = safeSessionStorage.set(
+                `${SEARCH_HANDOFF_PREFIX}${key}`,
+                JSON.stringify({
+                    createdAt: Date.now(),
+                    payload
+                })
+            );
+
+            if (!stored) {
+                return window.parker.route('pages.search', {}, rawQuery);
+            }
+
+            return window.parker.route('pages.search', {}, `state_key=${encodeURIComponent(key)}`);
+        },
+
+        load(key) {
+            if (!key) return null;
+
+            this.cleanup();
+
+            const raw = safeSessionStorage.get(`${SEARCH_HANDOFF_PREFIX}${key}`);
+            if (!raw) return null;
+
+            try {
+                const parsed = JSON.parse(raw);
+                return parsed.payload || null;
+            } catch (e) {
+                safeSessionStorage.remove(`${SEARCH_HANDOFF_PREFIX}${key}`);
+                return null;
+            }
+        }
+    };
+
 
     // Export utilities
     window.parker = { ...(window.parker || {}),
@@ -508,7 +625,8 @@ document.addEventListener('error', function(e) {
         formatDate,
         paginationMixin,
         storage,
-        prefs
+        prefs,
+        searchHandoff
     };
 
 })();

--- a/tests/api/test_insights.py
+++ b/tests/api/test_insights.py
@@ -1,0 +1,315 @@
+from app.models.comic import Comic, Volume
+from app.models.credits import ComicCredit, Person
+from app.models.library import Library
+from app.models.series import Series
+
+
+def _seed_creator_collab_fixture(db, normal_user):
+    visible_lib = Library(name="Insights Visible", path="/tmp/insights-visible")
+    hidden_lib = Library(name="Insights Hidden", path="/tmp/insights-hidden")
+    db.add_all([visible_lib, hidden_lib])
+    db.flush()
+
+    safe_series = Series(name="Insights Safe Series", library_id=visible_lib.id)
+    banned_series = Series(name="Insights Banned Series", library_id=visible_lib.id)
+    hidden_series = Series(name="Insights Hidden Series", library_id=hidden_lib.id)
+    db.add_all([safe_series, banned_series, hidden_series])
+    db.flush()
+
+    safe_volume = Volume(series_id=safe_series.id, volume_number=1)
+    banned_volume = Volume(series_id=banned_series.id, volume_number=1)
+    hidden_volume = Volume(series_id=hidden_series.id, volume_number=1)
+    db.add_all([safe_volume, banned_volume, hidden_volume])
+    db.flush()
+
+    safe_comics = [
+        Comic(
+            volume_id=safe_volume.id,
+            number="1",
+            title="Safe #1",
+            age_rating="Teen",
+            filename="safe-1.cbz",
+            file_path="/tmp/safe-1.cbz",
+        ),
+        Comic(
+            volume_id=safe_volume.id,
+            number="2",
+            title="Safe #2",
+            age_rating="Teen",
+            filename="safe-2.cbz",
+            file_path="/tmp/safe-2.cbz",
+        ),
+        Comic(
+            volume_id=safe_volume.id,
+            number="3",
+            title="Safe #3",
+            age_rating="Teen",
+            filename="safe-3.cbz",
+            file_path="/tmp/safe-3.cbz",
+        ),
+    ]
+    banned_comics = [
+        Comic(
+            volume_id=banned_volume.id,
+            number="1",
+            title="Banned #1",
+            age_rating="Mature 17+",
+            filename="banned-1.cbz",
+            file_path="/tmp/banned-1.cbz",
+        ),
+        Comic(
+            volume_id=banned_volume.id,
+            number="2",
+            title="Banned #2",
+            age_rating="Mature 17+",
+            filename="banned-2.cbz",
+            file_path="/tmp/banned-2.cbz",
+        ),
+    ]
+    hidden_comics = [
+        Comic(
+            volume_id=hidden_volume.id,
+            number="1",
+            title="Hidden #1",
+            age_rating="Teen",
+            filename="hidden-1.cbz",
+            file_path="/tmp/hidden-1.cbz",
+        ),
+        Comic(
+            volume_id=hidden_volume.id,
+            number="2",
+            title="Hidden #2",
+            age_rating="Teen",
+            filename="hidden-2.cbz",
+            file_path="/tmp/hidden-2.cbz",
+        ),
+    ]
+    db.add_all(safe_comics + banned_comics + hidden_comics)
+    db.flush()
+
+    writer_a = Person(name="Insight Writer A")
+    writer_b = Person(name="Insight Writer B")
+    artist_x = Person(name="Insight Artist X")
+    artist_y = Person(name="Insight Artist Y")
+    artist_z = Person(name="Insight Artist Z")
+    artist_hidden = Person(name="Insight Hidden Artist")
+    db.add_all([writer_a, writer_b, artist_x, artist_y, artist_z, artist_hidden])
+    db.flush()
+
+    db.add_all([
+        ComicCredit(comic_id=safe_comics[0].id, person_id=writer_a.id, role="writer"),
+        ComicCredit(comic_id=safe_comics[1].id, person_id=writer_a.id, role="writer"),
+        ComicCredit(comic_id=safe_comics[2].id, person_id=writer_b.id, role="writer"),
+        ComicCredit(comic_id=safe_comics[0].id, person_id=artist_x.id, role="penciller"),
+        ComicCredit(comic_id=safe_comics[1].id, person_id=artist_x.id, role="penciller"),
+        ComicCredit(comic_id=safe_comics[2].id, person_id=artist_y.id, role="penciller"),
+
+        ComicCredit(comic_id=banned_comics[0].id, person_id=writer_a.id, role="writer"),
+        ComicCredit(comic_id=banned_comics[1].id, person_id=writer_a.id, role="writer"),
+        ComicCredit(comic_id=banned_comics[0].id, person_id=artist_z.id, role="penciller"),
+        ComicCredit(comic_id=banned_comics[1].id, person_id=artist_z.id, role="penciller"),
+
+        ComicCredit(comic_id=hidden_comics[0].id, person_id=writer_a.id, role="writer"),
+        ComicCredit(comic_id=hidden_comics[1].id, person_id=writer_a.id, role="writer"),
+        ComicCredit(comic_id=hidden_comics[0].id, person_id=artist_hidden.id, role="penciller"),
+        ComicCredit(comic_id=hidden_comics[1].id, person_id=artist_hidden.id, role="penciller"),
+    ])
+
+    normal_user.accessible_libraries.append(visible_lib)
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    return {
+        "visible_lib": visible_lib,
+        "hidden_lib": hidden_lib,
+    }
+
+
+def test_creator_collaborations_respect_rls_and_age_filters(auth_client, db, normal_user):
+    _seed_creator_collab_fixture(db, normal_user)
+
+    response = auth_client.get("/api/insights/creator-collaborations")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["pair_count"] == 1
+    assert payload["max_shared_issues"] == 2
+    assert len(payload["rows"]) == 1
+    assert payload["rows"][0]["name"] == "Insight Writer A"
+    assert payload["rows"][0]["total_shared"] == 2
+    assert payload["rows"][0]["id"] > 0
+    assert len(payload["columns"]) == 1
+    assert payload["columns"][0]["name"] == "Insight Artist X"
+    assert payload["columns"][0]["total_shared"] == 2
+    assert payload["columns"][0]["id"] > 0
+    assert payload["top_collaborations"][0]["person_a"] == "Insight Writer A"
+    assert payload["top_collaborations"][0]["person_b"] == "Insight Artist X"
+    assert payload["top_collaborations"][0]["shared_issues"] == 2
+
+
+def test_creator_collaborations_library_filter_blocks_unauthorized_library(auth_client, db, normal_user):
+    data = _seed_creator_collab_fixture(db, normal_user)
+
+    response = auth_client.get(f"/api/insights/creator-collaborations?library_id={data['hidden_lib'].id}")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Library not found"
+
+
+def test_creator_collaborations_superuser_sees_all_matching_pairs(admin_client, db, normal_user):
+    data = _seed_creator_collab_fixture(db, normal_user)
+
+    response = admin_client.get(
+        f"/api/insights/creator-collaborations?library_id={data['hidden_lib'].id}&min_shared=2"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["pair_count"] == 1
+    assert payload["pairs"][0]["person_a"] == "Insight Writer A"
+    assert payload["pairs"][0]["person_b"] == "Insight Hidden Artist"
+    assert payload["pairs"][0]["shared_issues"] == 2
+
+
+def test_creator_collaborations_include_lower_threshold_pairs(auth_client, db, normal_user):
+    _seed_creator_collab_fixture(db, normal_user)
+
+    response = auth_client.get("/api/insights/creator-collaborations?min_shared=1")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["pair_count"] == 2
+    names = {(pair["person_a"], pair["person_b"], pair["shared_issues"]) for pair in payload["pairs"]}
+    assert ("Insight Writer A", "Insight Artist X", 2) in names
+    assert ("Insight Writer B", "Insight Artist Y", 1) in names
+
+
+def test_creator_collaborations_reject_limit_over_guardrail(auth_client, db, normal_user):
+    _seed_creator_collab_fixture(db, normal_user)
+
+    response = auth_client.get("/api/insights/creator-collaborations?limit=16")
+
+    assert response.status_code == 422
+
+
+def test_creator_collaborations_include_identity_fields_for_matrix_alignment(auth_client, db, normal_user):
+    _seed_creator_collab_fixture(db, normal_user)
+
+    response = auth_client.get("/api/insights/creator-collaborations")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    row = payload["rows"][0]
+    column = payload["columns"][0]
+    pair = payload["pairs"][0]
+
+    assert row["id"] > 0
+    assert column["id"] > 0
+    assert pair["person_a_id"] == row["id"]
+    assert pair["person_b_id"] == column["id"]
+
+
+def test_creator_collaboration_header_totals_match_visible_matrix(auth_client, db, normal_user):
+    visible_lib = Library(name="Visible Matrix Totals", path="/tmp/visible-matrix-totals")
+    db.add(visible_lib)
+    db.flush()
+
+    series = Series(name="Visible Matrix Totals Series", library_id=visible_lib.id)
+    db.add(series)
+    db.flush()
+
+    volume = Volume(series_id=series.id, volume_number=1)
+    db.add(volume)
+    db.flush()
+
+    comics = [
+        Comic(
+            volume_id=volume.id,
+            number="1",
+            title="Visible #1",
+            age_rating="Teen",
+            filename="visible-1.cbz",
+            file_path="/tmp/visible-1.cbz",
+        ),
+        Comic(
+            volume_id=volume.id,
+            number="2",
+            title="Visible #2",
+            age_rating="Teen",
+            filename="visible-2.cbz",
+            file_path="/tmp/visible-2.cbz",
+        ),
+        Comic(
+            volume_id=volume.id,
+            number="3",
+            title="Visible #3",
+            age_rating="Teen",
+            filename="visible-3.cbz",
+            file_path="/tmp/visible-3.cbz",
+        ),
+        Comic(
+            volume_id=volume.id,
+            number="4",
+            title="Visible #4",
+            age_rating="Teen",
+            filename="visible-4.cbz",
+            file_path="/tmp/visible-4.cbz",
+        ),
+        Comic(
+            volume_id=volume.id,
+            number="5",
+            title="Visible #5",
+            age_rating="Teen",
+            filename="visible-5.cbz",
+            file_path="/tmp/visible-5.cbz",
+        ),
+    ]
+    db.add_all(comics)
+    db.flush()
+
+    writer_a = Person(name="Visible Writer A")
+    writer_b = Person(name="Visible Writer B")
+    writer_c = Person(name="Visible Writer C")
+    artist_x = Person(name="Visible Artist X")
+    artist_y = Person(name="Visible Artist Y")
+    db.add_all([writer_a, writer_b, writer_c, artist_x, artist_y])
+    db.flush()
+
+    db.add_all([
+        ComicCredit(comic_id=comics[0].id, person_id=writer_a.id, role="writer"),
+        ComicCredit(comic_id=comics[1].id, person_id=writer_a.id, role="writer"),
+        ComicCredit(comic_id=comics[2].id, person_id=writer_b.id, role="writer"),
+        ComicCredit(comic_id=comics[3].id, person_id=writer_b.id, role="writer"),
+        ComicCredit(comic_id=comics[4].id, person_id=writer_c.id, role="writer"),
+        ComicCredit(comic_id=comics[0].id, person_id=artist_x.id, role="penciller"),
+        ComicCredit(comic_id=comics[1].id, person_id=artist_x.id, role="penciller"),
+        ComicCredit(comic_id=comics[2].id, person_id=artist_y.id, role="penciller"),
+        ComicCredit(comic_id=comics[3].id, person_id=artist_y.id, role="penciller"),
+        ComicCredit(comic_id=comics[4].id, person_id=artist_x.id, role="penciller"),
+    ])
+
+    normal_user.accessible_libraries.append(visible_lib)
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    response = auth_client.get("/api/insights/creator-collaborations?min_shared=1&limit=2")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert [row["name"] for row in payload["rows"]] == ["Visible Writer A", "Visible Writer B"]
+    assert [column["name"] for column in payload["columns"]] == ["Visible Artist X", "Visible Artist Y"]
+    assert {(pair["person_a"], pair["person_b"], pair["shared_issues"]) for pair in payload["pairs"]} == {
+        ("Visible Writer A", "Visible Artist X", 2),
+        ("Visible Writer B", "Visible Artist Y", 2),
+    }
+    assert payload["rows"][0]["total_shared"] == 2
+    assert payload["rows"][1]["total_shared"] == 2
+    assert payload["columns"][0]["total_shared"] == 2
+    assert payload["columns"][1]["total_shared"] == 2


### PR DESCRIPTION
This PR introduces the first Insights experience in Parker: Creator Chemistry.

The new page (/insights) visualizes creator collaboration metadata as a matrix so users can quickly spot strong writer/artist pairings and then jump straight into Advanced Search to inspect the matching books. This is meant to be a Phase 1 foundation for future insight pages, not the final word on insights overall.

What’s included
- Adds a new Insights page and navigation entry
- Adds a new Creator Chemistry view for creator-to-creator collaboration analysis
- Adds a new insights API endpoint for creator collaboration aggregation
- Supports filtering by role pair, library, minimum shared issues, and creator limit
- Adds drill-down from insight cells/cards into Advanced Search with hydrated multi-rule filters
- Adds guardrails on matrix size to keep the page usable
- Improves tablet usability and matrix scrolling behavior
- Adds sticky left column and sticky top header within the matrix viewport
- Truncates long sample series titles in matrix cells while preserving full hover titles

Implementation notes
- Creator pair identity now uses creator IDs instead of just display names, which keeps the matrix and sidebar collaboration list aligned
- “Visible total” values are calculated from the filtered, on-screen matrix pairs rather than broader pre-filter rankings
- Advanced Search was extended to support hydrated multi-filter state from insight drill-downs, allowing insight cells/cards to open prebuilt multi-rule searches reliably
- Search handoff was hardened to avoid overly long query-string payloads by using the shared search handoff state flow

Testing
- Added API tests for:role/library/age-filter behavior
- superuser access behavior
- lower threshold pair inclusion
- limit guardrails
- matrix identity alignment
- visible total correctness

