### PR TITLE
Add fourth insight view

### DIFF
--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -54,6 +54,12 @@ async def insights_writer_character(request: Request, user: CurrentUser):
     """Writer to character insights page"""
     return templates.TemplateResponse(request=request, name="insights_writer_character.html")
 
+
+@router.get("/insights/artist-character", response_class=HTMLResponse, name="insights_artist_character")
+async def insights_artist_character(request: Request, user: CurrentUser):
+    """Artist to character insights page"""
+    return templates.TemplateResponse(request=request, name="insights_artist_character.html")
+
 @router.get("/collections", response_class=HTMLResponse, name="collections")
 async def collections_view(request: Request, user: CurrentUser):
     """Collections page"""

--- a/app/templates/insights.html
+++ b/app/templates/insights.html
@@ -14,7 +14,7 @@
         </div>
     </section>
 
-    <section class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+    <section class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <a href="{{ url('/insights/creator-chemistry') }}" class="group rounded-3xl border border-gray-700 bg-gray-800/80 hover:border-blue-500/60 hover:bg-gray-800 px-6 py-6 shadow-xl transition-all">
             <h2 class="text-2xl font-black text-white">Creator Chemistry</h2>
             <p class="mt-3 text-sm leading-6 text-gray-400">
@@ -47,6 +47,18 @@
 
             <div class="mt-6 inline-flex items-center gap-2 text-sm font-bold text-amber-300 group-hover:text-amber-200">
                 Open Writer to Character
+                <span aria-hidden="true">&rarr;</span>
+            </div>
+        </a>
+
+        <a href="{{ url('/insights/artist-character') }}" class="group rounded-3xl border border-gray-700 bg-gray-800/80 hover:border-rose-500/60 hover:bg-gray-800 px-6 py-6 shadow-xl transition-all">
+            <h2 class="text-2xl font-black text-white">Artist to Character</h2>
+            <p class="mt-3 text-sm leading-6 text-gray-400">
+                See which artists are most strongly associated with which characters, based on penciller credits in your library metadata.
+            </p>
+
+            <div class="mt-6 inline-flex items-center gap-2 text-sm font-bold text-rose-300 group-hover:text-rose-200">
+                Open Artist to Character
                 <span aria-hidden="true">&rarr;</span>
             </div>
         </a>

--- a/app/templates/insights_artist_character.html
+++ b/app/templates/insights_artist_character.html
@@ -1,22 +1,22 @@
 {% extends "base.html" %}
 
-{% block title %}Writer to Character - Parker{% endblock %}
+{% block title %}Artist to Character - Parker{% endblock %}
 
 {% block content %}
-<div class="max-w-7xl mx-auto space-y-8" x-data="writerCharacterInsights()">
+<div class="max-w-7xl mx-auto space-y-8" x-data="artistCharacterInsights()">
     <div class="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-6">
         <div class="max-w-3xl">
             <div class="flex flex-wrap items-center gap-3 text-xs font-bold uppercase tracking-[0.25em]">
                 <a href="{{ url('/insights') }}" class="text-gray-500 hover:text-white transition-colors">Insights</a>
                 <span class="text-gray-700">/</span>
-                <span class="text-amber-300">Writer to Character</span>
+                <span class="text-rose-300">Artist to Character</span>
             </div>
-            <h1 class="mt-3 text-4xl font-black text-white tracking-tight">Writer to Character</h1>
+            <h1 class="mt-3 text-4xl font-black text-white tracking-tight">Artist to Character</h1>
             <p class="mt-3 text-gray-400 text-sm md:text-base">
-                Explore which writers are most associated with which characters in your library. Click any highlighted cell to jump straight into Advanced Search with both writer and character filters applied.
+                Explore which artists are most associated with which characters in your library. Click any highlighted cell to jump straight into Advanced Search with both artist and character filters applied.
             </p>
             <p class="mt-2 text-xs text-gray-500">
-                Based on available writer credits and character tags in your library metadata.
+                Based on available penciller credits and character tags in your library metadata.
             </p>
             <div class="mt-4 overflow-x-auto pb-1">
                 <div class="inline-flex min-w-max gap-2 pr-1">
@@ -26,12 +26,12 @@
                     <a href="{{ url('/insights/character-chemistry') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-emerald-500/50 transition-colors whitespace-nowrap">
                         Character Chemistry
                     </a>
-                    <span class="px-3 py-1.5 rounded-full border border-amber-500/40 bg-amber-500/10 text-xs font-bold uppercase tracking-wider text-amber-200 whitespace-nowrap">
+                    <a href="{{ url('/insights/writer-character') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-amber-500/50 transition-colors whitespace-nowrap">
                         Writer to Character
-                    </span>
-                    <a href="{{ url('/insights/artist-character') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-rose-500/50 transition-colors whitespace-nowrap">
-                        Artist to Character
                     </a>
+                    <span class="px-3 py-1.5 rounded-full border border-rose-500/40 bg-rose-500/10 text-xs font-bold uppercase tracking-wider text-rose-200 whitespace-nowrap">
+                        Artist to Character
+                    </span>
                 </div>
             </div>
         </div>
@@ -43,7 +43,7 @@
             </div>
             <div class="bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 shadow-lg">
                 <div class="text-[10px] uppercase tracking-wider text-gray-500">Strongest Pairing</div>
-                <div class="mt-1 text-sm font-bold text-amber-300 truncate" :title="topPairLabel()" x-text="topPairLabel()"></div>
+                <div class="mt-1 text-sm font-bold text-rose-300 truncate" :title="topPairLabel()" x-text="topPairLabel()"></div>
             </div>
             <div class="bg-gray-800 border border-gray-700 rounded-xl px-4 py-3 shadow-lg col-span-2 md:col-span-1">
                 <div class="text-[10px] uppercase tracking-wider text-gray-500">Peak Shared Issues</div>
@@ -71,7 +71,7 @@
                 </div>
 
                 <div>
-                    <label class="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">Top Writers and Characters</label>
+                    <label class="block text-[10px] uppercase tracking-wider text-gray-500 mb-2">Top Artists and Characters</label>
                     <input
                         type="number"
                         min="2"
@@ -86,7 +86,7 @@
                 <div class="flex items-end">
                     <button
                         x-on:click="loadInsights()"
-                        class="w-full bg-amber-600 hover:bg-amber-500 text-white font-bold px-4 py-2.5 rounded-lg transition-colors flex items-center justify-center"
+                        class="w-full bg-rose-600 hover:bg-rose-500 text-white font-bold px-4 py-2.5 rounded-lg transition-colors flex items-center justify-center"
                     >
                         <span x-show="loading">Working</span>
                         <span x-show="!loading">Refresh</span>
@@ -95,7 +95,7 @@
             </div>
 
             <p x-show="showDensityWarning()" x-cloak class="mt-4 text-[11px] leading-5 text-amber-300">
-                Larger axes get dense fast. Parker will cap this view at 15 writers and 15 characters.
+                Larger axes get dense fast. Parker will cap this view at 15 artists and 15 characters.
             </p>
             <p class="mt-4 text-xs text-gray-500">
                 Stronger cells mean more shared issues. Empty cells do not have enough overlap for the current threshold.
@@ -104,8 +104,8 @@
 
         <div x-show="loading" class="px-6 py-16 text-center text-gray-400">
             <div class="inline-flex items-center gap-3">
-                <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-amber-400"></div>
-                <span>Mapping writer to character relationships...</span>
+                <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-rose-400"></div>
+                <span>Mapping artist to character relationships...</span>
             </div>
         </div>
 
@@ -115,7 +115,7 @@
 
         <div x-show="!loading && !errorMessage && data && data.pair_count === 0" x-cloak class="px-6 py-20 text-center">
             <div class="max-w-xl mx-auto">
-                <h2 class="text-2xl font-bold text-white">No writer and character pairs matched this view</h2>
+                <h2 class="text-2xl font-bold text-white">No artist and character pairs matched this view</h2>
                 <p class="mt-3 text-gray-400">
                     Try lowering the shared-issue threshold or broadening the library scope.
                 </p>
@@ -128,23 +128,23 @@
                     <div class="flex flex-col gap-2 md:flex-row md:flex-wrap md:items-center md:justify-between">
                         <div class="text-sm text-gray-300">
                             <span class="font-bold text-white">Rows:</span>
-                            <span>Writer</span>
+                            <span>Artist</span>
                             <span class="mx-2 text-gray-600">&middot;</span>
                             <span class="font-bold text-white">Columns:</span>
                             <span>Character</span>
                         </div>
-                        <div class="text-sm text-amber-300">
+                        <div class="text-sm text-rose-300">
                             Tap a center cell to open the matching books.
                         </div>
                     </div>
                     <div class="mt-2 text-xs text-gray-500">
-                        Header cards show visible totals for each writer or character in this matrix. Only the center intersection cells are drill-down links.
+                        Header cards show visible totals for each artist or character in this matrix. Only the center intersection cells are drill-down links.
                     </div>
                 </div>
 
                 <div class="flex items-center justify-between gap-3 mb-3 xl:hidden">
                     <div class="text-xs uppercase tracking-[0.2em] text-gray-500">Heatmap</div>
-                    <div class="text-[11px] text-amber-300 bg-amber-950/40 border border-amber-900/60 rounded-full px-3 py-1">
+                    <div class="text-[11px] text-rose-300 bg-rose-950/40 border border-rose-900/60 rounded-full px-3 py-1">
                         Swipe sideways to explore
                     </div>
                 </div>
@@ -155,7 +155,7 @@
                             <tr>
                                 <th class="sticky top-0 left-0 z-30 w-[190px] min-w-[190px] align-top bg-gray-900/95 backdrop-blur py-3 px-3 rounded-lg border border-gray-700 shadow-lg text-left">
                                     <div class="text-[11px] uppercase tracking-wider text-gray-500">Rows</div>
-                                    <div class="mt-1 text-sm font-bold text-white">Writer</div>
+                                    <div class="mt-1 text-sm font-bold text-white">Artist</div>
                                     <div class="mt-3 text-[11px] uppercase tracking-wider text-gray-500">Columns</div>
                                     <div class="mt-1 text-xs font-bold text-gray-300">Character</div>
                                 </th>
@@ -174,7 +174,7 @@
                             <template x-for="row in (matrixRows() || [])" :key="`row-${row.id}`">
                                 <tr>
                                     <th scope="row" class="sticky left-0 z-10 w-[190px] min-w-[190px] h-[176px] align-top bg-gray-800/95 backdrop-blur py-3 px-3 rounded-lg border border-gray-700 text-left">
-                                        <div class="text-[11px] uppercase tracking-wider text-gray-500">Writer</div>
+                                        <div class="text-[11px] uppercase tracking-wider text-gray-500">Artist</div>
                                         <div class="mt-1 text-sm font-bold text-white leading-tight" x-text="row.name"></div>
                                         <div class="mt-1 text-[11px] text-gray-500" x-text="`${row.total_shared} visible total`"></div>
                                     </th>
@@ -221,12 +221,12 @@
                     <template x-for="pair in (data?.top_collaborations || [])" :key="`${pair.person_a_id}-${pair.person_b_id}`">
                         <button
                             x-on:click="openSearch(pair)"
-                            class="w-full text-left rounded-xl border border-gray-700 bg-gray-800/80 hover:bg-gray-750 hover:border-amber-500/50 p-4 transition-all shadow-lg"
+                            class="w-full text-left rounded-xl border border-gray-700 bg-gray-800/80 hover:bg-gray-750 hover:border-rose-500/50 p-4 transition-all shadow-lg"
                         >
                             <div class="flex items-start justify-between gap-3">
                                 <div>
                                     <div class="text-sm font-bold text-white" x-text="pair.person_a"></div>
-                                    <div class="text-xs text-amber-300 mt-0.5" x-text="pair.person_b"></div>
+                                    <div class="text-xs text-rose-300 mt-0.5" x-text="pair.person_b"></div>
                                 </div>
                                 <div class="text-right">
                                     <div class="text-xl font-black text-white" x-text="pair.shared_issues"></div>
@@ -244,7 +244,7 @@
                 <div class="mt-6 md:mt-4 xl:mt-6 rounded-xl border border-gray-700 bg-gray-800/60 p-4 md:col-span-2 xl:col-span-1">
                     <h3 class="text-sm font-bold text-white">Why this view works</h3>
                     <p class="mt-2 text-xs leading-6 text-gray-400">
-                        Writer and character metadata make long-run associations easier to spot than a search form alone. Insights helps you notice the connection, then drill into the exact books.
+                        Artist and character metadata make visual stewardship patterns easier to spot than a search form alone. Insights helps you notice the connection, then drill into the exact books.
                     </p>
                 </div>
             </aside>
@@ -253,7 +253,7 @@
 </div>
 
 <script>
-function writerCharacterInsights() {
+function artistCharacterInsights() {
     return {
         libraries: [],
         data: null,
@@ -263,7 +263,7 @@ function writerCharacterInsights() {
         minShared: 2,
         limit: 12,
         pairMap: {},
-        storageKey: 'parker-insights-writer-character',
+        storageKey: 'parker-insights-artist-character',
 
         async init() {
             await this.loadLibraries();
@@ -288,7 +288,7 @@ function writerCharacterInsights() {
                 if (saved.minShared !== undefined && saved.minShared !== null) this.minShared = saved.minShared;
                 if (saved.limit !== undefined && saved.limit !== null) this.limit = saved.limit;
             } catch (error) {
-                console.error('Failed to restore writer character state', error);
+                console.error('Failed to restore artist character state', error);
             }
         },
 
@@ -300,7 +300,7 @@ function writerCharacterInsights() {
                     limit: this.limit,
                 }));
             } catch (error) {
-                console.error('Failed to persist writer character state', error);
+                console.error('Failed to persist artist character state', error);
             }
         },
 
@@ -339,7 +339,7 @@ function writerCharacterInsights() {
             try {
                 const normalizedLimit = this.normalizeLimit();
                 const query = new URLSearchParams({
-                    role_a: 'writer',
+                    role_a: 'penciller',
                     min_shared: String(parseInt(this.minShared, 10) || 1),
                     limit: String(normalizedLimit),
                 });
@@ -400,7 +400,7 @@ function writerCharacterInsights() {
         cellStyle(cell) {
             const alpha = 0.18 + (cell.intensity * 0.62);
             const borderAlpha = 0.12 + (cell.intensity * 0.45);
-            return `background: linear-gradient(160deg, rgba(217, 119, 6, ${alpha}) 0%, rgba(30, 41, 59, 0.92) 100%); border-color: rgba(251, 191, 36, ${borderAlpha});`;
+            return `background: linear-gradient(160deg, rgba(225, 29, 72, ${alpha}) 0%, rgba(30, 41, 59, 0.92) 100%); border-color: rgba(251, 113, 133, ${borderAlpha});`;
         },
 
         buildSearchUrl(pair) {
@@ -408,7 +408,7 @@ function writerCharacterInsights() {
                 match: 'all',
                 libraryId: this.selectedLibraryId || null,
                 filters: [
-                    { field: 'writer', operator: 'contains', value: [pair.person_a] },
+                    { field: 'penciller', operator: 'contains', value: [pair.person_a] },
                     { field: 'character', operator: 'contains', value: [pair.person_b] },
                 ]
             };

--- a/app/templates/insights_character.html
+++ b/app/templates/insights_character.html
@@ -15,16 +15,24 @@
             <p class="mt-3 text-gray-400 text-sm md:text-base">
                 Explore which characters co-appear most often in your library. Click any highlighted cell to jump straight into Advanced Search with both character filters applied.
             </p>
-            <div class="mt-4 flex flex-wrap gap-2">
-                <a href="{{ url('/insights/creator-chemistry') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-blue-500/50 transition-colors">
-                    Creator Chemistry
-                </a>
-                <span class="px-3 py-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/10 text-xs font-bold uppercase tracking-wider text-emerald-200">
-                    Character Chemistry
-                </span>
-                <a href="{{ url('/insights/writer-character') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-amber-500/50 transition-colors">
-                    Writer to Character
-                </a>
+            <p class="mt-2 text-xs text-gray-500">
+                Based on books with character tags in your library metadata.
+            </p>
+            <div class="mt-4 overflow-x-auto pb-1">
+                <div class="inline-flex min-w-max gap-2 pr-1">
+                    <a href="{{ url('/insights/creator-chemistry') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-blue-500/50 transition-colors whitespace-nowrap">
+                        Creator Chemistry
+                    </a>
+                    <span class="px-3 py-1.5 rounded-full border border-emerald-500/40 bg-emerald-500/10 text-xs font-bold uppercase tracking-wider text-emerald-200 whitespace-nowrap">
+                        Character Chemistry
+                    </span>
+                    <a href="{{ url('/insights/writer-character') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-amber-500/50 transition-colors whitespace-nowrap">
+                        Writer to Character
+                    </a>
+                    <a href="{{ url('/insights/artist-character') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-rose-500/50 transition-colors whitespace-nowrap">
+                        Artist to Character
+                    </a>
+                </div>
             </div>
         </div>
 
@@ -255,10 +263,45 @@ function characterChemistry() {
         minShared: 2,
         limit: 12,
         pairMap: {},
+        storageKey: 'parker-insights-character-chemistry',
 
         async init() {
             await this.loadLibraries();
+            this.restoreState();
+            this.registerStateWatchers();
             await this.loadInsights();
+        },
+
+        registerStateWatchers() {
+            this.$watch('selectedLibraryId', () => this.persistState());
+            this.$watch('minShared', () => this.persistState());
+            this.$watch('limit', () => this.persistState());
+        },
+
+        restoreState() {
+            try {
+                const raw = sessionStorage.getItem(this.storageKey);
+                if (!raw) return;
+
+                const saved = JSON.parse(raw);
+                if (typeof saved.selectedLibraryId === 'string') this.selectedLibraryId = saved.selectedLibraryId;
+                if (saved.minShared !== undefined && saved.minShared !== null) this.minShared = saved.minShared;
+                if (saved.limit !== undefined && saved.limit !== null) this.limit = saved.limit;
+            } catch (error) {
+                console.error('Failed to restore character chemistry state', error);
+            }
+        },
+
+        persistState() {
+            try {
+                sessionStorage.setItem(this.storageKey, JSON.stringify({
+                    selectedLibraryId: this.selectedLibraryId,
+                    minShared: this.minShared,
+                    limit: this.limit,
+                }));
+            } catch (error) {
+                console.error('Failed to persist character chemistry state', error);
+            }
         },
 
         normalizeLimit() {

--- a/app/templates/insights_creator.html
+++ b/app/templates/insights_creator.html
@@ -15,16 +15,21 @@
             <p class="mt-3 text-gray-400 text-sm md:text-base">
                 Explore which creators show up together most often in your library. Click any highlighted cell to jump straight into Advanced Search with those creator filters applied.
             </p>
-            <div class="mt-4 flex flex-wrap gap-2">
-                <span class="px-3 py-1.5 rounded-full border border-blue-500/40 bg-blue-500/10 text-xs font-bold uppercase tracking-wider text-blue-200">
-                    Creator Chemistry
-                </span>
-                <a href="{{ url('/insights/character-chemistry') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-emerald-500/50 transition-colors">
-                    Character Chemistry
-                </a>
-                <a href="{{ url('/insights/writer-character') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-amber-500/50 transition-colors">
-                    Writer to Character
-                </a>
+            <div class="mt-4 overflow-x-auto pb-1">
+                <div class="inline-flex min-w-max gap-2 pr-1">
+                    <span class="px-3 py-1.5 rounded-full border border-blue-500/40 bg-blue-500/10 text-xs font-bold uppercase tracking-wider text-blue-200 whitespace-nowrap">
+                        Creator Chemistry
+                    </span>
+                    <a href="{{ url('/insights/character-chemistry') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-emerald-500/50 transition-colors whitespace-nowrap">
+                        Character Chemistry
+                    </a>
+                    <a href="{{ url('/insights/writer-character') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-amber-500/50 transition-colors whitespace-nowrap">
+                        Writer to Character
+                    </a>
+                    <a href="{{ url('/insights/artist-character') }}" class="px-3 py-1.5 rounded-full border border-gray-700 text-xs font-bold uppercase tracking-wider text-gray-300 hover:text-white hover:border-rose-500/50 transition-colors whitespace-nowrap">
+                        Artist to Character
+                    </a>
+                </div>
             </div>
         </div>
 
@@ -283,10 +288,51 @@ function creatorChemistry() {
         minShared: 2,
         limit: 12,
         pairMap: {},
+        storageKey: 'parker-insights-creator-chemistry',
 
         async init() {
             await this.loadLibraries();
+            this.restoreState();
+            this.registerStateWatchers();
             await this.loadInsights();
+        },
+
+        registerStateWatchers() {
+            this.$watch('roleA', () => this.persistState());
+            this.$watch('roleB', () => this.persistState());
+            this.$watch('selectedLibraryId', () => this.persistState());
+            this.$watch('minShared', () => this.persistState());
+            this.$watch('limit', () => this.persistState());
+        },
+
+        restoreState() {
+            try {
+                const raw = sessionStorage.getItem(this.storageKey);
+                if (!raw) return;
+
+                const saved = JSON.parse(raw);
+                if (typeof saved.roleA === 'string') this.roleA = saved.roleA;
+                if (typeof saved.roleB === 'string') this.roleB = saved.roleB;
+                if (typeof saved.selectedLibraryId === 'string') this.selectedLibraryId = saved.selectedLibraryId;
+                if (saved.minShared !== undefined && saved.minShared !== null) this.minShared = saved.minShared;
+                if (saved.limit !== undefined && saved.limit !== null) this.limit = saved.limit;
+            } catch (error) {
+                console.error('Failed to restore creator chemistry state', error);
+            }
+        },
+
+        persistState() {
+            try {
+                sessionStorage.setItem(this.storageKey, JSON.stringify({
+                    roleA: this.roleA,
+                    roleB: this.roleB,
+                    selectedLibraryId: this.selectedLibraryId,
+                    minShared: this.minShared,
+                    limit: this.limit,
+                }));
+            } catch (error) {
+                console.error('Failed to persist creator chemistry state', error);
+            }
         },
 
         normalizeLimit() {

--- a/tests/api/test_insights.py
+++ b/tests/api/test_insights.py
@@ -361,6 +361,130 @@ def _seed_writer_character_fixture(db, normal_user):
     }
 
 
+def _seed_artist_character_fixture(db, normal_user):
+    visible_lib = Library(name="Artist Character Visible", path="/tmp/artist-character-visible")
+    hidden_lib = Library(name="Artist Character Hidden", path="/tmp/artist-character-hidden")
+    db.add_all([visible_lib, hidden_lib])
+    db.flush()
+
+    safe_series = Series(name="Artist Character Safe Series", library_id=visible_lib.id)
+    banned_series = Series(name="Artist Character Banned Series", library_id=visible_lib.id)
+    hidden_series = Series(name="Artist Character Hidden Series", library_id=hidden_lib.id)
+    db.add_all([safe_series, banned_series, hidden_series])
+    db.flush()
+
+    safe_volume = Volume(series_id=safe_series.id, volume_number=1)
+    banned_volume = Volume(series_id=banned_series.id, volume_number=1)
+    hidden_volume = Volume(series_id=hidden_series.id, volume_number=1)
+    db.add_all([safe_volume, banned_volume, hidden_volume])
+    db.flush()
+
+    safe_comics = [
+        Comic(
+            volume_id=safe_volume.id,
+            number="1",
+            title="Artist Character Safe #1",
+            age_rating="Teen",
+            filename="artist-character-safe-1.cbz",
+            file_path="/tmp/artist-character-safe-1.cbz",
+        ),
+        Comic(
+            volume_id=safe_volume.id,
+            number="2",
+            title="Artist Character Safe #2",
+            age_rating="Teen",
+            filename="artist-character-safe-2.cbz",
+            file_path="/tmp/artist-character-safe-2.cbz",
+        ),
+        Comic(
+            volume_id=safe_volume.id,
+            number="3",
+            title="Artist Character Safe #3",
+            age_rating="Teen",
+            filename="artist-character-safe-3.cbz",
+            file_path="/tmp/artist-character-safe-3.cbz",
+        ),
+    ]
+    banned_comics = [
+        Comic(
+            volume_id=banned_volume.id,
+            number="1",
+            title="Artist Character Banned #1",
+            age_rating="Mature 17+",
+            filename="artist-character-banned-1.cbz",
+            file_path="/tmp/artist-character-banned-1.cbz",
+        ),
+        Comic(
+            volume_id=banned_volume.id,
+            number="2",
+            title="Artist Character Banned #2",
+            age_rating="Mature 17+",
+            filename="artist-character-banned-2.cbz",
+            file_path="/tmp/artist-character-banned-2.cbz",
+        ),
+    ]
+    hidden_comics = [
+        Comic(
+            volume_id=hidden_volume.id,
+            number="1",
+            title="Artist Character Hidden #1",
+            age_rating="Teen",
+            filename="artist-character-hidden-1.cbz",
+            file_path="/tmp/artist-character-hidden-1.cbz",
+        ),
+        Comic(
+            volume_id=hidden_volume.id,
+            number="2",
+            title="Artist Character Hidden #2",
+            age_rating="Teen",
+            filename="artist-character-hidden-2.cbz",
+            file_path="/tmp/artist-character-hidden-2.cbz",
+        ),
+    ]
+    db.add_all(safe_comics + banned_comics + hidden_comics)
+    db.flush()
+
+    artist_a = Person(name="Artist Character A")
+    artist_b = Person(name="Artist Character B")
+    hidden_artist = Person(name="Artist Hidden")
+    mature_artist = Person(name="Artist Mature")
+    hero_alpha = Character(name="Artist Hero Alpha")
+    hero_beta = Character(name="Artist Hero Beta")
+    hero_gamma = Character(name="Artist Hero Gamma")
+    hidden_ally = Character(name="Artist Hidden Ally")
+    mature_villain = Character(name="Artist Mature Villain")
+    db.add_all([artist_a, artist_b, hidden_artist, mature_artist, hero_alpha, hero_beta, hero_gamma, hidden_ally, mature_villain])
+    db.flush()
+
+    db.add_all([
+        ComicCredit(comic_id=safe_comics[0].id, person_id=artist_a.id, role="penciller"),
+        ComicCredit(comic_id=safe_comics[1].id, person_id=artist_a.id, role="penciller"),
+        ComicCredit(comic_id=safe_comics[2].id, person_id=artist_b.id, role="penciller"),
+        ComicCredit(comic_id=banned_comics[0].id, person_id=mature_artist.id, role="penciller"),
+        ComicCredit(comic_id=banned_comics[1].id, person_id=mature_artist.id, role="penciller"),
+        ComicCredit(comic_id=hidden_comics[0].id, person_id=hidden_artist.id, role="penciller"),
+        ComicCredit(comic_id=hidden_comics[1].id, person_id=hidden_artist.id, role="penciller"),
+    ])
+
+    safe_comics[0].characters.extend([hero_alpha, hero_beta])
+    safe_comics[1].characters.extend([hero_alpha, hero_beta])
+    safe_comics[2].characters.extend([hero_alpha, hero_gamma])
+    banned_comics[0].characters.extend([hero_alpha, mature_villain])
+    banned_comics[1].characters.extend([hero_alpha, mature_villain])
+    hidden_comics[0].characters.extend([hidden_ally, hero_alpha])
+    hidden_comics[1].characters.extend([hidden_ally, hero_alpha])
+
+    normal_user.accessible_libraries.append(visible_lib)
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    return {
+        "visible_lib": visible_lib,
+        "hidden_lib": hidden_lib,
+    }
+
+
 def test_creator_collaborations_respect_rls_and_age_filters(auth_client, db, normal_user):
     _seed_creator_collab_fixture(db, normal_user)
 
@@ -688,5 +812,79 @@ def test_writer_character_collaborations_reject_limit_over_guardrail(auth_client
     _seed_writer_character_fixture(db, normal_user)
 
     response = auth_client.get("/api/insights/creator-character-collaborations?role_a=writer&limit=16")
+
+    assert response.status_code == 422
+
+
+def test_artist_character_collaborations_respect_rls_and_age_filters(auth_client, db, normal_user):
+    _seed_artist_character_fixture(db, normal_user)
+
+    response = auth_client.get("/api/insights/creator-character-collaborations?role_a=penciller")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["pair_count"] == 2
+    assert payload["max_shared_issues"] == 2
+    assert len(payload["rows"]) == 1
+    assert len(payload["columns"]) == 2
+    assert payload["rows"][0]["name"] == "Artist Character A"
+    assert payload["rows"][0]["total_shared"] == 4
+    assert payload["columns"][0]["name"] == "Artist Hero Alpha"
+    assert payload["columns"][0]["total_shared"] == 2
+    assert payload["columns"][1]["name"] == "Artist Hero Beta"
+    assert payload["columns"][1]["total_shared"] == 2
+    assert payload["top_collaborations"][0]["person_a"] == "Artist Character A"
+    assert payload["top_collaborations"][0]["person_b"] == "Artist Hero Alpha"
+    assert payload["top_collaborations"][0]["shared_issues"] == 2
+
+
+def test_artist_character_collaborations_library_filter_blocks_unauthorized_library(auth_client, db, normal_user):
+    data = _seed_artist_character_fixture(db, normal_user)
+
+    response = auth_client.get(
+        f"/api/insights/creator-character-collaborations?role_a=penciller&library_id={data['hidden_lib'].id}"
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Library not found"
+
+
+def test_artist_character_collaborations_superuser_sees_hidden_library(admin_client, db, normal_user):
+    data = _seed_artist_character_fixture(db, normal_user)
+
+    response = admin_client.get(
+        f"/api/insights/creator-character-collaborations?role_a=penciller&library_id={data['hidden_lib'].id}&min_shared=2"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["pair_count"] == 2
+    names = {(pair["person_a"], pair["person_b"], pair["shared_issues"]) for pair in payload["pairs"]}
+    assert ("Artist Hidden", "Artist Hero Alpha", 2) in names
+    assert ("Artist Hidden", "Artist Hidden Ally", 2) in names
+
+
+def test_artist_character_collaborations_include_lower_threshold_pairs(auth_client, db, normal_user):
+    _seed_artist_character_fixture(db, normal_user)
+
+    response = auth_client.get("/api/insights/creator-character-collaborations?role_a=penciller&min_shared=1")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["pair_count"] == 4
+    names = {(pair["person_a"], pair["person_b"], pair["shared_issues"]) for pair in payload["pairs"]}
+    assert ("Artist Character A", "Artist Hero Alpha", 2) in names
+    assert ("Artist Character A", "Artist Hero Beta", 2) in names
+    assert ("Artist Character B", "Artist Hero Alpha", 1) in names
+    assert ("Artist Character B", "Artist Hero Gamma", 1) in names
+
+
+def test_artist_character_collaborations_reject_limit_over_guardrail(auth_client, db, normal_user):
+    _seed_artist_character_fixture(db, normal_user)
+
+    response = auth_client.get("/api/insights/creator-character-collaborations?role_a=penciller&limit=16")
 
     assert response.status_code == 422


### PR DESCRIPTION
Expands Parker’s insights experience with a fourth view, Artist to Character, and follows through with a usability polish pass across the full insights set. This will round out the initial metadata-driven insight pages and improves navigation, continuity, and expectation-setting for users exploring and drilling into their library data.

What Changed
- Added a new Artist to Character insights page at /insights/artist-character.
- Reused the creator-to-character insights API with penciller-backed artist mapping for consistent search drill-down behavior.
- Updated the insights hub to include all four current insight pages.
- Added cross-navigation between all insight pages.
- Persisted insight filter state in sessionStorage so returning from Advanced Search restores the previous view.
- Tightened the insight page switcher so the capsule navigation stays on a stable horizontal rail instead of wrapping.
- Added subtle metadata coverage notes to the character-driven insight pages to clarify that results depend on available creator and character metadata.

Implementation Notes
- Kept the implementation aligned with Parker’s existing metadata model, where artist-oriented search and credit behavior maps to penciller.
- Used page-specific parker-insights-* session keys so each insight view restores independently without affecting the others.
- Applied the filter restore after async library options load so saved library selections rehydrate correctly.
