### PR TITLE
Add Parker rating discovery to Advanced Search

### DIFF
--- a/alembic/versions/4b8d4f7f6c21_add_user_comic_ratings_table.py
+++ b/alembic/versions/4b8d4f7f6c21_add_user_comic_ratings_table.py
@@ -1,0 +1,37 @@
+"""add_user_comic_ratings_table
+
+Revision ID: 4b8d4f7f6c21
+Revises: d2a3c1e79f4b
+Create Date: 2026-07-13 13:45:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "4b8d4f7f6c21"
+down_revision: Union[str, None] = "d2a3c1e79f4b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade():
+    op.create_table(
+        "user_comic_ratings",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("comic_id", sa.Integer(), nullable=False),
+        sa.Column("rating", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint("rating >= 1 AND rating <= 5", name="ck_user_comic_ratings_rating_range"),
+        sa.ForeignKeyConstraint(["comic_id"], ["comics.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "comic_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("user_comic_ratings")

--- a/app/api/comics.py
+++ b/app/api/comics.py
@@ -6,6 +6,7 @@ from typing import List, Annotated, Literal
 from pathlib import Path
 import re
 import random
+from pydantic import BaseModel, Field
 
 from app.core.comic_helpers import (get_reading_time, get_format_sort_index, REVERSE_NUMBERING_SERIES,
                                     get_age_rating_config, get_series_age_restriction, get_thumbnail_url, get_thumbnail_hash)
@@ -18,14 +19,20 @@ from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.collection import Collection, CollectionItem
 from app.models.pull_list import PullList, PullListItem
 from app.models.reading_progress import ReadingProgress
+from app.models.interactions import UserComicRating
 
 
 from app.schemas.search import SearchRequest, SearchResponse
 from app.services.search import SearchService
+from app.services.comic_ratings import build_parker_rating_state
 
 
 
 router = APIRouter()
+
+
+class ComicRatingUpdate(BaseModel):
+    rating: int = Field(..., ge=1, le=5)
 
 # --- SECURITY HELPER ---
 def filter_by_user_access(query, user: CurrentUser):
@@ -43,6 +50,21 @@ def natural_sort_key(s):
     """Sorts 'Issue 1' before 'Issue 10' and handles '10a'"""
     return [int(text) if text.isdigit() else text.lower()
             for text in re.split('([0-9]+)', str(s))]
+
+
+def _ensure_user_can_view_comic(current_user: CurrentUser, comic: Comic):
+    """
+    Applies the same age restriction logic used by the detail endpoint.
+    """
+    if not current_user.is_superuser and current_user.max_age_rating:
+        _, banned = get_age_rating_config(current_user)
+
+        if comic.age_rating in banned:
+            raise HTTPException(status_code=403, detail="Content restricted by age rating")
+
+        if not current_user.allow_unknown_age_ratings:
+            if not comic.age_rating or comic.age_rating == "" or comic.age_rating.lower() == "unknown":
+                raise HTTPException(status_code=403, detail="Content restricted by age rating")
 
 @router.post("/search", response_model=SearchResponse, name="search")
 async def search_comics(request: SearchRequest, db: SessionDep, current_user: CurrentUser):
@@ -101,23 +123,7 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
 
     # --- AGE RATING CHECK ---
     # We have the comic loaded. We can check python side to save a query.
-    if not current_user.is_superuser and current_user.max_age_rating:
-
-        allowed, banned = get_age_rating_config(current_user)
-
-        is_banned = False
-
-        # Check explicit ban
-        if comic.age_rating in banned:
-            is_banned = True
-
-        # Check Unknowns
-        if not current_user.allow_unknown_age_ratings:
-            if not comic.age_rating or comic.age_rating == "" or comic.age_rating.lower() == "unknown":
-                is_banned = True
-
-        if is_banned:
-            raise HTTPException(status_code=403, detail="Content restricted by age rating")
+    _ensure_user_can_view_comic(current_user, comic)
     # ------------------------
 
 
@@ -144,6 +150,8 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
     # If started but not finished, show "Continue"
     if progress and not progress.completed and progress.current_page > 0:
         read_status = "in_progress"
+
+    parker_rating = build_parker_rating_state(db, comic.id, current_user.id)
 
     return {
         "id": comic.id,
@@ -189,6 +197,7 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
         "age_rating": comic.age_rating,
         "language_iso": comic.language_iso,
         "community_rating": comic.community_rating,
+        "source_rating": comic.community_rating,
 
         # Tags
         "characters": [c.name for c in comic.characters],
@@ -210,7 +219,58 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
 
         # ColorScape data
         "color_palette": comic.color_palette,
+
+        # Parker rating
+        **parker_rating,
     }
+
+
+@router.put("/{comic_id}/rating", name="set_rating")
+async def set_comic_rating(
+        comic: ComicDep,
+        payload: ComicRatingUpdate,
+        db: SessionDep,
+        current_user: CurrentUser
+):
+    _ensure_user_can_view_comic(current_user, comic)
+
+    rating = db.query(UserComicRating).filter(
+        UserComicRating.comic_id == comic.id,
+        UserComicRating.user_id == current_user.id,
+    ).first()
+
+    if rating:
+        rating.rating = payload.rating
+    else:
+        rating = UserComicRating(
+            comic_id=comic.id,
+            user_id=current_user.id,
+            rating=payload.rating,
+        )
+        db.add(rating)
+
+    db.commit()
+    return build_parker_rating_state(db, comic.id, current_user.id)
+
+
+@router.delete("/{comic_id}/rating", name="delete_rating")
+async def delete_comic_rating(
+        comic: ComicDep,
+        db: SessionDep,
+        current_user: CurrentUser
+):
+    _ensure_user_can_view_comic(current_user, comic)
+
+    rating = db.query(UserComicRating).filter(
+        UserComicRating.comic_id == comic.id,
+        UserComicRating.user_id == current_user.id,
+    ).first()
+
+    if rating:
+        db.delete(rating)
+        db.commit()
+
+    return build_parker_rating_state(db, comic.id, current_user.id)
 
 
 @router.get("/{comic_id}/thumbnail", name="thumbnail")

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -10,6 +10,7 @@ from app.core.settings_loader import get_cached_setting
 from app.api.deps import SessionDep, CurrentUser
 from app.core.comic_helpers import get_smart_cover, get_series_age_restriction, get_thumbnail_url
 from app.models.comic import Comic, Volume
+from app.models.interactions import UserComicRating
 from app.models.series import Series
 from app.models.user import User
 from app.models.reading_progress import ReadingProgress
@@ -21,7 +22,16 @@ router = APIRouter()
 # (Or define a simple one here if ComicSearchItem is too heavy,
 # but it should be fine as it matches what comic_card expects)
 
-def format_home_item(comic: Comic, progress: ReadingProgress = None) -> dict:
+def format_home_item(
+        comic: Comic,
+        progress: ReadingProgress = None,
+        *,
+        rating_mode: str = "none",
+        rating_value: float | None = None,
+        rating_label: str | None = None,
+        parker_rating_average: float | None = None,
+        parker_rating_count: int = 0,
+) -> dict:
     """Helper to flatten Comic object into ComicSearchItem schema"""
     item = {
         "id": comic.id,
@@ -35,6 +45,12 @@ def format_home_item(comic: Comic, progress: ReadingProgress = None) -> dict:
         "format": comic.format,
         "thumbnail_path": get_thumbnail_url(comic.id, comic.updated_at),
         "community_rating": comic.community_rating,
+        "source_rating": comic.community_rating,
+        "rating_mode": rating_mode,
+        "rating_value": rating_value,
+        "rating_label": rating_label,
+        "parker_rating_average": parker_rating_average,
+        "parker_rating_count": parker_rating_count,
         "progress_percentage": None
     }
 
@@ -189,7 +205,77 @@ def get_top_rated(
 
     gems = query.order_by(desc(Comic.community_rating)).limit(limit).all()
 
-    return [format_home_item(c) for c in gems]
+    return [
+        format_home_item(
+            c,
+            rating_mode="source",
+            rating_value=c.community_rating,
+            rating_label="Source Rating",
+        )
+        for c in gems
+    ]
+
+
+@router.get("/parker-rated", response_model=List[dict], name="top_parker_rated")
+def get_top_parker_rated(
+        db: SessionDep,
+        current_user: CurrentUser,
+        limit: int = 10
+):
+    """
+    Get issues with the highest Parker rating averages.
+    Live aggregate for now; this is the main surface likely to benefit from caching later.
+    """
+    rating_stats = (
+        db.query(
+            UserComicRating.comic_id.label("comic_id"),
+            func.avg(UserComicRating.rating).label("parker_rating_average"),
+            func.count(UserComicRating.user_id).label("parker_rating_count"),
+        )
+        .having(func.count(UserComicRating.user_id) >= 2)
+        .group_by(UserComicRating.comic_id)
+        .subquery()
+    )
+
+    query = (
+        db.query(
+            Comic,
+            rating_stats.c.parker_rating_average,
+            rating_stats.c.parker_rating_count,
+        )
+        .join(rating_stats, rating_stats.c.comic_id == Comic.id)
+        .join(Volume).join(Series)
+        .options(joinedload(Comic.volume).joinedload(Volume.series))
+    )
+
+    age_filter = get_series_age_restriction(current_user)
+    if age_filter is not None:
+        query = query.filter(age_filter)
+
+    results = (
+        query.order_by(
+            desc(rating_stats.c.parker_rating_average),
+            desc(rating_stats.c.parker_rating_count),
+            desc(Comic.updated_at),
+        )
+        .limit(limit)
+        .all()
+    )
+
+    if len(results) < 4:
+        return []
+
+    return [
+        format_home_item(
+            comic,
+            rating_mode="parker",
+            rating_value=float(parker_average) if parker_average is not None else None,
+            rating_label="Parker Rating",
+            parker_rating_average=float(parker_average) if parker_average is not None else None,
+            parker_rating_count=int(parker_count or 0),
+        )
+        for comic, parker_average, parker_count in results
+    ]
 
 
 @router.get("/resume", response_model=List[ComicSearchItem], name="resume_reading")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,7 +9,7 @@ from app.models.collection import Collection, CollectionItem
 from app.models.reading_progress import ReadingProgress
 from app.models.job import ScanJob
 from app.models.user import User
-from app.models.interactions import UserSeries
+from app.models.interactions import UserSeries, UserComicRating
 from app.models.saved_search import SavedSearch
 from app.models.setting import SystemSetting
 from app.models.pull_list import PullList, PullListItem
@@ -26,7 +26,7 @@ __all__ = [
     'ReadingProgress', 'ActivityLog',
     'ScanJob',
     'User',
-    'UserSeries',
+    'UserSeries', 'UserComicRating',
     'SavedSearch', 'SmartList',
     'SystemSetting',
     'PullList', 'PullListItem',

--- a/app/models/interactions.py
+++ b/app/models/interactions.py
@@ -1,6 +1,6 @@
-from sqlalchemy import Column, Integer, Boolean, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, Boolean, ForeignKey, DateTime, CheckConstraint
 from sqlalchemy.orm import relationship
-from datetime import datetime
+from datetime import datetime, timezone
 from app.database import Base
 
 
@@ -20,3 +20,29 @@ class UserSeries(Base):
     # Relationships
     user = relationship("User", backref="series_preferences")
     series = relationship("Series", backref="user_preferences")
+
+
+class UserComicRating(Base):
+    """
+    Junction table for User <-> Comic rating interactions.
+    Stores one Parker rating per user per comic.
+    """
+    __tablename__ = "user_comic_ratings"
+    __table_args__ = (
+        CheckConstraint("rating >= 1 AND rating <= 5", name="ck_user_comic_ratings_rating_range"),
+    )
+
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    comic_id = Column(Integer, ForeignKey("comics.id", ondelete="CASCADE"), primary_key=True)
+    rating = Column(Integer, nullable=False)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False)
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    # Relationships
+    user = relationship("User", backref="comic_ratings")
+    comic = relationship("Comic", backref="user_ratings")

--- a/app/schemas/search.py
+++ b/app/schemas/search.py
@@ -9,7 +9,7 @@ class SearchFilter(BaseModel):
 
         # Metadata
         'series', 'volume', 'number', 'title', 'publisher', 'imprint',
-        'summary', 'web', 'rating', 'age_rating', 'language', 'format', 'year',
+        'summary', 'web', 'rating', 'parker_rating', 'age_rating', 'language', 'format', 'year',
 
         # Creators
         'writer', 'penciller', 'inker', 'colorist', 'letterer', 'cover_artist', 'editor',
@@ -23,6 +23,7 @@ class SearchFilter(BaseModel):
     ]
     operator: Literal[
         'equal', 'not_equal',
+        'at_least', 'at_most',
         'contains', 'does_not_contain', 'must_contain',
         'is_empty', 'is_not_empty'
     ]
@@ -35,7 +36,7 @@ class SearchRequest(BaseModel):
     match: Literal['any', 'all'] = 'all'
     filters: List[SearchFilter] = Field(default_factory=list)
 
-    sort_by: Literal['created', 'updated', 'year', 'series', 'title', 'page_count', 'rating'] = 'created'
+    sort_by: Literal['created', 'updated', 'year', 'series', 'title', 'page_count', 'rating', 'parker_rating'] = 'created'
     sort_order: Literal['asc', 'desc'] = 'desc'
 
     limit: int = Field(default=50, ge=1, le=1000)
@@ -57,6 +58,8 @@ class ComicSearchItem(BaseModel):
     format: Optional[str] = None
     thumbnail_path: Optional[str] = None
     community_rating: Optional[float] = None
+    parker_rating_average: Optional[float] = None
+    parker_rating_count: int = 0
     rating_mode: Optional[Literal['parker', 'source', 'none']] = 'none'
     rating_value: Optional[float] = None
     rating_label: Optional[str] = None

--- a/app/schemas/search.py
+++ b/app/schemas/search.py
@@ -57,6 +57,9 @@ class ComicSearchItem(BaseModel):
     format: Optional[str] = None
     thumbnail_path: Optional[str] = None
     community_rating: Optional[float] = None
+    rating_mode: Optional[Literal['parker', 'source', 'none']] = 'none'
+    rating_value: Optional[float] = None
+    rating_label: Optional[str] = None
     progress_percentage: Optional[float] = None
 
 

--- a/app/services/comic_ratings.py
+++ b/app/services/comic_ratings.py
@@ -1,0 +1,41 @@
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.interactions import UserComicRating
+
+
+def recompute_parker_rating_summary(db: Session, comic_id: int) -> dict:
+    """
+    Compute the current Parker aggregate for a comic.
+    This is the single place to evolve later if we add cached columns.
+    """
+    average, count = (
+        db.query(
+            func.avg(UserComicRating.rating),
+            func.count(UserComicRating.user_id),
+        )
+        .filter(UserComicRating.comic_id == comic_id)
+        .one()
+    )
+
+    return {
+        "parker_rating_average": float(average) if average is not None else None,
+        "parker_rating_count": int(count or 0),
+    }
+
+
+def get_user_comic_rating(db: Session, comic_id: int, user_id: int) -> int | None:
+    return (
+        db.query(UserComicRating.rating)
+        .filter(
+            UserComicRating.comic_id == comic_id,
+            UserComicRating.user_id == user_id,
+        )
+        .scalar()
+    )
+
+
+def build_parker_rating_state(db: Session, comic_id: int, user_id: int | None) -> dict:
+    state = recompute_parker_rating_summary(db, comic_id)
+    state["user_rating"] = get_user_comic_rating(db, comic_id, user_id) if user_id is not None else None
+    return state

--- a/app/services/search.py
+++ b/app/services/search.py
@@ -497,5 +497,8 @@ class SearchService:
             "publisher": comic.publisher,
             "format": comic.format,
             "thumbnail_path": get_thumbnail_url(comic.id, comic.updated_at),
-            "community_rating": comic.community_rating
+            "community_rating": comic.community_rating,
+            "rating_mode": "source" if comic.community_rating and comic.community_rating > 0 else "none",
+            "rating_value": comic.community_rating,
+            "rating_label": "Source Rating" if comic.community_rating and comic.community_rating > 0 else None,
         }

--- a/app/services/search.py
+++ b/app/services/search.py
@@ -1,13 +1,13 @@
 from sqlalchemy.orm import Session, joinedload
-from sqlalchemy import or_, and_, func, not_, text
-from typing import List, Dict, Any, Union
+from sqlalchemy import or_, and_, func, not_, text, select
+from typing import List, Dict, Any, Union, Optional
 from app.models import (Comic, Volume, Series,
                         Character, Team, Location, Genre,
                         Person, ComicCredit,
                         Collection, CollectionItem,
                         ReadingList, ReadingListItem,
                         PullList, PullListItem,
-                        Library, User)
+                        Library, User, UserComicRating)
 
 from app.core.comic_helpers import get_series_age_restriction, get_thumbnail_url
 from app.schemas.search import SearchRequest, SearchFilter
@@ -19,11 +19,23 @@ class SearchService:
     def __init__(self, db: Session, current_user: User):
         self.db = db
         self.user = current_user
+        self._parker_rating_column = None
+        self._parker_rating_count_column = None
 
     def search(self, request: SearchRequest) -> Dict[str, Any]:
         """Execute search based on request parameters"""
         # Start with base query joining essential tables
+        self._parker_rating_column = None
+        self._parker_rating_count_column = None
         query = self.db.query(Comic).join(Volume).join(Series)
+        parker_stats = None
+        prefer_parker_rating = self._should_prefer_parker_rating(request)
+
+        if self._request_needs_parker_stats(request):
+            parker_stats = self._build_parker_rating_subquery()
+            query = query.outerjoin(parker_stats, parker_stats.c.comic_id == Comic.id)
+            self._parker_rating_column = parker_stats.c.parker_rating_average
+            self._parker_rating_count_column = parker_stats.c.parker_rating_count
 
         # 1. Apply Library Context Scope
         if hasattr(request, 'context_library_id') and request.context_library_id:
@@ -62,7 +74,13 @@ class SearchService:
         total = query.with_entities(func.count(func.distinct(Comic.id))).scalar()
 
         # Apply sorting
-        query = self._apply_sorting(query, request.sort_by, request.sort_order)
+        query = self._apply_sorting(
+            query,
+            request.sort_by,
+            request.sort_order,
+            parker_rating_column=self._parker_rating_column,
+            parker_rating_count_column=self._parker_rating_count_column,
+        )
 
         # Apply pagination
         query = query.offset(request.offset).limit(request.limit)
@@ -71,8 +89,25 @@ class SearchService:
         # OPTIMIZATION: Eager load relationships to prevent N+1 in _format_comic
         query = query.options(joinedload(Comic.volume).joinedload(Volume.series))
 
-        comics = query.all()
-        results = [self._format_comic(comic) for comic in comics]
+        if parker_stats is not None:
+            query = query.add_columns(
+                parker_stats.c.parker_rating_average,
+                parker_stats.c.parker_rating_count,
+            )
+
+            rows = query.all()
+            results = [
+                self._format_comic(
+                    comic,
+                    prefer_parker_rating=prefer_parker_rating,
+                    parker_rating_average=parker_rating_average,
+                    parker_rating_count=parker_rating_count,
+                )
+                for comic, parker_rating_average, parker_rating_count in rows
+            ]
+        else:
+            comics = query.all()
+            results = [self._format_comic(comic, prefer_parker_rating=False) for comic in comics]
 
         return {
             "total": total,
@@ -120,7 +155,7 @@ class SearchService:
 
         elif field in ['title', 'number', 'publisher', 'imprint', 'format',
                        'year', 'series_group', 'web',
-                       'age_rating', 'language', 'rating']:
+                       'age_rating', 'language']:
             # Map string field name to Column object
             col_map = {
                 'title': Comic.title,
@@ -134,9 +169,14 @@ class SearchService:
                 'web': Comic.web,
                 'age_rating': Comic.age_rating,
                 'language': Comic.language_iso,
-                'rating': Comic.community_rating
             }
             return self._build_simple_field_condition(col_map[field], operator, value)
+        elif field == 'rating':
+            return self._build_numeric_field_condition(Comic.community_rating, operator, value)
+        elif field == 'parker_rating':
+            if self._parker_rating_column is None:
+                return None
+            return self._build_numeric_field_condition(self._parker_rating_column, operator, value)
 
         # 2. Credits (Writer, Penciller, etc.)
         elif field in ['writer', 'penciller', 'inker', 'colorist', 'letterer', 'cover_artist', 'editor']:
@@ -159,6 +199,35 @@ class SearchService:
             return self._build_reading_list_condition(operator, value)
         elif field == 'pull_list':
             return self._build_pull_list_condition(operator, value)
+
+        return None
+
+    @staticmethod
+    def _coerce_numeric_value(value) -> Optional[float]:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def _build_numeric_field_condition(cls, column, operator, value):
+        values = value if isinstance(value, list) else [value]
+        numeric_values = [cls._coerce_numeric_value(v) for v in values]
+        numeric_values = [v for v in numeric_values if v is not None]
+
+        if not numeric_values:
+            return None
+
+        single_val = numeric_values[0]
+
+        if operator == 'equal':
+            return column == single_val
+        elif operator == 'not_equal':
+            return column != single_val
+        elif operator == 'at_least':
+            return column >= single_val
+        elif operator == 'at_most':
+            return column <= single_val
 
         return None
 
@@ -305,8 +374,7 @@ class SearchService:
 
         return None
 
-    @staticmethod
-    def _build_empty_condition(field: str, is_empty: bool):
+    def _build_empty_condition(self, field: str, is_empty: bool):
         """Build condition for checking if field is empty/null"""
 
         field_map = {
@@ -321,6 +389,13 @@ class SearchService:
             'age_rating': Comic.age_rating,
             'language': Comic.language_iso,
         }
+
+        if field == 'parker_rating':
+            if self._parker_rating_column is None:
+                return None
+            if is_empty:
+                return self._parker_rating_column.is_(None)
+            return self._parker_rating_column.isnot(None)
 
         # For relationship fields
         if field == 'character':
@@ -451,7 +526,37 @@ class SearchService:
 
 
     @staticmethod
-    def _apply_sorting(query, sort_by: str, sort_order: str):
+    def _build_parker_rating_subquery():
+        return (
+            select(
+                UserComicRating.comic_id.label("comic_id"),
+                func.avg(UserComicRating.rating).label("parker_rating_average"),
+                func.count(UserComicRating.user_id).label("parker_rating_count"),
+            )
+            .group_by(UserComicRating.comic_id)
+            .subquery()
+        )
+
+    @staticmethod
+    def _should_prefer_parker_rating(request: SearchRequest) -> bool:
+        if request.sort_by == 'parker_rating':
+            return True
+        return any(filter_item.field == 'parker_rating' for filter_item in request.filters)
+
+    @staticmethod
+    def _request_needs_parker_stats(request: SearchRequest) -> bool:
+        if request.sort_by == 'parker_rating':
+            return True
+        return any(filter_item.field == 'parker_rating' for filter_item in request.filters)
+
+    @staticmethod
+    def _apply_sorting(
+        query,
+        sort_by: str,
+        sort_order: str,
+        parker_rating_column=None,
+        parker_rating_count_column=None,
+    ):
         if sort_by == 'series':
             col = Series.name
         elif sort_by == 'year':
@@ -462,6 +567,8 @@ class SearchService:
             col = Comic.page_count
         elif sort_by == 'rating':
             col = Comic.community_rating
+        elif sort_by == 'parker_rating' and parker_rating_column is not None:
+            col = parker_rating_column
         elif sort_by == 'updated':
             col = Comic.updated_at
         elif sort_by == 'created':  # (Explicit)
@@ -478,14 +585,49 @@ class SearchService:
         # SECONDARY SORT (Stability)
         # If sorting by Rating, Year, or Page Count, ties are common.
         # Always break ties with Series Name -> Number
-        if sort_by in ['rating', 'year', 'page_count']:
+        if sort_by == 'parker_rating':
+            if parker_rating_count_column is not None:
+                query = query.order_by(
+                    parker_rating_count_column.desc(),
+                    Series.name.asc(),
+                    Comic.number.asc(),
+                )
+            else:
+                query = query.order_by(Series.name.asc(), Comic.number.asc())
+        elif sort_by in ['rating', 'year', 'page_count']:
             query = query.order_by(Series.name.asc(), Comic.number.asc())
 
         return query
 
     @staticmethod
-    def _format_comic(comic: Comic) -> dict:
+    def _format_comic(
+        comic: Comic,
+        *,
+        prefer_parker_rating: bool = False,
+        parker_rating_average: Optional[float] = None,
+        parker_rating_count: Optional[int] = None,
+    ) -> dict:
         """Format comic for response grid"""
+
+        parker_average = float(parker_rating_average) if parker_rating_average is not None else None
+        parker_count = int(parker_rating_count or 0)
+
+        if prefer_parker_rating and parker_average is not None and parker_average > 0:
+            rating_mode = "parker"
+            rating_value = parker_average
+            rating_label = "Parker Rating"
+        elif prefer_parker_rating:
+            rating_mode = "none"
+            rating_value = None
+            rating_label = None
+        elif comic.community_rating and comic.community_rating > 0:
+            rating_mode = "source"
+            rating_value = comic.community_rating
+            rating_label = "Source Rating"
+        else:
+            rating_mode = "none"
+            rating_value = None
+            rating_label = None
 
         return {
             "id": comic.id,
@@ -498,7 +640,9 @@ class SearchService:
             "format": comic.format,
             "thumbnail_path": get_thumbnail_url(comic.id, comic.updated_at),
             "community_rating": comic.community_rating,
-            "rating_mode": "source" if comic.community_rating and comic.community_rating > 0 else "none",
-            "rating_value": comic.community_rating,
-            "rating_label": "Source Rating" if comic.community_rating and comic.community_rating > 0 else None,
+            "parker_rating_average": parker_average,
+            "parker_rating_count": parker_count,
+            "rating_mode": rating_mode,
+            "rating_value": rating_value,
+            "rating_label": rating_label,
         }

--- a/app/templates/comics/comic_detail.html
+++ b/app/templates/comics/comic_detail.html
@@ -120,16 +120,6 @@
                     <div class="flex items-center gap-3 mt-4 text-sm text-gray-300">
                         <span x-text="comic?.year" class="bg-gray-700 px-2 py-1 rounded"></span>
 
-                        <template x-if="comic?.community_rating && comic?.community_rating > 0">
-                            <div class="flex items-center gap-1 bg-yellow-500/10 text-yellow-400 border border-yellow-500/20 px-2 py-1 rounded" title="Community Rating">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-3 h-3">
-                                    <path fill-rule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.007 5.404.433c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.433 2.082-5.006z" clip-rule="evenodd" />
-                                </svg>
-                                <span class="font-bold text-xs" x-text="Number(comic.community_rating).toFixed(1)"></span>
-                            </div>
-                        </template>
-
-
                         {% with publisher_ref="comic?.publisher" %}
                             {% include "partials/publisher_link.html" %}
                         {% endwith %}
@@ -153,6 +143,61 @@
                             </a>
                         </template>
 
+                    </div>
+                </div>
+
+                <div class="bg-gray-800/80 border border-gray-700 rounded-xl p-4 shadow-lg">
+                    <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                        <div>
+                            <div class="text-[10px] uppercase tracking-[0.2em] text-blue-300/80 font-bold">Parker Rating</div>
+                            <div class="flex items-baseline gap-2 mt-1.5">
+                                <span class="text-2xl font-bold text-white" x-text="comic?.parker_rating_average ? Number(comic.parker_rating_average).toFixed(1) : '--'"></span>
+                                <span class="text-sm text-gray-400" x-text="comic?.parker_rating_count ? `${comic.parker_rating_count} rating${comic.parker_rating_count === 1 ? '' : 's'}` : 'No Parker ratings yet'"></span>
+                            </div>
+                            <p class="text-[11px] text-gray-500 mt-0.5">This server's rating for this issue.</p>
+                        </div>
+
+                        <template x-if="comic?.source_rating && comic?.source_rating > 0">
+                            <div class="bg-yellow-500/10 text-yellow-300 border border-yellow-500/20 rounded-lg px-3 py-1.5 text-sm">
+                                <div class="text-[10px] uppercase tracking-wider text-yellow-200/80 font-bold mb-0.5">Source Rating</div>
+                                <div class="font-semibold" x-text="Number(comic.source_rating).toFixed(1)"></div>
+                            </div>
+                        </template>
+                    </div>
+
+                    <div class="mt-3 grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto] gap-3 md:items-center" @mouseleave="hoverRating = 0">
+                        <div class="text-sm text-gray-300 order-2 md:order-1">
+                            <div class="flex flex-col sm:flex-row sm:items-center gap-2">
+                                <span x-text="comic?.user_rating ? `Your rating: ${comic.user_rating}/5` : 'Rate this comic to get Parker started.'"></span>
+                                <button
+                                    x-show="comic?.user_rating"
+                                    type="button"
+                                    class="text-red-300 hover:text-white border border-red-500/30 hover:border-red-400/60 px-2.5 py-0.5 rounded transition-colors disabled:opacity-50 w-fit"
+                                    :disabled="submittingRating"
+                                    @click="clearRating()"
+                                >
+                                    Remove Rating
+                                </button>
+                            </div>
+                        </div>
+
+                        <div class="flex items-center gap-1 justify-start md:justify-end order-1 md:order-2">
+                            <template x-for="star in [1, 2, 3, 4, 5]" :key="star">
+                                <button
+                                    type="button"
+                                    class="p-0.5 transition-colors disabled:opacity-50"
+                                    :disabled="submittingRating"
+                                    @mouseenter="hoverRating = star"
+                                    @click="setRating(star)"
+                                    :title="`Rate ${star} star${star === 1 ? '' : 's'}`"
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-7 h-7 transition-colors"
+                                         :class="star <= activeRating ? 'text-yellow-400' : 'text-gray-600 hover:text-yellow-200'">
+                                        <path fill-rule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.007 5.404.433c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.433 2.082-5.006z" clip-rule="evenodd" />
+                                    </svg>
+                                </button>
+                            </template>
+                        </div>
                     </div>
                 </div>
 
@@ -310,6 +355,12 @@ function comicDetail() {
         comic: null,
         loading: true,
         error: null,
+        hoverRating: 0,
+        submittingRating: false,
+
+        get activeRating() {
+            return this.hoverRating || this.comic?.user_rating || 0;
+        },
 
         init() {
             this.loadComic();
@@ -343,6 +394,56 @@ function comicDetail() {
 
         async markUnread() {
             await fetch(window.parker.route('progress.mark_comic_as_unread', { comic_id: this.comicId }), { method: 'DELETE' });
+        },
+
+        applyRatingState(data) {
+            if (!this.comic) return;
+            this.comic = { ...this.comic, ...data };
+            this.hoverRating = 0;
+        },
+
+        async setRating(rating) {
+            if (this.submittingRating) return;
+            this.submittingRating = true;
+
+            try {
+                const res = await fetch(window.parker.route('comics.set_rating', { comic_id: this.comicId }), {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ rating })
+                });
+
+                if (!res.ok) throw new Error('Failed to save rating');
+                const data = await res.json();
+                this.applyRatingState(data);
+                if (window.parker) window.parker.showToast('Parker rating saved', 'success');
+            } catch (e) {
+                console.error(e);
+                if (window.parker) window.parker.showToast('Failed to save Parker rating', 'error');
+            } finally {
+                this.submittingRating = false;
+            }
+        },
+
+        async clearRating() {
+            if (this.submittingRating) return;
+            this.submittingRating = true;
+
+            try {
+                const res = await fetch(window.parker.route('comics.delete_rating', { comic_id: this.comicId }), {
+                    method: 'DELETE'
+                });
+
+                if (!res.ok) throw new Error('Failed to remove rating');
+                const data = await res.json();
+                this.applyRatingState(data);
+                if (window.parker) window.parker.showToast('Parker rating removed', 'success');
+            } catch (e) {
+                console.error(e);
+                if (window.parker) window.parker.showToast('Failed to remove Parker rating', 'error');
+            } finally {
+                this.submittingRating = false;
+            }
         },
 
     }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -94,6 +94,22 @@
             </div>
         </div>
 
+        <div x-show="!loading.parkerTopRated && parkerTopRatedComics.length > 0">
+            <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
+                <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                    <span class="text-blue-400">&#9733;</span> Top Rated on Parker
+                </h2>
+            </div>
+
+            <div class="flex space-x-4 overflow-x-auto pb-6 scrollbar-thin scrollbar-thumb-gray-700 scrollbar-track-transparent">
+                <template x-for="comic in parkerTopRatedComics" :key="comic.id">
+                    <div class="w-36 flex-shrink-0">
+                        {% include "partials/comic_card.html" %}
+                    </div>
+                </template>
+            </div>
+        </div>
+
         <div x-show="!loading.popular && popularSeries.length > 0">
             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
@@ -215,6 +231,7 @@ function homePage() {
         onDeckSeries: [],
         randomSeries: [],
         topRatedComics: [],
+        parkerTopRatedComics: [],
         resumeComics: [],
         smartLists: [],
         popularSeries: [],
@@ -226,6 +243,7 @@ function homePage() {
             onDeck: true,
             random: true,
             topRated: true,
+            parkerTopRated: true,
             resume: true,
             popular: true,
         },
@@ -235,6 +253,7 @@ function homePage() {
                 || this.loading.updated || this.loading.starred
                 || this.loading.onDeck || this.loading.random
                 || this.loading.topRated || this.loading.resume
+                || this.loading.parkerTopRated
                 ;
         },
 
@@ -253,6 +272,7 @@ function homePage() {
             this.fetchResume();
             this.fetchRandom();
             this.fetchTopRated();
+            this.fetchTopParkerRated();
             this.fetchSmartLists();
             this.fetchPopular();
         },
@@ -325,6 +345,14 @@ function homePage() {
                 if (res.ok) this.topRatedComics = await res.json();
             } catch(e) { console.error(e); }
             finally { this.loading.topRated = false; }
+        },
+
+        async fetchTopParkerRated() {
+            try {
+                const res = await fetch(window.parker.route('home.top_parker_rated', {}, 'limit=12'));
+                if (res.ok) this.parkerTopRatedComics = await res.json();
+            } catch(e) { console.error(e); }
+            finally { this.loading.parkerTopRated = false; }
         },
 
         async fetchSmartLists() {

--- a/app/templates/partials/comic_card.html
+++ b/app/templates/partials/comic_card.html
@@ -61,10 +61,10 @@
                 </div>
             </template>
 
-            <template x-if="comic.community_rating && comic.community_rating > 0">
-                <div class="absolute bottom-2 right-2 z-10 bg-black/70 text-yellow-400 text-[10px] font-bold px-1.5 py-0.5 rounded backdrop-blur-sm border border-white/10 flex items-center gap-0.5">
+            <template x-if="comic.rating_mode && comic.rating_mode !== 'none' && comic.rating_value && comic.rating_value > 0">
+                <div class="absolute bottom-2 z-10 min-h-[22px] bg-black/70 text-yellow-400 text-[10px] font-bold px-1.5 py-1 rounded shadow-md backdrop-blur-sm border border-white/10 flex items-center gap-0.5" :class="comic.format && comic.format !== 'Comic' ? 'right-1' : 'right-2'" :title="comic.rating_label || ''">
                     <span>★</span>
-                    <span x-text="Number(comic.community_rating).toFixed(1)"></span>
+                    <span x-text="Number(comic.rating_value).toFixed(1)"></span>
                 </div>
             </template>
 

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -106,6 +106,7 @@
                             <option value="summary">Summary</option>
                             <option value="web">Web/Wiki Link</option>
                             <option value="rating">Source Rating</option>
+                            <option value="parker_rating">Parker Rating</option>
                             <option value="age_rating">Age Rating</option>
                             <option value="language">Language (ISO)</option>
                         </optgroup>
@@ -131,22 +132,22 @@
                     </select>
 
                     <select x-model="rule.operator" class="w-full md:w-40 bg-gray-700 text-white rounded px-3 py-2 border border-gray-600 outline-none">
-                        <option value="equal">Equals</option>
-                        <option value="not_equal">Not Equals</option>
-                        <option value="contains">Contains (Any)</option>
-                        <option value="does_not_contain">Does Not Contain</option>
-                        <option value="must_contain">Must Contain (All)</option>
-                        <option value="is_empty">Is Empty</option>
-                        <option value="is_not_empty">Is Not Empty</option>
+                        <template x-for="option in operatorOptions(rule.field)" :key="`${rule.id}-${option.value}`">
+                            <option :value="option.value" x-text="option.label"></option>
+                        </template>
                     </select>
 
                     <div class="flex-1 w-full" x-show="!['is_empty', 'is_not_empty'].includes(rule.operator)">
 
-                        <div x-show="['title', 'year', 'summary', 'web', 'rating'].includes(rule.field)">
+                        <div x-show="usesSimpleInput(rule.field) && !usesNumericInput(rule.field)">
                             <input type="text" x-on:keydown.enter="performSearch()" x-model="rule.value" class="w-full bg-gray-700 text-white rounded px-3 py-2 border border-gray-600 outline-none focus:border-blue-500">
                         </div>
 
-                        <div x-show="!['title', 'year', 'summary', 'web', 'rating'].includes(rule.field)">
+                        <div x-show="usesNumericInput(rule.field)">
+                            <input type="number" step="0.1" min="0" max="5" x-on:keydown.enter="performSearch()" x-model="rule.value" class="w-full bg-gray-700 text-white rounded px-3 py-2 border border-gray-600 outline-none focus:border-blue-500">
+                        </div>
+
+                        <div x-show="!usesSimpleInput(rule.field)">
                             <div
                                 x-data="tagInput(rule)"
                                 class="relative w-full"
@@ -214,6 +215,7 @@
                         <option value="title">Issue Title</option>
                         <option value="page_count">Page Count</option>
                         <option value="rating">Source Rating</option>
+                        <option value="parker_rating">Parker Rating</option>
                     </select>
                 </div>
                 <div class="flex items-center space-x-2">
@@ -428,7 +430,7 @@ document.addEventListener('alpine:init', () => {
                 id: Date.now() + index + Math.random(),
                 field: filter.field,
                 operator: filter.operator || 'contains',
-                value: filter.value ?? []
+                value: this.normalizeRuleValue(filter.field, filter.value)
             }));
 
             return true;
@@ -536,9 +538,7 @@ document.addEventListener('alpine:init', () => {
                     id: Date.now(),
                     field: field,
                     operator: operator,
-                    // Check if value exists before wrapping in array.
-                    // If null, return empty array [] which TagInput can handle.
-                    value: value ? [value] : []
+                    value: this.normalizeRuleValue(field, value)
 
                 }];
 
@@ -568,6 +568,48 @@ document.addEventListener('alpine:init', () => {
             this.rules.push({ id: this.nextId++, field: 'character', operator: 'contains', value: [] });
         },
 
+        usesSimpleInput(field) {
+            return ['title', 'year', 'summary', 'web', 'rating', 'parker_rating'].includes(field);
+        },
+
+        usesNumericInput(field) {
+            return ['rating', 'parker_rating'].includes(field);
+        },
+
+        normalizeRuleValue(field, value) {
+            if (this.usesSimpleInput(field)) {
+                if (Array.isArray(value)) return value[0] ?? '';
+                return value ?? '';
+            }
+
+            if (Array.isArray(value)) return value;
+            if (value === null || value === undefined || value === '') return [];
+            return [value];
+        },
+
+        operatorOptions(field) {
+            if (['rating', 'parker_rating'].includes(field)) {
+                return [
+                    { value: 'equal', label: 'Equals' },
+                    { value: 'not_equal', label: 'Not Equals' },
+                    { value: 'at_least', label: 'At Least' },
+                    { value: 'at_most', label: 'At Most' },
+                    { value: 'is_empty', label: 'Is Empty' },
+                    { value: 'is_not_empty', label: 'Is Not Empty' },
+                ];
+            }
+
+            return [
+                { value: 'equal', label: 'Equals' },
+                { value: 'not_equal', label: 'Not Equals' },
+                { value: 'contains', label: 'Contains (Any)' },
+                { value: 'does_not_contain', label: 'Does Not Contain' },
+                { value: 'must_contain', label: 'Must Contain (All)' },
+                { value: 'is_empty', label: 'Is Empty' },
+                { value: 'is_not_empty', label: 'Is Not Empty' },
+            ];
+        },
+
         removeRule(index) {
             // Don't remove the last rule, just reset it
             if (this.rules.length === 1) {
@@ -579,6 +621,10 @@ document.addEventListener('alpine:init', () => {
 
         resetRule(rule) {
             rule.value = []; // Clear values when field changes
+            const options = this.operatorOptions(rule.field);
+            if (!options.some(option => option.value === rule.operator)) {
+                rule.operator = options[0].value;
+            }
         },
 
         async performSearch() {
@@ -695,7 +741,7 @@ document.addEventListener('alpine:init', () => {
                     id: Date.now() + i + Math.random(),
                     field: f.field,
                     operator: f.operator,
-                    value: f.value
+                    value: this.normalizeRuleValue(f.field, f.value)
                 }));
             } else {
                 this.rules = [{ id: Date.now() + 1 + Math.random(), field: 'series', operator: 'contains', value: [] }];

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -105,7 +105,7 @@
                             <option value="imprint">Imprint</option>
                             <option value="summary">Summary</option>
                             <option value="web">Web/Wiki Link</option>
-                            <option value="rating">Community Rating</option>
+                            <option value="rating">Source Rating</option>
                             <option value="age_rating">Age Rating</option>
                             <option value="language">Language (ISO)</option>
                         </optgroup>
@@ -213,7 +213,7 @@
                         <option value="series">Series Name</option>
                         <option value="title">Issue Title</option>
                         <option value="page_count">Page Count</option>
-                        <option value="rating">Community Rating</option>
+                        <option value="rating">Source Rating</option>
                     </select>
                 </div>
                 <div class="flex items-center space-x-2">

--- a/docs/releases/0.1.18.md
+++ b/docs/releases/0.1.18.md
@@ -1,0 +1,68 @@
+# Parker 0.1.18 Release Notes
+
+Status: In progress
+
+This file tracks the work landing in `0.1.18` so release notes can be built incrementally instead of reconstructed at release time.
+
+## Added
+
+- Added a new `Insights` entry point in the main navigation.
+- Added an insights landing page that links to individual insight experiences.
+- Added the first insights page, `Creator Chemistry`, for exploring creator-to-creator collaboration patterns.
+- Added the second insights page, `Character Chemistry`, for exploring character co-appearance patterns.
+- Added the third insights page, `Writer to Character`, for exploring which characters each writer is most associated with.
+- Added the fourth insights page, `Artist to Character`, for exploring which characters are most associated with penciller credits in your library.
+- Added a creator collaboration insights API endpoint at `/api/insights/creator-collaborations`.
+- Added a character collaboration insights API endpoint at `/api/insights/character-collaborations`.
+- Added a creator-to-character insights API endpoint at `/api/insights/creator-character-collaborations`.
+- Added drill-down from insight cells and top-collaboration cards into Advanced Search.
+- Added support for hydrated multi-rule search state handoff so complex insight drill-downs can open prebuilt searches reliably.
+- Added API test coverage for the new insights endpoint and its visibility/guardrail behavior.
+- Added Parker comic ratings with per-user 1-5 star rating support on comic detail pages.
+- Added Parker rating aggregates to comic detail payloads, including average rating, rating count, and the current user's rating.
+- Added comic rating write/delete API endpoints for setting and clearing Parker ratings.
+- Added a `Top Rated on Parker` home rail driven by live Parker rating aggregates.
+- Added minimum-data thresholds to the `Top Rated on Parker` rail so it only appears when enough ratings exist to make it meaningful.
+- Added Advanced Search support for sorting and filtering by Parker rating.
+
+## Changed
+
+- Hardened insight-to-search handoff so large multi-rule searches do not depend on oversized query strings.
+- Limited creator matrix size to keep the page usable and prevent overly dense visualizations.
+- Defaulted the `Creator Chemistry` role pairing to `Writer` x `Penciller`.
+- Refined the insights matrix to be more tablet-friendly with a dedicated internal scroll area.
+- Added sticky left-column behavior for row headers in the insights matrix.
+- Added sticky top-header behavior for matrix columns inside the insights scroll viewport.
+- Converted the heatmap rendering to a stable table-based layout so row/column alignment remains consistent.
+- Extended the matrix interaction model from creator pairings to character pairings on the same insights foundation.
+- Extended the matrix interaction model from pair chemistry into creator-to-character mapping on the same insights foundation.
+- Switched visible matrix identity and lookup behavior to creator IDs instead of only creator display names.
+- Updated visible row and column totals so they reflect only the currently displayed matrix cells.
+- Normalized empty and populated matrix cell heights for a more consistent grid.
+- Truncated long sample series titles inside matrix cards while preserving full hover titles.
+- Expanded the insights hub and cross-navigation so all three insight views are discoverable from the same entry point.
+- Expanded the insights hub and cross-navigation again so all four current insight views are discoverable from the same entry point.
+- Renamed front-facing imported `Community Rating` labels to `Source Rating` to clearly distinguish metadata ratings from Parker ratings.
+- Refined comic detail page rating presentation so Parker's rating and source metadata ratings are visually distinct.
+- Upgraded Advanced Search rating filters to use numeric-friendly operators for both Source Rating and Parker Rating.
+- Switched shared comic-card rating badges to an explicit rating context contract so each surface decides whether to show Parker rating, source rating, or no rating badge.
+
+## Fixed
+
+- Fixed search drill-down errors when the insights page attempted to open Advanced Search before the search handoff helper was available.
+- Fixed insights-page hydration errors caused by null access during initial render.
+- Fixed matrix layout bugs that allowed header-style cards to appear in the middle of the data grid.
+- Fixed column/body alignment issues where visible collaboration values could appear under the wrong header.
+- Fixed header totals that could include off-matrix collaborations and no longer matched the visible blue cells.
+- Fixed long sample titles causing a single matrix column to expand wider than the rest.
+- Fixed broken icon rendering in the `Top Rated on Parker` home rail.
+
+## Validation
+
+- Verified with:
+
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_insights.py
+```
+
+- Current result: `22 passed`

--- a/tests/api/test_comics.py
+++ b/tests/api/test_comics.py
@@ -75,6 +75,8 @@ def test_search_comics_delegates_to_search_service(auth_client):
                 "format": None,
                 "thumbnail_path": None,
                 "community_rating": None,
+                "parker_rating_average": None,
+                "parker_rating_count": 0,
                 "rating_mode": "none",
                 "rating_value": None,
                 "rating_label": None,
@@ -101,6 +103,68 @@ def test_search_comics_delegates_to_search_service(auth_client):
     assert response.status_code == 200
     assert response.json() == expected
     mock_service_cls.return_value.search.assert_called_once()
+
+
+def test_search_comics_can_sort_and_filter_by_parker_rating(auth_client, db, normal_user):
+    library, _, volume = _create_graph(db, lib_name="comic-search-rating", series_name="Search Rating Saga")
+
+    top_rated = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="Top Rated",
+        community_rating=4.8,
+        filename="top-rated.cbz",
+        file_path="/tmp/top-rated.cbz",
+    )
+    lower_rated = Comic(
+        volume_id=volume.id,
+        number="2",
+        title="Lower Rated",
+        community_rating=4.9,
+        filename="lower-rated.cbz",
+        file_path="/tmp/lower-rated.cbz",
+    )
+    second_user = User(
+        username="search-second-rater",
+        email="search-second-rater@example.com",
+        hashed_password="fakehash",
+        is_superuser=False,
+        is_active=True,
+    )
+
+    db.add_all([top_rated, lower_rated, second_user])
+    db.flush()
+    db.add_all([
+        UserComicRating(user_id=normal_user.id, comic_id=top_rated.id, rating=5),
+        UserComicRating(user_id=second_user.id, comic_id=top_rated.id, rating=4),
+        UserComicRating(user_id=normal_user.id, comic_id=lower_rated.id, rating=3),
+        UserComicRating(user_id=second_user.id, comic_id=lower_rated.id, rating=2),
+    ])
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.post(
+        "/api/comics/search",
+        json={
+            "match": "all",
+            "filters": [
+                {"field": "parker_rating", "operator": "at_least", "value": 4}
+            ],
+            "sort_by": "parker_rating",
+            "sort_order": "desc",
+            "limit": 10,
+            "offset": 0,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert [item["title"] for item in payload["results"]] == ["Top Rated"]
+    assert payload["results"][0]["rating_mode"] == "parker"
+    assert payload["results"][0]["rating_value"] == 4.5
+    assert payload["results"][0]["parker_rating_average"] == 4.5
+    assert payload["results"][0]["parker_rating_count"] == 2
 
 
 def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, db, normal_user):

--- a/tests/api/test_comics.py
+++ b/tests/api/test_comics.py
@@ -5,12 +5,14 @@ from app.api.comics import filter_by_user_access, natural_sort_key
 from app.models.collection import Collection, CollectionItem
 from app.models.comic import Comic, Volume
 from app.models.credits import ComicCredit, Person
+from app.models.interactions import UserComicRating
 from app.models.library import Library
 from app.models.pull_list import PullList, PullListItem
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.tags import Character, Genre, Location, Team
+from app.models.user import User
 
 
 def _create_graph(db, *, lib_name: str, series_name: str):
@@ -73,6 +75,9 @@ def test_search_comics_delegates_to_search_service(auth_client):
                 "format": None,
                 "thumbnail_path": None,
                 "community_rating": None,
+                "rating_mode": "none",
+                "rating_value": None,
+                "rating_label": None,
                 "progress_percentage": None,
             }
         ],
@@ -111,6 +116,7 @@ def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, d
         imprint="Detail Imprint",
         age_rating="Teen",
         language_iso="en",
+        community_rating=3.8,
         filename="detail-7.cbz",
         file_path="/tmp/detail-7.cbz",
     )
@@ -166,6 +172,141 @@ def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, d
     assert payload["locations"] == ["Detail City"]
     assert payload["genres"] == ["Detail Genre"]
     assert payload["read_status"] == "in_progress"
+    assert payload["source_rating"] == 3.8
+    assert payload["parker_rating_average"] is None
+    assert payload["parker_rating_count"] == 0
+    assert payload["user_rating"] is None
+
+
+def test_set_comic_rating_creates_and_updates_single_user_row(auth_client, db, normal_user):
+    library, _, volume = _create_graph(db, lib_name="comic-rate", series_name="Rate Saga")
+    comic = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="Rate Me",
+        filename="rate-me.cbz",
+        file_path="/tmp/rate-me.cbz",
+    )
+    db.add(comic)
+
+    other_user = User(
+        username="other-rater",
+        email="other-rater@example.com",
+        hashed_password="fakehash",
+        is_superuser=False,
+        is_active=True,
+    )
+    db.add(other_user)
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    create_response = auth_client.put(f"/api/comics/{comic.id}/rating", json={"rating": 4})
+
+    assert create_response.status_code == 200
+    assert create_response.json() == {
+        "parker_rating_average": 4.0,
+        "parker_rating_count": 1,
+        "user_rating": 4,
+    }
+
+    rows = db.query(UserComicRating).filter(UserComicRating.user_id == normal_user.id, UserComicRating.comic_id == comic.id).all()
+    assert len(rows) == 1
+    assert rows[0].rating == 4
+
+    db.add(UserComicRating(user_id=other_user.id, comic_id=comic.id, rating=2))
+    db.commit()
+
+    update_response = auth_client.put(f"/api/comics/{comic.id}/rating", json={"rating": 5})
+
+    assert update_response.status_code == 200
+    assert update_response.json() == {
+        "parker_rating_average": 3.5,
+        "parker_rating_count": 2,
+        "user_rating": 5,
+    }
+
+    rows = db.query(UserComicRating).filter(UserComicRating.user_id == normal_user.id, UserComicRating.comic_id == comic.id).all()
+    assert len(rows) == 1
+    assert rows[0].rating == 5
+
+
+def test_delete_comic_rating_updates_aggregate(auth_client, db, normal_user):
+    library, _, volume = _create_graph(db, lib_name="comic-unrate", series_name="Unrate Saga")
+    comic = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="Unrate Me",
+        filename="unrate-me.cbz",
+        file_path="/tmp/unrate-me.cbz",
+    )
+    db.add(comic)
+
+    other_user = User(
+        username="other-unrater",
+        email="other-unrater@example.com",
+        hashed_password="fakehash",
+        is_superuser=False,
+        is_active=True,
+    )
+    db.add(other_user)
+    db.flush()
+
+    db.add_all([
+        UserComicRating(user_id=normal_user.id, comic_id=comic.id, rating=4),
+        UserComicRating(user_id=other_user.id, comic_id=comic.id, rating=2),
+    ])
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.delete(f"/api/comics/{comic.id}/rating")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "parker_rating_average": 2.0,
+        "parker_rating_count": 1,
+        "user_rating": None,
+    }
+
+    assert db.query(UserComicRating).filter(
+        UserComicRating.user_id == normal_user.id,
+        UserComicRating.comic_id == comic.id,
+    ).first() is None
+
+
+def test_rating_endpoints_respect_hidden_and_age_restricted_comics(auth_client, db, normal_user):
+    hidden_library, _, hidden_volume = _create_graph(db, lib_name="comic-rate-hidden", series_name="Hidden Rate Saga")
+    hidden_comic = Comic(
+        volume_id=hidden_volume.id,
+        number="1",
+        title="Hidden Rate",
+        filename="hidden-rate.cbz",
+        file_path="/tmp/hidden-rate.cbz",
+    )
+
+    safe_library, _, safe_volume = _create_graph(db, lib_name="comic-rate-safe", series_name="Safe Rate Saga")
+    mature_comic = Comic(
+        volume_id=safe_volume.id,
+        number="2",
+        title="Mature Rate",
+        age_rating="Mature 17+",
+        filename="mature-rate.cbz",
+        file_path="/tmp/mature-rate.cbz",
+    )
+
+    db.add_all([hidden_comic, mature_comic])
+    normal_user.accessible_libraries.append(safe_library)
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    hidden_response = auth_client.put(f"/api/comics/{hidden_comic.id}/rating", json={"rating": 4})
+    assert hidden_response.status_code == 404
+    assert hidden_response.json() == {"detail": "Comic not found"}
+
+    restricted_response = auth_client.put(f"/api/comics/{mature_comic.id}/rating", json={"rating": 4})
+    assert restricted_response.status_code == 403
+    assert restricted_response.json() == {"detail": "Content restricted by age rating"}
 
 
 def test_get_comic_detail_missing_or_hidden_returns_404(auth_client, db):

--- a/tests/api/test_home.py
+++ b/tests/api/test_home.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from app.api.home import _pick_best_cover, format_home_item
 from app.models.comic import Comic, Volume
+from app.models.interactions import UserComicRating
 from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
@@ -64,6 +65,9 @@ def test_format_home_item_and_pick_best_cover_helpers():
     assert item["series"] == "Unknown"
     assert item["volume"] == 0
     assert item["thumbnail_path"] == "/api/comics/11/thumbnail?v=0"
+    assert item["rating_mode"] == "none"
+    assert item["rating_value"] is None
+    assert item["rating_label"] is None
     assert item["progress_percentage"] == 100.0
 
     no_progress = format_home_item(comic)
@@ -167,6 +171,111 @@ def test_home_rated_orders_by_rating(auth_client, db):
     assert len(payload) == 2
     assert payload[0]["id"] == high.id
     assert payload[0]["community_rating"] == 4.9
+
+
+def test_home_top_parker_rated_orders_by_average_then_count(auth_client, db):
+    _, _, volume = _create_series_graph(db, lib_name="home-parker-rated-lib", series_name="Home Parker Rated")
+
+    top = _add_comic(db, volume, number="3", title="Parker Top")
+    tiebreak = _add_comic(db, volume, number="2", title="Parker Tiebreak")
+    lower = _add_comic(db, volume, number="1", title="Parker Lower")
+    fourth = _add_comic(db, volume, number="4", title="Parker Fourth")
+
+    user_a = _add_user(db, username="parker-rater-a", email="parker-rater-a@example.com", share_progress_enabled=False)
+    user_b = _add_user(db, username="parker-rater-b", email="parker-rater-b@example.com", share_progress_enabled=False)
+    user_c = _add_user(db, username="parker-rater-c", email="parker-rater-c@example.com", share_progress_enabled=False)
+    user_d = _add_user(db, username="parker-rater-d", email="parker-rater-d@example.com", share_progress_enabled=False)
+
+    db.add_all([
+        UserComicRating(user_id=user_a.id, comic_id=top.id, rating=5),
+        UserComicRating(user_id=user_b.id, comic_id=top.id, rating=5),
+        UserComicRating(user_id=user_a.id, comic_id=tiebreak.id, rating=5),
+        UserComicRating(user_id=user_b.id, comic_id=tiebreak.id, rating=4),
+        UserComicRating(user_id=user_c.id, comic_id=tiebreak.id, rating=5),
+        UserComicRating(user_id=user_a.id, comic_id=lower.id, rating=4),
+        UserComicRating(user_id=user_b.id, comic_id=lower.id, rating=4),
+        UserComicRating(user_id=user_c.id, comic_id=fourth.id, rating=3),
+        UserComicRating(user_id=user_d.id, comic_id=fourth.id, rating=3),
+    ])
+    db.commit()
+
+    response = auth_client.get("/api/home/parker-rated?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["id"] for item in payload] == [top.id, tiebreak.id, lower.id, fourth.id]
+    assert payload[0]["rating_mode"] == "parker"
+    assert payload[0]["rating_value"] == 5.0
+    assert payload[0]["parker_rating_average"] == 5.0
+    assert payload[0]["parker_rating_count"] == 2
+    assert payload[0]["rating_label"] == "Parker Rating"
+    assert payload[1]["parker_rating_average"] == 14 / 3
+    assert payload[1]["parker_rating_count"] == 3
+
+
+def test_home_top_parker_rated_returns_empty_without_enough_qualifying_items(auth_client, db):
+    _, _, volume = _create_series_graph(db, lib_name="home-parker-threshold-lib", series_name="Home Parker Threshold")
+
+    first = _add_comic(db, volume, number="1", title="Threshold First")
+    second = _add_comic(db, volume, number="2", title="Threshold Second")
+    third = _add_comic(db, volume, number="3", title="Threshold Third")
+
+    user_a = _add_user(db, username="parker-threshold-a", email="parker-threshold-a@example.com", share_progress_enabled=False)
+    user_b = _add_user(db, username="parker-threshold-b", email="parker-threshold-b@example.com", share_progress_enabled=False)
+    user_c = _add_user(db, username="parker-threshold-c", email="parker-threshold-c@example.com", share_progress_enabled=False)
+
+    db.add_all([
+        UserComicRating(user_id=user_a.id, comic_id=first.id, rating=5),
+        UserComicRating(user_id=user_b.id, comic_id=first.id, rating=5),
+        UserComicRating(user_id=user_a.id, comic_id=second.id, rating=4),
+        UserComicRating(user_id=user_b.id, comic_id=second.id, rating=4),
+        UserComicRating(user_id=user_c.id, comic_id=third.id, rating=5),
+    ])
+    db.commit()
+
+    response = auth_client.get("/api/home/parker-rated?limit=10")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_home_top_parker_rated_applies_age_filter(auth_client, db, normal_user):
+    _, _, safe_volume = _create_series_graph(db, lib_name="home-parker-age-safe-lib", series_name="Home Parker Safe")
+    _, _, second_safe_volume = _create_series_graph(db, lib_name="home-parker-age-safe-lib-2", series_name="Home Parker Safe Two")
+    _, _, third_safe_volume = _create_series_graph(db, lib_name="home-parker-age-safe-lib-3", series_name="Home Parker Safe Three")
+    _, _, fourth_safe_volume = _create_series_graph(db, lib_name="home-parker-age-safe-lib-4", series_name="Home Parker Safe Four")
+    _, _, banned_volume = _create_series_graph(db, lib_name="home-parker-age-banned-lib", series_name="Home Parker Banned")
+
+    safe = _add_comic(db, safe_volume, number="1", title="Parker Safe", age_rating="Teen")
+    safe_two = _add_comic(db, second_safe_volume, number="1", title="Parker Safe Two", age_rating="Teen")
+    safe_three = _add_comic(db, third_safe_volume, number="1", title="Parker Safe Three", age_rating="Teen")
+    safe_four = _add_comic(db, fourth_safe_volume, number="1", title="Parker Safe Four", age_rating="Teen")
+    banned = _add_comic(db, banned_volume, number="1", title="Parker Banned", age_rating="Mature 17+")
+
+    rater = _add_user(db, username="parker-age-rater", email="parker-age-rater@example.com", share_progress_enabled=False)
+    db.add_all([
+        UserComicRating(user_id=rater.id, comic_id=safe.id, rating=4),
+        UserComicRating(user_id=normal_user.id, comic_id=safe.id, rating=4),
+        UserComicRating(user_id=rater.id, comic_id=safe_two.id, rating=4),
+        UserComicRating(user_id=normal_user.id, comic_id=safe_two.id, rating=4),
+        UserComicRating(user_id=rater.id, comic_id=safe_three.id, rating=4),
+        UserComicRating(user_id=normal_user.id, comic_id=safe_three.id, rating=4),
+        UserComicRating(user_id=rater.id, comic_id=safe_four.id, rating=4),
+        UserComicRating(user_id=normal_user.id, comic_id=safe_four.id, rating=4),
+        UserComicRating(user_id=normal_user.id, comic_id=banned.id, rating=5),
+        UserComicRating(user_id=rater.id, comic_id=banned.id, rating=5),
+    ])
+
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    response = auth_client.get("/api/home/parker-rated?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 4
+    assert {item["id"] for item in payload} == {safe.id, safe_two.id, safe_three.id, safe_four.id}
 
 
 def test_home_resume_applies_staleness_and_progress_percentage(auth_client, db, normal_user):

--- a/tests/services/test_search_service.py
+++ b/tests/services/test_search_service.py
@@ -2,10 +2,13 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from sqlalchemy import literal_column
 
 from app.models.comic import Comic, Volume
+from app.models.interactions import UserComicRating
 from app.models.library import Library
 from app.models.series import Series
+from app.models.user import User
 from app.schemas.search import SearchFilter, SearchRequest
 from app.services.search import SearchService
 
@@ -164,6 +167,54 @@ def test_search_service_applies_age_filter_and_skips_invalid_filters(db, normal_
     assert len(results["results"]) == 2
 
 
+def test_search_service_filters_and_sorts_by_parker_rating(db, normal_user):
+    data = _seed_search_graph(db)
+    other_alpha_user = User(
+        username="alpha-rater",
+        email="alpha-rater@example.com",
+        hashed_password="x",
+        is_superuser=False,
+        is_active=True,
+    )
+    other_beta_user = User(
+        username="beta-rater",
+        email="beta-rater@example.com",
+        hashed_password="x",
+        is_superuser=False,
+        is_active=True,
+    )
+    db.add_all([other_alpha_user, other_beta_user])
+    db.flush()
+
+    db.add_all([
+        UserComicRating(user_id=normal_user.id, comic_id=data["alpha"].id, rating=5),
+        UserComicRating(user_id=normal_user.id, comic_id=data["beta"].id, rating=3),
+        UserComicRating(user_id=other_alpha_user.id, comic_id=data["alpha"].id, rating=4),
+        UserComicRating(user_id=other_beta_user.id, comic_id=data["beta"].id, rating=2),
+    ])
+    db.commit()
+
+    service = SearchService(db, normal_user)
+    request = SearchRequest(
+        match="all",
+        filters=[SearchFilter(field="parker_rating", operator="at_least", value=4)],
+        sort_by="parker_rating",
+        sort_order="desc",
+        limit=10,
+        offset=0,
+    )
+
+    results = service.search(request)
+
+    assert results["total"] == 1
+    assert len(results["results"]) == 1
+    assert results["results"][0]["id"] == data["alpha"].id
+    assert results["results"][0]["rating_mode"] == "parker"
+    assert results["results"][0]["rating_value"] == 4.5
+    assert results["results"][0]["parker_rating_average"] == 4.5
+    assert results["results"][0]["parker_rating_count"] == 2
+
+
 def test_build_condition_handles_empty_operators_and_fts_routing(normal_user):
     service = SearchService(MagicMock(), normal_user)
     service._build_empty_condition = MagicMock(return_value="empty-expr")
@@ -229,6 +280,20 @@ def test_build_simple_field_condition_operators():
     assert SearchService._build_simple_field_condition(Comic.publisher, "must_contain", "Marvel") is None
 
 
+def test_build_numeric_field_condition_operators():
+    equal_expr = SearchService._build_numeric_field_condition(Comic.community_rating, "equal", 4.5)
+    not_equal_expr = SearchService._build_numeric_field_condition(Comic.community_rating, "not_equal", 3)
+    at_least_expr = SearchService._build_numeric_field_condition(Comic.community_rating, "at_least", "4")
+    at_most_expr = SearchService._build_numeric_field_condition(Comic.community_rating, "at_most", 2.5)
+
+    assert "comics.community_rating = 4.5" in _sql(equal_expr)
+    assert "comics.community_rating != 3.0" in _sql(not_equal_expr)
+    assert "comics.community_rating >= 4.0" in _sql(at_least_expr)
+    assert "comics.community_rating <= 2.5" in _sql(at_most_expr)
+    assert SearchService._build_numeric_field_condition(Comic.community_rating, "contains", 4) is None
+    assert SearchService._build_numeric_field_condition(Comic.community_rating, "equal", "bad") is None
+
+
 def test_build_credit_condition_operators():
     equal_expr = SearchService._build_credit_condition("writer", "equal", "Alan Moore")
     contains_expr = SearchService._build_credit_condition("writer", "contains", ["Alan", "Grant"])
@@ -281,23 +346,29 @@ def test_collection_and_reading_list_condition_operators():
     assert SearchService._build_reading_list_condition("unknown", "x") is None
 
 
-def test_build_empty_condition_relationship_and_simple_paths():
-    assert "NOT (EXISTS" in _sql(SearchService._build_empty_condition("character", True))
-    assert "EXISTS" in _sql(SearchService._build_empty_condition("character", False))
-    assert "NOT (EXISTS" in _sql(SearchService._build_empty_condition("team", True))
-    assert "EXISTS" in _sql(SearchService._build_empty_condition("location", False))
-    assert "NOT (EXISTS" in _sql(SearchService._build_empty_condition("collection", True))
-    assert "EXISTS" in _sql(SearchService._build_empty_condition("reading_list", False))
-    assert "comic_credits.role = 'writer'" in _sql(SearchService._build_empty_condition("writer", True))
-    assert "comic_credits.role = 'writer'" in _sql(SearchService._build_empty_condition("writer", False))
-    assert "NOT (EXISTS" in _sql(SearchService._build_empty_condition("pull_list", True))
+def test_build_empty_condition_relationship_and_simple_paths(normal_user):
+    service = SearchService(MagicMock(), normal_user)
 
-    empty_title = _sql(SearchService._build_empty_condition("title", True))
-    non_empty_title = _sql(SearchService._build_empty_condition("title", False))
+    assert "NOT (EXISTS" in _sql(service._build_empty_condition("character", True))
+    assert "EXISTS" in _sql(service._build_empty_condition("character", False))
+    assert "NOT (EXISTS" in _sql(service._build_empty_condition("team", True))
+    assert "EXISTS" in _sql(service._build_empty_condition("location", False))
+    assert "NOT (EXISTS" in _sql(service._build_empty_condition("collection", True))
+    assert "EXISTS" in _sql(service._build_empty_condition("reading_list", False))
+    assert "comic_credits.role = 'writer'" in _sql(service._build_empty_condition("writer", True))
+    assert "comic_credits.role = 'writer'" in _sql(service._build_empty_condition("writer", False))
+    assert "NOT (EXISTS" in _sql(service._build_empty_condition("pull_list", True))
+
+    empty_title = _sql(service._build_empty_condition("title", True))
+    non_empty_title = _sql(service._build_empty_condition("title", False))
     assert "comics.title IS NULL" in empty_title and "comics.title = ''" in empty_title
     assert "comics.title IS NOT NULL" in non_empty_title and "comics.title != ''" in non_empty_title
 
-    assert SearchService._build_empty_condition("story_arc", True) is None
+    service._parker_rating_column = Comic.community_rating
+    assert "comics.community_rating IS NULL" in _sql(service._build_empty_condition("parker_rating", True))
+    assert "comics.community_rating IS NOT NULL" in _sql(service._build_empty_condition("parker_rating", False))
+
+    assert service._build_empty_condition("story_arc", True) is None
 
 
 def test_build_pull_list_condition_scopes_to_current_user(normal_user):
@@ -350,32 +421,39 @@ class _OrderRecorder:
 
 
 @pytest.mark.parametrize(
-    "sort_by,sort_order,expected_column,expects_secondary",
+    "sort_by,sort_order,expected_column,expected_secondary",
     [
-        ("series", "desc", "series.name", False),
-        ("year", "asc", "comics.year", True),
-        ("title", "asc", "comics.title", False),
-        ("page_count", "desc", "comics.page_count", True),
-        ("rating", "desc", "comics.community_rating", True),
-        ("updated", "asc", "comics.updated_at", False),
-        ("created", "desc", "comics.created_at", False),
-        ("unknown", "asc", "comics.created_at", False),
+        ("series", "desc", "series.name", []),
+        ("year", "asc", "comics.year", ["series.name ASC", "comics.number ASC"]),
+        ("title", "asc", "comics.title", []),
+        ("page_count", "desc", "comics.page_count", ["series.name ASC", "comics.number ASC"]),
+        ("rating", "desc", "comics.community_rating", ["series.name ASC", "comics.number ASC"]),
+        ("parker_rating", "desc", "parker_average", ["parker_count DESC", "series.name ASC", "comics.number ASC"]),
+        ("updated", "asc", "comics.updated_at", []),
+        ("created", "desc", "comics.created_at", []),
+        ("unknown", "asc", "comics.created_at", []),
     ],
 )
-def test_apply_sorting_chooses_expected_columns(sort_by, sort_order, expected_column, expects_secondary):
+def test_apply_sorting_chooses_expected_columns(sort_by, sort_order, expected_column, expected_secondary):
     recorder = _OrderRecorder()
-    result = SearchService._apply_sorting(recorder, sort_by, sort_order)
+    result = SearchService._apply_sorting(
+        recorder,
+        sort_by,
+        sort_order,
+        parker_rating_column=literal_column("parker_average"),
+        parker_rating_count_column=literal_column("parker_count"),
+    )
 
     assert result is recorder
-    assert len(recorder.calls) == (2 if expects_secondary else 1)
+    assert len(recorder.calls) == (1 + (1 if expected_secondary else 0))
 
     primary_sql = str(recorder.calls[0][0])
     assert expected_column in primary_sql
     assert (" DESC" in primary_sql) == (sort_order == "desc")
 
-    if expects_secondary:
+    if expected_secondary:
         secondary = [str(expr) for expr in recorder.calls[1]]
-        assert secondary == ["series.name ASC", "comics.number ASC"]
+        assert secondary == expected_secondary
 
 
 def test_format_comic_uses_thumbnail_helper(monkeypatch, db):
@@ -387,3 +465,29 @@ def test_format_comic_uses_thumbnail_helper(monkeypatch, db):
     assert payload["id"] == comic.id
     assert payload["series"] == data["series"].name
     assert payload["thumbnail_path"] == f"/thumb/{comic.id}"
+
+
+def test_format_comic_prefers_parker_rating_context(monkeypatch, db):
+    data = _seed_search_graph(db)
+    comic = data["alpha"]
+    comic.community_rating = 4.8
+    monkeypatch.setattr("app.services.search.get_thumbnail_url", lambda comic_id, updated_at: f"/thumb/{comic_id}")
+
+    parker_payload = SearchService._format_comic(
+        comic,
+        prefer_parker_rating=True,
+        parker_rating_average=4.25,
+        parker_rating_count=3,
+    )
+    assert parker_payload["rating_mode"] == "parker"
+    assert parker_payload["rating_value"] == 4.25
+    assert parker_payload["parker_rating_count"] == 3
+
+    unrated_payload = SearchService._format_comic(
+        comic,
+        prefer_parker_rating=True,
+        parker_rating_average=None,
+        parker_rating_count=0,
+    )
+    assert unrated_payload["rating_mode"] == "none"
+    assert unrated_payload["rating_value"] is None


### PR DESCRIPTION
## Summary
- add Parker rating sorting and filtering to Advanced Search
- introduce numeric rating operators for both Parker and source ratings
- show explicit Parker rating context on search result cards when the search is Parker-driven
- add search service and API coverage for Parker aggregate behavior
- update the 0.1.18 release notes for the new search capabilities

## Testing
- .venv\\Scripts\\python.exe -m pytest tests\\services\\test_search_service.py tests\\api\\test_comics.py