### PR TITLE
Adds the third Parker insights experience

### DIFF
--- a/app/api/insights.py
+++ b/app/api/insights.py
@@ -290,3 +290,84 @@ async def get_character_collaborations(
         "limit": limit,
         **_serialize_visible_matrix(pairs, limit),
     }
+
+
+@router.get("/creator-character-collaborations", name="creator_character_collaborations")
+async def get_creator_character_collaborations(
+    db: SessionDep,
+    current_user: CurrentUser,
+    role_a: CreatorRole = Query("writer"),
+    library_id: Optional[int] = Query(None, ge=1),
+    min_shared: int = Query(2, ge=1, le=100),
+    limit: int = Query(12, ge=2, le=15, description="Maximum creators and characters shown per axis"),
+):
+    """
+    Aggregates creator-to-character pairings for heatmap-style insights.
+    """
+    if library_id is not None:
+        _ensure_library_access(library_id, current_user)
+
+    credit_a = aliased(ComicCredit)
+    person_a = aliased(Person)
+    char_link_b = comic_characters.alias("char_link_b")
+    character_b = aliased(Character)
+
+    shared_issue_count = func.count(func.distinct(Comic.id))
+    shared_series_count = func.count(func.distinct(Series.id))
+
+    query = (
+        db.query(
+            person_a.id.label("person_a_id"),
+            person_a.name.label("person_a"),
+            character_b.id.label("person_b_id"),
+            character_b.name.label("person_b"),
+            shared_issue_count.label("shared_issues"),
+            shared_series_count.label("shared_series"),
+            func.min(Series.name).label("sample_series"),
+        )
+        .select_from(Comic)
+        .join(Volume, Comic.volume_id == Volume.id)
+        .join(Series, Volume.series_id == Series.id)
+        .join(credit_a, credit_a.comic_id == Comic.id)
+        .join(person_a, person_a.id == credit_a.person_id)
+        .join(char_link_b, char_link_b.c.comic_id == Comic.id)
+        .join(character_b, character_b.id == char_link_b.c.character_id)
+        .filter(credit_a.role == role_a)
+    )
+
+    if not current_user.is_superuser:
+        allowed_ids = [lib.id for lib in current_user.accessible_libraries]
+        query = query.filter(Series.library_id.in_(allowed_ids))
+
+    if library_id is not None:
+        query = query.filter(Series.library_id == library_id)
+
+    age_filter = get_series_age_restriction(current_user)
+    if age_filter is not None:
+        query = query.filter(age_filter)
+
+    pair_cap = max(limit * limit * 2, 50)
+
+    pairs = (
+        query.group_by(person_a.id, person_a.name, character_b.id, character_b.name)
+        .having(shared_issue_count >= min_shared)
+        .order_by(desc("shared_issues"), person_a.name.asc(), character_b.name.asc())
+        .limit(pair_cap)
+        .all()
+    )
+
+    if not pairs:
+        return _empty_matrix_payload(
+            role_a=role_a,
+            library_id=library_id,
+            min_shared=min_shared,
+            limit=limit,
+        )
+
+    return {
+        "role_a": role_a,
+        "library_id": library_id,
+        "min_shared": min_shared,
+        "limit": limit,
+        **_serialize_visible_matrix(pairs, limit),
+    }

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -48,6 +48,12 @@ async def insights_character_chemistry(request: Request, user: CurrentUser):
     """Character co-appearance insights page"""
     return templates.TemplateResponse(request=request, name="insights_character.html")
 
+
+@router.get("/insights/writer-character", response_class=HTMLResponse, name="insights_writer_character")
+async def insights_writer_character(request: Request, user: CurrentUser):
+    """Writer to character insights page"""
+    return templates.TemplateResponse(request=request, name="insights_writer_character.html")
+
 @router.get("/collections", response_class=HTMLResponse, name="collections")
 async def collections_view(request: Request, user: CurrentUser):
     """Collections page"""

--- a/app/templates/insights.html
+++ b/app/templates/insights.html
@@ -14,56 +14,40 @@
         </div>
     </section>
 
-    <section class="grid grid-cols-1 xl:grid-cols-2 gap-6">
+    <section class="grid grid-cols-1 xl:grid-cols-3 gap-6">
         <a href="{{ url('/insights/creator-chemistry') }}" class="group rounded-3xl border border-gray-700 bg-gray-800/80 hover:border-blue-500/60 hover:bg-gray-800 px-6 py-6 shadow-xl transition-all">
-            <div class="flex items-start justify-between gap-4">
-                <div>
-                    <div class="text-[10px] uppercase tracking-[0.25em] text-blue-300">Phase 1</div>
-                    <h2 class="mt-3 text-2xl font-black text-white">Creator Chemistry</h2>
-                    <p class="mt-3 text-sm leading-6 text-gray-400">
-                        See which writers, pencillers, inkers, colorists, and editors show up together most often across your library.
-                    </p>
-                </div>
-                <div class="rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-xs font-bold uppercase tracking-wider text-blue-200">
-                    Live
-                </div>
-            </div>
-
-            <div class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-3 text-xs text-gray-400">
-                <div class="rounded-xl border border-gray-700 bg-gray-900/50 px-4 py-3">Creator role pair filters</div>
-                <div class="rounded-xl border border-gray-700 bg-gray-900/50 px-4 py-3">Matrix drill-down to Search</div>
-                <div class="rounded-xl border border-gray-700 bg-gray-900/50 px-4 py-3">Visible collaboration totals</div>
-            </div>
+            <h2 class="text-2xl font-black text-white">Creator Chemistry</h2>
+            <p class="mt-3 text-sm leading-6 text-gray-400">
+                See which writers, pencillers, inkers, colorists, and editors show up together most often across your library.
+            </p>
 
             <div class="mt-6 inline-flex items-center gap-2 text-sm font-bold text-blue-300 group-hover:text-blue-200">
                 Open Creator Chemistry
-                <span aria-hidden="true">→</span>
+                <span aria-hidden="true">&rarr;</span>
             </div>
         </a>
 
         <a href="{{ url('/insights/character-chemistry') }}" class="group rounded-3xl border border-gray-700 bg-gray-800/80 hover:border-emerald-500/60 hover:bg-gray-800 px-6 py-6 shadow-xl transition-all">
-            <div class="flex items-start justify-between gap-4">
-                <div>
-                    <div class="text-[10px] uppercase tracking-[0.25em] text-emerald-300">Phase 2</div>
-                    <h2 class="mt-3 text-2xl font-black text-white">Character Chemistry</h2>
-                    <p class="mt-3 text-sm leading-6 text-gray-400">
-                        Explore which characters co-appear most often, surface recurring team-ups, and jump into the matching issues in one click.
-                    </p>
-                </div>
-                <div class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-bold uppercase tracking-wider text-emerald-200">
-                    New
-                </div>
-            </div>
-
-            <div class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-3 text-xs text-gray-400">
-                <div class="rounded-xl border border-gray-700 bg-gray-900/50 px-4 py-3">Character co-appearance matrix</div>
-                <div class="rounded-xl border border-gray-700 bg-gray-900/50 px-4 py-3">Top team-up sidebar</div>
-                <div class="rounded-xl border border-gray-700 bg-gray-900/50 px-4 py-3">Search handoff with dual character rules</div>
-            </div>
+            <h2 class="text-2xl font-black text-white">Character Chemistry</h2>
+            <p class="mt-3 text-sm leading-6 text-gray-400">
+                Explore which characters co-appear most often, surface recurring team-ups, and jump into the matching issues in one click.
+            </p>
 
             <div class="mt-6 inline-flex items-center gap-2 text-sm font-bold text-emerald-300 group-hover:text-emerald-200">
                 Open Character Chemistry
-                <span aria-hidden="true">→</span>
+                <span aria-hidden="true">&rarr;</span>
+            </div>
+        </a>
+
+        <a href="{{ url('/insights/writer-character') }}" class="group rounded-3xl border border-gray-700 bg-gray-800/80 hover:border-amber-500/60 hover:bg-gray-800 px-6 py-6 shadow-xl transition-all">
+            <h2 class="text-2xl font-black text-white">Writer to Character</h2>
+            <p class="mt-3 text-sm leading-6 text-gray-400">
+                See which writers are most closely associated with which characters, then jump straight into the matching books.
+            </p>
+
+            <div class="mt-6 inline-flex items-center gap-2 text-sm font-bold text-amber-300 group-hover:text-amber-200">
+                Open Writer to Character
+                <span aria-hidden="true">&rarr;</span>
             </div>
         </a>
     </section>

--- a/app/templates/insights_creator.html
+++ b/app/templates/insights_creator.html
@@ -22,6 +22,9 @@
                 <a href="{{ url('/insights/character-chemistry') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-emerald-500/50 transition-colors">
                     Character Chemistry
                 </a>
+                <a href="{{ url('/insights/writer-character') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-amber-500/50 transition-colors">
+                    Writer to Character
+                </a>
             </div>
         </div>
 

--- a/app/templates/insights_writer_character.html
+++ b/app/templates/insights_writer_character.html
@@ -1,41 +1,41 @@
 {% extends "base.html" %}
 
-{% block title %}Character Chemistry - Parker{% endblock %}
+{% block title %}Writer to Character - Parker{% endblock %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto space-y-8" x-data="characterChemistry()">
+<div class="max-w-7xl mx-auto space-y-8" x-data="writerCharacterInsights()">
     <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
         <div class="max-w-3xl">
             <div class="flex flex-wrap items-center gap-3 text-xs font-bold uppercase tracking-[0.25em]">
                 <a href="{{ url('/insights') }}" class="text-gray-500 hover:text-white transition-colors">Insights</a>
                 <span class="text-gray-700">/</span>
-                <span class="text-emerald-300">Character Chemistry</span>
+                <span class="text-amber-300">Writer to Character</span>
             </div>
-            <h1 class="mt-3 text-4xl font-black text-white tracking-tight">Character Chemistry</h1>
+            <h1 class="mt-3 text-4xl font-black text-white tracking-tight">Writer to Character</h1>
             <p class="mt-3 text-gray-400 text-sm md:text-base">
-                Explore which characters co-appear most often in your library. Click any highlighted cell to jump straight into Advanced Search with both character filters applied.
+                Explore which writers are most associated with which characters in your library. Click any highlighted cell to jump straight into Advanced Search with both writer and character filters applied.
             </p>
             <div class="mt-4 flex flex-wrap gap-2">
                 <a href="{{ url('/insights/creator-chemistry') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-blue-500/50 transition-colors">
                     Creator Chemistry
                 </a>
-                <span class="px-3 py-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/10 text-xs font-bold uppercase tracking-wider text-emerald-200">
+                <a href="{{ url('/insights/character-chemistry') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-emerald-500/50 transition-colors">
                     Character Chemistry
-                </span>
-                <a href="{{ url('/insights/writer-character') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-amber-500/50 transition-colors">
-                    Writer to Character
                 </a>
+                <span class="px-3 py-1.5 rounded-full border border-amber-500/40 bg-amber-500/10 text-xs font-bold uppercase tracking-wider text-amber-200">
+                    Writer to Character
+                </span>
             </div>
         </div>
 
         <div class="grid grid-cols-2 md:grid-cols-3 gap-3 lg:w-auto">
             <div class="bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 shadow-lg">
-                <div class="text-[10px] uppercase tracking-wider text-gray-500">Visible Team-Ups</div>
+                <div class="text-[10px] uppercase tracking-wider text-gray-500">Visible Pairings</div>
                 <div class="mt-1 text-2xl font-bold text-white" x-text="data?.pair_count || 0"></div>
             </div>
             <div class="bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 shadow-lg">
                 <div class="text-[10px] uppercase tracking-wider text-gray-500">Strongest Pairing</div>
-                <div class="mt-1 text-sm font-bold text-emerald-300 truncate" :title="topPairLabel()" x-text="topPairLabel()"></div>
+                <div class="mt-1 text-sm font-bold text-amber-300 truncate" :title="topPairLabel()" x-text="topPairLabel()"></div>
             </div>
             <div class="bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 shadow-lg col-span-2 md:col-span-1">
                 <div class="text-[10px] uppercase tracking-wider text-gray-500">Peak Shared Issues</div>
@@ -63,7 +63,7 @@
                 </div>
 
                 <div>
-                    <label class="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">Top Characters Per Axis</label>
+                    <label class="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">Top Writers and Characters</label>
                     <input
                         type="number"
                         min="2"
@@ -78,7 +78,7 @@
                 <div class="flex items-end">
                     <button
                         x-on:click="loadInsights()"
-                        class="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-bold px-4 py-2.5 rounded-lg transition-colors flex items-center justify-center"
+                        class="w-full bg-amber-600 hover:bg-amber-500 text-white font-bold px-4 py-2.5 rounded-lg transition-colors flex items-center justify-center"
                     >
                         <span x-show="loading">Working</span>
                         <span x-show="!loading">Refresh</span>
@@ -87,7 +87,7 @@
             </div>
 
             <p x-show="showDensityWarning()" x-cloak class="mt-4 text-[11px] leading-5 text-amber-300">
-                Larger axes get dense fast. Parker will cap this view at 15 characters per side.
+                Larger axes get dense fast. Parker will cap this view at 15 writers and 15 characters.
             </p>
             <p class="mt-4 text-xs text-gray-500">
                 Stronger cells mean more shared issues. Empty cells do not have enough overlap for the current threshold.
@@ -96,8 +96,8 @@
 
         <div x-show="loading" class="px-6 py-16 text-center text-gray-400">
             <div class="inline-flex items-center gap-3">
-                <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-emerald-400"></div>
-                <span>Mapping character team-ups...</span>
+                <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-amber-400"></div>
+                <span>Mapping writer to character relationships...</span>
             </div>
         </div>
 
@@ -107,7 +107,7 @@
 
         <div x-show="!loading && !errorMessage && data && data.pair_count === 0" x-cloak class="px-6 py-20 text-center">
             <div class="max-w-xl mx-auto">
-                <h2 class="text-2xl font-bold text-white">No character pairs matched this view</h2>
+                <h2 class="text-2xl font-bold text-white">No writer and character pairs matched this view</h2>
                 <p class="mt-3 text-gray-400">
                     Try lowering the shared-issue threshold or broadening the library scope.
                 </p>
@@ -120,23 +120,23 @@
                     <div class="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-center md:justify-between">
                         <div class="text-sm text-gray-300">
                             <span class="font-bold text-white">Rows:</span>
-                            <span>Character</span>
+                            <span>Writer</span>
                             <span class="mx-2 text-gray-600">&middot;</span>
                             <span class="font-bold text-white">Columns:</span>
                             <span>Character</span>
                         </div>
-                        <div class="text-sm text-emerald-300">
+                        <div class="text-sm text-amber-300">
                             Tap a center cell to open the matching books.
                         </div>
                     </div>
                     <div class="mt-2 text-xs text-gray-500">
-                        Header cards show visible totals for each character in this matrix. Only the center intersection cells are drill-down links.
+                        Header cards show visible totals for each writer or character in this matrix. Only the center intersection cells are drill-down links.
                     </div>
                 </div>
 
                 <div class="flex items-center justify-between gap-3 mb-3 xl:hidden">
                     <div class="text-xs uppercase tracking-[0.2em] text-gray-500">Heatmap</div>
-                    <div class="text-[11px] text-emerald-300 bg-emerald-950/40 border border-emerald-900/60 rounded-full px-3 py-1">
+                    <div class="text-[11px] text-amber-300 bg-amber-950/40 border border-amber-900/60 rounded-full px-3 py-1">
                         Swipe sideways to explore
                     </div>
                 </div>
@@ -147,7 +147,7 @@
                             <tr>
                                 <th class="sticky top-0 left-0 z-30 w-[190px] min-w-[190px] align-top bg-gray-900/95 backdrop-blur py-3 px-3 rounded-lg border border-gray-700 shadow-lg text-left">
                                     <div class="text-[11px] uppercase tracking-wider text-gray-500">Rows</div>
-                                    <div class="mt-1 text-sm font-bold text-white">Character</div>
+                                    <div class="mt-1 text-sm font-bold text-white">Writer</div>
                                     <div class="mt-3 text-[11px] uppercase tracking-wider text-gray-500">Columns</div>
                                     <div class="mt-1 text-xs font-bold text-gray-300">Character</div>
                                 </th>
@@ -166,7 +166,7 @@
                             <template x-for="row in (matrixRows() || [])" :key="`row-${row.id}`">
                                 <tr>
                                     <th scope="row" class="sticky left-0 z-10 w-[190px] min-w-[190px] h-[176px] align-top bg-gray-800/95 backdrop-blur py-3 px-3 rounded-lg border border-gray-700 text-left">
-                                        <div class="text-[11px] uppercase tracking-wider text-gray-500">Character</div>
+                                        <div class="text-[11px] uppercase tracking-wider text-gray-500">Writer</div>
                                         <div class="mt-1 text-sm font-bold text-white leading-tight" x-text="row.name"></div>
                                         <div class="mt-1 text-[11px] text-gray-500" x-text="`${row.total_shared} visible total`"></div>
                                     </th>
@@ -205,7 +205,7 @@
 
             <aside class="border-t xl:border-t-0 xl:border-l border-gray-700 bg-gray-900/40 p-4 md:p-6">
                 <div class="flex items-center justify-between mb-4">
-                    <h2 class="text-lg font-bold text-white">Top Team-Ups</h2>
+                    <h2 class="text-lg font-bold text-white">Top Pairings</h2>
                     <span class="text-xs uppercase tracking-wider text-gray-500">click to drill down</span>
                 </div>
 
@@ -213,12 +213,12 @@
                     <template x-for="pair in (data?.top_collaborations || [])" :key="`${pair.person_a_id}-${pair.person_b_id}`">
                         <button
                             x-on:click="openSearch(pair)"
-                            class="w-full text-left rounded-xl border border-gray-700 bg-gray-800/80 hover:bg-gray-750 hover:border-emerald-500/50 p-4 transition-all shadow-lg"
+                            class="w-full text-left rounded-xl border border-gray-700 bg-gray-800/80 hover:bg-gray-750 hover:border-amber-500/50 p-4 transition-all shadow-lg"
                         >
                             <div class="flex items-start justify-between gap-3">
                                 <div>
                                     <div class="text-sm font-bold text-white" x-text="pair.person_a"></div>
-                                    <div class="text-xs text-emerald-300 mt-0.5" x-text="pair.person_b"></div>
+                                    <div class="text-xs text-amber-300 mt-0.5" x-text="pair.person_b"></div>
                                 </div>
                                 <div class="text-right">
                                     <div class="text-xl font-black text-white" x-text="pair.shared_issues"></div>
@@ -236,7 +236,7 @@
                 <div class="mt-6 md:mt-4 xl:mt-6 rounded-xl border border-gray-700 bg-gray-800/60 p-4 md:col-span-2 xl:col-span-1">
                     <h3 class="text-sm font-bold text-white">Why this view works</h3>
                     <p class="mt-2 text-xs leading-6 text-gray-400">
-                        Character metadata makes co-appearances easier to spot than a long search form. Insights helps you notice the pairing, then drill into the exact books.
+                        Writer and character metadata make long-run associations easier to spot than a search form alone. Insights helps you notice the connection, then drill into the exact books.
                     </p>
                 </div>
             </aside>
@@ -245,7 +245,7 @@
 </div>
 
 <script>
-function characterChemistry() {
+function writerCharacterInsights() {
     return {
         libraries: [],
         data: null,
@@ -296,6 +296,7 @@ function characterChemistry() {
             try {
                 const normalizedLimit = this.normalizeLimit();
                 const query = new URLSearchParams({
+                    role_a: 'writer',
                     min_shared: String(parseInt(this.minShared, 10) || 1),
                     limit: String(normalizedLimit),
                 });
@@ -304,7 +305,7 @@ function characterChemistry() {
                     query.set('library_id', this.selectedLibraryId);
                 }
 
-                const res = await fetch(window.parker.route('insights.character_collaborations', {}, query.toString()));
+                const res = await fetch(window.parker.route('insights.creator_character_collaborations', {}, query.toString()));
                 if (!res.ok) {
                     const payload = await res.json().catch(() => ({}));
                     throw new Error(payload.detail || 'Failed to load insights');
@@ -356,7 +357,7 @@ function characterChemistry() {
         cellStyle(cell) {
             const alpha = 0.18 + (cell.intensity * 0.62);
             const borderAlpha = 0.12 + (cell.intensity * 0.45);
-            return `background: linear-gradient(160deg, rgba(5, 150, 105, ${alpha}) 0%, rgba(30, 41, 59, 0.92) 100%); border-color: rgba(52, 211, 153, ${borderAlpha});`;
+            return `background: linear-gradient(160deg, rgba(217, 119, 6, ${alpha}) 0%, rgba(30, 41, 59, 0.92) 100%); border-color: rgba(251, 191, 36, ${borderAlpha});`;
         },
 
         buildSearchUrl(pair) {
@@ -364,7 +365,7 @@ function characterChemistry() {
                 match: 'all',
                 libraryId: this.selectedLibraryId || null,
                 filters: [
-                    { field: 'character', operator: 'contains', value: [pair.person_a] },
+                    { field: 'writer', operator: 'contains', value: [pair.person_a] },
                     { field: 'character', operator: 'contains', value: [pair.person_b] },
                 ]
             };

--- a/tests/api/test_insights.py
+++ b/tests/api/test_insights.py
@@ -237,6 +237,130 @@ def _seed_character_collab_fixture(db, normal_user):
     }
 
 
+def _seed_writer_character_fixture(db, normal_user):
+    visible_lib = Library(name="Writer Character Visible", path="/tmp/writer-character-visible")
+    hidden_lib = Library(name="Writer Character Hidden", path="/tmp/writer-character-hidden")
+    db.add_all([visible_lib, hidden_lib])
+    db.flush()
+
+    safe_series = Series(name="Writer Character Safe Series", library_id=visible_lib.id)
+    banned_series = Series(name="Writer Character Banned Series", library_id=visible_lib.id)
+    hidden_series = Series(name="Writer Character Hidden Series", library_id=hidden_lib.id)
+    db.add_all([safe_series, banned_series, hidden_series])
+    db.flush()
+
+    safe_volume = Volume(series_id=safe_series.id, volume_number=1)
+    banned_volume = Volume(series_id=banned_series.id, volume_number=1)
+    hidden_volume = Volume(series_id=hidden_series.id, volume_number=1)
+    db.add_all([safe_volume, banned_volume, hidden_volume])
+    db.flush()
+
+    safe_comics = [
+        Comic(
+            volume_id=safe_volume.id,
+            number="1",
+            title="Writer Character Safe #1",
+            age_rating="Teen",
+            filename="writer-character-safe-1.cbz",
+            file_path="/tmp/writer-character-safe-1.cbz",
+        ),
+        Comic(
+            volume_id=safe_volume.id,
+            number="2",
+            title="Writer Character Safe #2",
+            age_rating="Teen",
+            filename="writer-character-safe-2.cbz",
+            file_path="/tmp/writer-character-safe-2.cbz",
+        ),
+        Comic(
+            volume_id=safe_volume.id,
+            number="3",
+            title="Writer Character Safe #3",
+            age_rating="Teen",
+            filename="writer-character-safe-3.cbz",
+            file_path="/tmp/writer-character-safe-3.cbz",
+        ),
+    ]
+    banned_comics = [
+        Comic(
+            volume_id=banned_volume.id,
+            number="1",
+            title="Writer Character Banned #1",
+            age_rating="Mature 17+",
+            filename="writer-character-banned-1.cbz",
+            file_path="/tmp/writer-character-banned-1.cbz",
+        ),
+        Comic(
+            volume_id=banned_volume.id,
+            number="2",
+            title="Writer Character Banned #2",
+            age_rating="Mature 17+",
+            filename="writer-character-banned-2.cbz",
+            file_path="/tmp/writer-character-banned-2.cbz",
+        ),
+    ]
+    hidden_comics = [
+        Comic(
+            volume_id=hidden_volume.id,
+            number="1",
+            title="Writer Character Hidden #1",
+            age_rating="Teen",
+            filename="writer-character-hidden-1.cbz",
+            file_path="/tmp/writer-character-hidden-1.cbz",
+        ),
+        Comic(
+            volume_id=hidden_volume.id,
+            number="2",
+            title="Writer Character Hidden #2",
+            age_rating="Teen",
+            filename="writer-character-hidden-2.cbz",
+            file_path="/tmp/writer-character-hidden-2.cbz",
+        ),
+    ]
+    db.add_all(safe_comics + banned_comics + hidden_comics)
+    db.flush()
+
+    writer_a = Person(name="Writer Character A")
+    writer_b = Person(name="Writer Character B")
+    hidden_writer = Person(name="Writer Hidden")
+    mature_writer = Person(name="Writer Mature")
+    hero_alpha = Character(name="Writer Hero Alpha")
+    hero_beta = Character(name="Writer Hero Beta")
+    hero_gamma = Character(name="Writer Hero Gamma")
+    hidden_ally = Character(name="Writer Hidden Ally")
+    mature_villain = Character(name="Writer Mature Villain")
+    db.add_all([writer_a, writer_b, hidden_writer, mature_writer, hero_alpha, hero_beta, hero_gamma, hidden_ally, mature_villain])
+    db.flush()
+
+    db.add_all([
+        ComicCredit(comic_id=safe_comics[0].id, person_id=writer_a.id, role="writer"),
+        ComicCredit(comic_id=safe_comics[1].id, person_id=writer_a.id, role="writer"),
+        ComicCredit(comic_id=safe_comics[2].id, person_id=writer_b.id, role="writer"),
+        ComicCredit(comic_id=banned_comics[0].id, person_id=mature_writer.id, role="writer"),
+        ComicCredit(comic_id=banned_comics[1].id, person_id=mature_writer.id, role="writer"),
+        ComicCredit(comic_id=hidden_comics[0].id, person_id=hidden_writer.id, role="writer"),
+        ComicCredit(comic_id=hidden_comics[1].id, person_id=hidden_writer.id, role="writer"),
+    ])
+
+    safe_comics[0].characters.extend([hero_alpha, hero_beta])
+    safe_comics[1].characters.extend([hero_alpha, hero_beta])
+    safe_comics[2].characters.extend([hero_alpha, hero_gamma])
+    banned_comics[0].characters.extend([hero_alpha, mature_villain])
+    banned_comics[1].characters.extend([hero_alpha, mature_villain])
+    hidden_comics[0].characters.extend([hidden_ally, hero_alpha])
+    hidden_comics[1].characters.extend([hidden_ally, hero_alpha])
+
+    normal_user.accessible_libraries.append(visible_lib)
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    return {
+        "visible_lib": visible_lib,
+        "hidden_lib": hidden_lib,
+    }
+
+
 def test_creator_collaborations_respect_rls_and_age_filters(auth_client, db, normal_user):
     _seed_creator_collab_fixture(db, normal_user)
 
@@ -490,5 +614,79 @@ def test_character_collaborations_reject_limit_over_guardrail(auth_client, db, n
     _seed_character_collab_fixture(db, normal_user)
 
     response = auth_client.get("/api/insights/character-collaborations?limit=16")
+
+    assert response.status_code == 422
+
+
+def test_writer_character_collaborations_respect_rls_and_age_filters(auth_client, db, normal_user):
+    _seed_writer_character_fixture(db, normal_user)
+
+    response = auth_client.get("/api/insights/creator-character-collaborations?role_a=writer")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["pair_count"] == 2
+    assert payload["max_shared_issues"] == 2
+    assert len(payload["rows"]) == 1
+    assert len(payload["columns"]) == 2
+    assert payload["rows"][0]["name"] == "Writer Character A"
+    assert payload["rows"][0]["total_shared"] == 4
+    assert payload["columns"][0]["name"] == "Writer Hero Alpha"
+    assert payload["columns"][0]["total_shared"] == 2
+    assert payload["columns"][1]["name"] == "Writer Hero Beta"
+    assert payload["columns"][1]["total_shared"] == 2
+    assert payload["top_collaborations"][0]["person_a"] == "Writer Character A"
+    assert payload["top_collaborations"][0]["person_b"] == "Writer Hero Alpha"
+    assert payload["top_collaborations"][0]["shared_issues"] == 2
+
+
+def test_writer_character_collaborations_library_filter_blocks_unauthorized_library(auth_client, db, normal_user):
+    data = _seed_writer_character_fixture(db, normal_user)
+
+    response = auth_client.get(
+        f"/api/insights/creator-character-collaborations?role_a=writer&library_id={data['hidden_lib'].id}"
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Library not found"
+
+
+def test_writer_character_collaborations_superuser_sees_hidden_library(admin_client, db, normal_user):
+    data = _seed_writer_character_fixture(db, normal_user)
+
+    response = admin_client.get(
+        f"/api/insights/creator-character-collaborations?role_a=writer&library_id={data['hidden_lib'].id}&min_shared=2"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["pair_count"] == 2
+    names = {(pair["person_a"], pair["person_b"], pair["shared_issues"]) for pair in payload["pairs"]}
+    assert ("Writer Hidden", "Writer Hero Alpha", 2) in names
+    assert ("Writer Hidden", "Writer Hidden Ally", 2) in names
+
+
+def test_writer_character_collaborations_include_lower_threshold_pairs(auth_client, db, normal_user):
+    _seed_writer_character_fixture(db, normal_user)
+
+    response = auth_client.get("/api/insights/creator-character-collaborations?role_a=writer&min_shared=1")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["pair_count"] == 4
+    names = {(pair["person_a"], pair["person_b"], pair["shared_issues"]) for pair in payload["pairs"]}
+    assert ("Writer Character A", "Writer Hero Alpha", 2) in names
+    assert ("Writer Character A", "Writer Hero Beta", 2) in names
+    assert ("Writer Character B", "Writer Hero Alpha", 1) in names
+    assert ("Writer Character B", "Writer Hero Gamma", 1) in names
+
+
+def test_writer_character_collaborations_reject_limit_over_guardrail(auth_client, db, normal_user):
+    _seed_writer_character_fixture(db, normal_user)
+
+    response = auth_client.get("/api/insights/creator-character-collaborations?role_a=writer&limit=16")
 
     assert response.status_code == 422


### PR DESCRIPTION
Adds the third Parker insights experience, Writer to Character, so users can explore which characters each writer is most closely associated with and drill directly into the matching books. This also expands the insights hub so all available insight views are discoverable from one place.

What Changed
- Added a new insights API endpoint at /api/insights/creator-character-collaborations for creator-to-character heatmap data.
- Added a new /insights/writer-character page with:
   - writer vs. character matrix visualization
   - strongest pairing and visible pairing summary cards
   - drill-down into Advanced Search using hydrated multi-rule state
- Updated the insights hub to include the new page and simplified the hub cards by removing internal phase/status-style chrome.
- Added cross-links between all current insights pages.
- Added API coverage for visibility rules, age filtering, library access, threshold behavior, and guardrails.

Implementation Notes
- Reused the existing matrix serialization/presentation model introduced for earlier insight pages rather than introducing a new framework abstraction.
- Kept the search handoff aligned with the hardened multi-rule hydration flow, so writer+character drill-downs do not depend on oversized query strings.
- Writer-to-character results are modeled as full creator/character pairings, so one writer can surface across multiple character cells when the metadata supports it.

