### PR TITLE
Add startup diagnostics, suspicious-state warnings, and support snaps…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,3 +9,13 @@ This file captures follow-up work that should not get lost between releases.
   Current state: Parker ships a compatibility fix that walks the newer wrapped route structure and is covered by focused regression tests.
   Follow-up goal: Refactor the route-map helper to rely on the most stable/public FastAPI mechanism available instead of depending on wrapper internals like `original_router` and `include_context`.
   Candidate direction: Evaluate newer FastAPI route-context helpers such as `iter_route_contexts()` and confirm the best supported approach for nested routers and frontend route discovery.
+
+- Expand the admin diagnostics support snapshot after it has seen a few real support incidents.
+  Context: The current snapshot is intentionally lean and already covers startup status, runtime mode, database path/sizes, counts, configured-library samples, and the comics-path probe.
+  Follow-up goal: Only add more fields if they repeatedly save support back-and-forth in real reports.
+  Likely v2 additions:
+  Recent scan job summary (last few jobs, status, timestamps, error text).
+  Library detail summary (`last_scanned`, `is_scanning`, maybe a few more library rows than the current sample).
+  Key request/runtime settings that commonly affect support cases (`base_url`, selected proxy-related settings, maybe a few safe env-derived values).
+  Light filesystem health checks for storage/cache/cover directories.
+  Guardrails: Avoid secrets, tokens, full env dumps, or overly large payloads.

--- a/app/api/stats.py
+++ b/app/api/stats.py
@@ -2,14 +2,48 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import func, case, desc
 
 from app.api.deps import SessionDep, AdminUser
+from app.config import settings
 from app.models.comic import Comic, Volume
 from app.models.series import Series
 from app.models.library import Library
 from app.models.tags import Genre, comic_genres
 from app.models.user import User
 from app.models.reading_progress import ReadingProgress
+from app.services.startup_diagnostics import build_support_snapshot, collect_startup_diagnostics
 
 router = APIRouter()
+
+
+@router.get("/startup", name="startup")
+async def get_startup_diagnostics(
+        db: SessionDep,
+        admin: AdminUser
+):
+    """
+    Return startup diagnostics for troubleshooting suspicious empty-state behavior.
+    """
+    return collect_startup_diagnostics(
+        db,
+        database_url=settings.database_url,
+    )
+
+
+@router.get("/startup/support-snapshot", name="startup_support_snapshot")
+async def get_startup_support_snapshot(
+        db: SessionDep,
+        admin: AdminUser
+):
+    """
+    Return a structured support snapshot JSON for issue reports and troubleshooting.
+    """
+    diagnostics = collect_startup_diagnostics(
+        db,
+        database_url=settings.database_url,
+    )
+    return build_support_snapshot(
+        diagnostics,
+        app_version=settings.version,
+    )
 
 
 @router.get("/", name="system")

--- a/app/main.py
+++ b/app/main.py
@@ -152,6 +152,7 @@ app = FastAPI(
     lifespan=lifespan,
     root_path=settings.clean_base_url,
 )
+app.state.settings = settings
 
 # CORS middleware (adjust origins as needed)
 app.add_middleware(

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -5,9 +5,10 @@ import os
 from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import HTMLResponse, FileResponse
 
-from app.api.deps import AdminUser
+from app.api.deps import AdminUser, SessionDep
 from app.config import settings
 from app.core.templates import templates
+from app.services.startup_diagnostics import build_support_snapshot, collect_startup_diagnostics
 
 router = APIRouter()
 
@@ -99,6 +100,28 @@ async def admin_about_page(request: Request, admin_user: AdminUser):
         request=request,
         name="admin/about.html",
         context=context
+    )
+
+
+@router.get("/diagnostics", response_class=HTMLResponse, name="diagnostics", tags=['admin'])
+async def admin_diagnostics_page(request: Request, db: SessionDep, admin_user: AdminUser):
+    """Serve the Admin diagnostics page."""
+    diagnostics = collect_startup_diagnostics(
+        db,
+        database_url=settings.database_url,
+    )
+    support_snapshot = build_support_snapshot(
+        diagnostics,
+        app_version=settings.version,
+    )
+
+    return templates.TemplateResponse(
+        request=request,
+        name="admin/diagnostics.html",
+        context={
+            "diagnostics": diagnostics,
+            "support_snapshot": support_snapshot,
+        },
     )
 
 

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -3,20 +3,45 @@ from fastapi.responses import HTMLResponse
 
 from app.core.comic_helpers import get_smart_cover
 from app.api.deps import SessionDep, ComicDep, VolumeDep, SeriesDep, LibraryDep, CurrentUser
+from app.config import settings
 from app.core.templates import templates
 from app.models.comic import Comic, Volume
 from app.core.login_effects import get_active_effect
 from app.core.login_backgrounds import SOLID_COLORS, STATIC_COVERS
 from app.services.settings_service import SettingsService
+from app.services.startup_diagnostics import (
+    build_home_startup_notice,
+    collect_startup_diagnostics,
+)
 
 router = APIRouter()
 
 
 # Frontend routes
 @router.get("/", response_class=HTMLResponse, name="home")
-async def home(request: Request, user: CurrentUser):
+async def home(request: Request, db: SessionDep, user: CurrentUser):
     """Home page - Library browser"""
-    return templates.TemplateResponse(request=request, name="index.html")
+    startup_notice = None
+
+    try:
+        diagnostics = collect_startup_diagnostics(
+            db,
+            database_url=settings.database_url,
+        )
+    except Exception:
+        diagnostics = None
+
+    if diagnostics is not None:
+        startup_notice = build_home_startup_notice(
+            diagnostics,
+            is_admin=bool(user.is_superuser),
+        )
+
+    return templates.TemplateResponse(
+        request=request,
+        name="index.html",
+        context={"startup_notice": startup_notice},
+    )
 
 
 @router.get("/reader/{comic_id}", response_class=HTMLResponse, name="reader")

--- a/app/services/startup_diagnostics.py
+++ b/app/services/startup_diagnostics.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
 from sqlalchemy import text
@@ -11,6 +12,13 @@ from app.models.user import User
 
 
 logger = logging.getLogger("app.startup")
+
+STARTUP_STATUS_HEALTHY = "healthy"
+STARTUP_STATUS_FRESH_INSTALL = "fresh_install"
+STARTUP_STATUS_EMPTY_DATABASE = "empty_database"
+STARTUP_STATUS_STORAGE_MISMATCH = "storage_mismatch_suspected"
+RUNTIME_MODE_CONTAINER = "container_like"
+RUNTIME_MODE_LOCAL = "local_filesystem"
 
 
 def resolve_sqlite_db_path(database_url: str) -> Path | None:
@@ -61,12 +69,97 @@ def _safe_alembic_version(db: Session) -> str | None:
     return row[0]
 
 
-def log_startup_diagnostics(
+def _looks_like_container_library_path(path: str) -> bool:
+    normalized = path.replace("\\", "/").lower()
+    return normalized == "/comics" or normalized.startswith("/comics/")
+
+
+def _detect_runtime_mode(
+    comics_root: Path,
+    *,
+    comics_root_exists: bool,
+    library_sample: list[dict],
+) -> str:
+    if comics_root.as_posix() != "/comics":
+        return RUNTIME_MODE_LOCAL
+
+    if comics_root_exists:
+        return RUNTIME_MODE_CONTAINER
+
+    if any(_looks_like_container_library_path(item.get("path", "")) for item in library_sample):
+        return RUNTIME_MODE_CONTAINER
+
+    return RUNTIME_MODE_LOCAL
+
+
+def _classify_startup_status(
+    *,
+    users_count: int,
+    libraries_count: int,
+    series_count: int,
+    comics_count: int,
+    default_admin_present: bool,
+    comics_root_sample: list[str],
+) -> str:
+    if libraries_count == 0 and series_count == 0 and comics_count == 0:
+        if default_admin_present and comics_root_sample:
+            return STARTUP_STATUS_STORAGE_MISMATCH
+        if default_admin_present:
+            return STARTUP_STATUS_FRESH_INSTALL
+        return STARTUP_STATUS_EMPTY_DATABASE
+
+    return STARTUP_STATUS_HEALTHY
+
+
+def _status_title(status: str) -> str:
+    if status == STARTUP_STATUS_STORAGE_MISMATCH:
+        return "Storage Mismatch Suspected"
+    if status == STARTUP_STATUS_FRESH_INSTALL:
+        return "Fresh Install State"
+    if status == STARTUP_STATUS_EMPTY_DATABASE:
+        return "Empty Database"
+    return "Healthy"
+
+
+def _status_summary(status: str, comics_root: str) -> str:
+    if status == STARTUP_STATUS_STORAGE_MISMATCH:
+        return (
+            f"Parker can see entries under {comics_root}, but the active database has no libraries configured. "
+            "This usually means the server started against a different or newly initialized /app/storage directory."
+        )
+    if status == STARTUP_STATUS_FRESH_INSTALL:
+        return (
+            "Parker appears to be running with the default admin account and an empty database. "
+            "This is expected on a brand new install."
+        )
+    if status == STARTUP_STATUS_EMPTY_DATABASE:
+        return (
+            "Parker is running with an empty database, but the usual default-admin fingerprint was not detected."
+        )
+    return "Parker found existing content or configuration in the active database."
+
+
+def _build_recommended_actions(status: str) -> list[str]:
+    if status == STARTUP_STATUS_STORAGE_MISMATCH:
+        return [
+            "Verify that /app/storage points to the same host folder or volume used before the upgrade.",
+            "Compare the active comics.db file with the previous deployment and confirm the expected libraries exist there.",
+            "If this was an upgrade, avoid adding new libraries until the original storage path has been verified.",
+        ]
+    if status in {STARTUP_STATUS_FRESH_INSTALL, STARTUP_STATUS_EMPTY_DATABASE}:
+        return [
+            "If this is a brand new server, continue with normal setup.",
+            "If this is unexpected, verify the /app/storage bind mount or Docker volume before making changes.",
+        ]
+    return []
+
+
+def collect_startup_diagnostics(
     db: Session,
     *,
     database_url: str,
     comics_root: Path = Path("/comics"),
-) -> None:
+) -> dict:
     db_path = resolve_sqlite_db_path(database_url)
     db_exists = bool(db_path and db_path.exists())
     db_size = _safe_file_size(db_path)
@@ -92,43 +185,152 @@ def log_startup_diagnostics(
     comics_root_exists = comics_root.exists()
     comics_root_sample = _sample_directory(comics_root)
     alembic_version = _safe_alembic_version(db)
+    runtime_mode = _detect_runtime_mode(
+        comics_root,
+        comics_root_exists=comics_root_exists,
+        library_sample=library_sample,
+    )
+
+    status = _classify_startup_status(
+        users_count=users_count,
+        libraries_count=libraries_count,
+        series_count=series_count,
+        comics_count=comics_count,
+        default_admin_present=default_admin_present,
+        comics_root_sample=comics_root_sample,
+    )
+
+    return {
+        "status": status,
+        "status_title": _status_title(status),
+        "status_summary": _status_summary(status, str(comics_root)),
+        "is_suspicious": status == STARTUP_STATUS_STORAGE_MISMATCH,
+        "database": {
+            "url": database_url,
+            "path": str(db_path.resolve(strict=False)) if db_path else None,
+            "exists": db_exists,
+            "size_bytes": db_size,
+            "wal_size_bytes": wal_size,
+            "shm_size_bytes": shm_size,
+            "alembic_version": alembic_version,
+        },
+        "counts": {
+            "users": users_count,
+            "libraries": libraries_count,
+            "series": series_count,
+            "comics": comics_count,
+        },
+        "default_admin_present": default_admin_present,
+        "library_sample": library_sample,
+        "runtime": {
+            "mode": runtime_mode,
+            "label": "Container-like" if runtime_mode == RUNTIME_MODE_CONTAINER else "Local filesystem",
+        },
+        "comics_root": {
+            "path": str(comics_root),
+            "exists": comics_root_exists,
+            "sample": comics_root_sample,
+        },
+        "recommended_actions": _build_recommended_actions(status),
+    }
+
+
+def build_home_startup_notice(diagnostics: dict, *, is_admin: bool) -> dict | None:
+    status = diagnostics.get("status")
+    if status == STARTUP_STATUS_HEALTHY:
+        return None
+
+    if status == STARTUP_STATUS_STORAGE_MISMATCH:
+        return {
+            "status": status,
+            "title": diagnostics["status_title"],
+            "summary": diagnostics["status_summary"],
+            "is_suspicious": True,
+            "is_admin": is_admin,
+            "recommended_actions": diagnostics["recommended_actions"],
+            "diagnostics_url": "/admin/diagnostics" if is_admin else None,
+        }
+
+    return None
+
+
+def build_support_snapshot(
+    diagnostics: dict,
+    *,
+    app_version: str,
+    generated_at: datetime | None = None,
+) -> dict:
+    timestamp = generated_at or datetime.now(timezone.utc)
+
+    return {
+        "snapshot_type": "parker_startup_diagnostics",
+        "schema_version": 1,
+        "generated_at_utc": timestamp.isoformat(),
+        "app_version": app_version,
+        "status": {
+            "code": diagnostics["status"],
+            "title": diagnostics["status_title"],
+            "summary": diagnostics["status_summary"],
+            "is_suspicious": diagnostics["is_suspicious"],
+        },
+        "runtime": diagnostics["runtime"],
+        "database": diagnostics["database"],
+        "counts": diagnostics["counts"],
+        "default_admin_present": diagnostics["default_admin_present"],
+        "configured_library_sample": diagnostics["library_sample"],
+        "comics_probe": diagnostics["comics_root"],
+        "recommended_actions": diagnostics["recommended_actions"],
+    }
+
+
+def log_startup_diagnostics(
+    db: Session,
+    *,
+    database_url: str,
+    comics_root: Path = Path("/comics"),
+) -> None:
+    diagnostics = collect_startup_diagnostics(
+        db,
+        database_url=database_url,
+        comics_root=comics_root,
+    )
+
+    database = diagnostics["database"]
+    counts = diagnostics["counts"]
+    comics_root_info = diagnostics["comics_root"]
 
     logger.info(
         "Startup storage diagnostic: database_url=%s db_path=%s exists=%s size_bytes=%s wal_size_bytes=%s shm_size_bytes=%s alembic_version=%s",
-        database_url,
-        str(db_path.resolve(strict=False)) if db_path else None,
-        db_exists,
-        db_size,
-        wal_size,
-        shm_size,
-        alembic_version,
+        database["url"],
+        database["path"],
+        database["exists"],
+        database["size_bytes"],
+        database["wal_size_bytes"],
+        database["shm_size_bytes"],
+        database["alembic_version"],
     )
     logger.info(
-        "Startup storage diagnostic: counts users=%s libraries=%s series=%s comics=%s default_admin_present=%s library_sample=%s comics_root=%s comics_root_exists=%s comics_root_sample=%s",
-        users_count,
-        libraries_count,
-        series_count,
-        comics_count,
-        default_admin_present,
-        library_sample,
-        str(comics_root),
-        comics_root_exists,
-        comics_root_sample,
+        "Startup storage diagnostic: status=%s counts users=%s libraries=%s series=%s comics=%s default_admin_present=%s library_sample=%s comics_root=%s comics_root_exists=%s comics_root_sample=%s",
+        diagnostics["status"],
+        counts["users"],
+        counts["libraries"],
+        counts["series"],
+        counts["comics"],
+        diagnostics["default_admin_present"],
+        diagnostics["library_sample"],
+        comics_root_info["path"],
+        comics_root_info["exists"],
+        comics_root_info["sample"],
     )
 
-    if (
-        libraries_count == 0
-        and series_count == 0
-        and comics_count == 0
-        and default_admin_present
-    ):
+    if diagnostics["status"] in {STARTUP_STATUS_FRESH_INSTALL, STARTUP_STATUS_EMPTY_DATABASE}:
         logger.warning(
-            "Startup storage diagnostic: Parker is running with an effectively empty database. If this is unexpected after an upgrade, verify that /app/storage points to the same host folder or volume as before."
+            "Startup storage diagnostic: %s",
+            diagnostics["status_summary"],
         )
 
-    if libraries_count == 0 and comics_root_sample:
+    if diagnostics["status"] == STARTUP_STATUS_STORAGE_MISMATCH:
         logger.warning(
-            "Startup storage diagnostic: the comics mount at %s has visible top-level entries %s, but the database has no libraries configured. Parker does not auto-create libraries from the comics mount, so this often indicates a fresh or different /app/storage directory.",
-            str(comics_root),
-            comics_root_sample,
+            "Startup storage diagnostic: %s",
+            diagnostics["status_summary"],
         )

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -78,6 +78,17 @@
             <p class="text-sm text-gray-400">View library size, issue counts, and server usage metrics.</p>
         </a>
 
+        <a :href="window.parker.route('admin.diagnostics')" class="block bg-gray-800 hover:bg-gray-750 border border-gray-700 hover:border-amber-500 rounded-lg p-6 transition-all group shadow-lg">
+            <div class="flex items-center justify-between mb-4">
+                <div class="w-12 h-12 bg-amber-900/30 rounded-lg flex items-center justify-center text-2xl group-hover:scale-110 transition-transform">
+                    🔬
+                </div>
+                <span class="text-gray-500 group-hover:text-amber-400 transition-colors">→</span>
+            </div>
+            <h3 class="text-xl font-bold text-white mb-2">Diagnostics</h3>
+            <p class="text-sm text-gray-400">Inspect the active database, startup state, and comics mount when troubleshooting.</p>
+        </a>
+
         <a :href="window.parker.route('admin.reports')" class="block bg-gray-800 hover:bg-gray-750 border border-gray-700 hover:border-teal-500 rounded-lg p-6 transition-all group shadow-lg">
             <div class="flex items-center justify-between mb-4">
                 <div class="w-12 h-12 bg-teal-900/30 rounded-lg flex items-center justify-center text-2xl group-hover:scale-110 transition-transform">

--- a/app/templates/admin/diagnostics.html
+++ b/app/templates/admin/diagnostics.html
@@ -1,0 +1,228 @@
+{% extends "base.html" %}
+
+{% block title %}Startup Diagnostics - Parker{% endblock %}
+
+{% block content %}
+<div class="max-w-5xl mx-auto space-y-8">
+    {% from "partials/admin_header.html" import admin_header %}
+    {{ admin_header(
+        title="Startup Diagnostics",
+        description="Inspect the active storage and startup state Parker is using right now."
+    ) }}
+
+    <div class="rounded-2xl border border-gray-700 bg-gray-800/60 p-6 shadow-xl space-y-4">
+        <div class="flex flex-wrap items-center gap-3">
+            <span class="text-xs font-bold uppercase tracking-[0.25em] text-gray-400">Status</span>
+            <span class="inline-flex rounded-full border px-3 py-1 text-sm font-bold
+                {% if diagnostics.status == 'healthy' %}border-emerald-500/40 bg-emerald-500/10 text-emerald-200
+                {% elif diagnostics.status == 'storage_mismatch_suspected' %}border-amber-500/40 bg-amber-500/10 text-amber-200
+                {% else %}border-blue-500/40 bg-blue-500/10 text-blue-200{% endif %}">
+                {{ diagnostics.status_title }}
+            </span>
+        </div>
+        <p class="text-gray-300 leading-relaxed">{{ diagnostics.status_summary }}</p>
+
+        {% if diagnostics.recommended_actions %}
+        <div class="space-y-2">
+            <h2 class="text-sm font-bold uppercase tracking-[0.2em] text-gray-400">Recommended Actions</h2>
+            <ul class="space-y-2 text-sm text-gray-300">
+                {% for action in diagnostics.recommended_actions %}
+                <li class="rounded-lg border border-gray-700 bg-gray-900/40 px-4 py-3">{{ action }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+        <section class="rounded-2xl border border-gray-700 bg-gray-800/60 p-6 shadow-xl space-y-4">
+            <h2 class="text-lg font-bold text-white">Database</h2>
+            <dl class="space-y-3 text-sm">
+                <div>
+                    <dt class="text-gray-500 uppercase tracking-[0.2em] text-xs">Runtime</dt>
+                    <dd class="text-gray-200">{{ diagnostics.runtime.label }}</dd>
+                </div>
+                <div>
+                    <dt class="text-gray-500 uppercase tracking-[0.2em] text-xs">URL</dt>
+                    <dd class="text-gray-200 break-all">{{ diagnostics.database.url }}</dd>
+                </div>
+                <div>
+                    <dt class="text-gray-500 uppercase tracking-[0.2em] text-xs">Path</dt>
+                    <dd class="text-gray-200 break-all">{{ diagnostics.database.path }}</dd>
+                </div>
+                <div class="grid grid-cols-2 gap-3">
+                    <div>
+                        <dt class="text-gray-500 uppercase tracking-[0.2em] text-xs">DB Size</dt>
+                        <dd class="text-gray-200">{{ diagnostics.database.size_bytes }}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-gray-500 uppercase tracking-[0.2em] text-xs">Alembic</dt>
+                        <dd class="text-gray-200">{{ diagnostics.database.alembic_version }}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-gray-500 uppercase tracking-[0.2em] text-xs">WAL Size</dt>
+                        <dd class="text-gray-200">{{ diagnostics.database.wal_size_bytes }}</dd>
+                    </div>
+                    <div>
+                        <dt class="text-gray-500 uppercase tracking-[0.2em] text-xs">SHM Size</dt>
+                        <dd class="text-gray-200">{{ diagnostics.database.shm_size_bytes }}</dd>
+                    </div>
+                </div>
+            </dl>
+        </section>
+
+        <section class="rounded-2xl border border-gray-700 bg-gray-800/60 p-6 shadow-xl space-y-4">
+            <h2 class="text-lg font-bold text-white">Counts</h2>
+            <div class="grid grid-cols-2 gap-4">
+                <div class="rounded-xl border border-gray-700 bg-gray-900/40 p-4">
+                    <div class="text-xs uppercase tracking-[0.2em] text-gray-500">Users</div>
+                    <div class="mt-2 text-3xl font-black text-white">{{ diagnostics.counts.users }}</div>
+                </div>
+                <div class="rounded-xl border border-gray-700 bg-gray-900/40 p-4">
+                    <div class="text-xs uppercase tracking-[0.2em] text-gray-500">Libraries</div>
+                    <div class="mt-2 text-3xl font-black text-white">{{ diagnostics.counts.libraries }}</div>
+                </div>
+                <div class="rounded-xl border border-gray-700 bg-gray-900/40 p-4">
+                    <div class="text-xs uppercase tracking-[0.2em] text-gray-500">Series</div>
+                    <div class="mt-2 text-3xl font-black text-white">{{ diagnostics.counts.series }}</div>
+                </div>
+                <div class="rounded-xl border border-gray-700 bg-gray-900/40 p-4">
+                    <div class="text-xs uppercase tracking-[0.2em] text-gray-500">Comics</div>
+                    <div class="mt-2 text-3xl font-black text-white">{{ diagnostics.counts.comics }}</div>
+                </div>
+            </div>
+            <p class="text-sm text-gray-400">
+                Default seeded admin present:
+                <span class="font-bold text-gray-200">{{ diagnostics.default_admin_present }}</span>
+            </p>
+        </section>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+        <section class="rounded-2xl border border-gray-700 bg-gray-800/60 p-6 shadow-xl space-y-4">
+            <h2 class="text-lg font-bold text-white">Configured Libraries</h2>
+            {% if diagnostics.library_sample %}
+            <ul class="space-y-3 text-sm text-gray-300">
+                {% for library in diagnostics.library_sample %}
+                <li class="rounded-lg border border-gray-700 bg-gray-900/40 px-4 py-3">
+                    <div class="font-bold text-white">{{ library.name }}</div>
+                    <div class="mt-1 break-all text-gray-400">{{ library.path }}</div>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="text-sm text-gray-400">No libraries are configured in the active database.</p>
+            {% endif %}
+        </section>
+
+        <section class="rounded-2xl border border-gray-700 bg-gray-800/60 p-6 shadow-xl space-y-4">
+            <h2 class="text-lg font-bold text-white">
+                {% if diagnostics.runtime.mode == 'container_like' %}
+                Container Comics Mount
+                {% else %}
+                Local Comics Probe
+                {% endif %}
+            </h2>
+            <p class="text-sm text-gray-300 break-all">{{ diagnostics.comics_root.path }}</p>
+            <p class="text-sm text-gray-400">Exists: {{ diagnostics.comics_root.exists }}</p>
+
+            {% if diagnostics.comics_root.sample %}
+            <ul class="space-y-2 text-sm text-gray-300">
+                {% for entry in diagnostics.comics_root.sample %}
+                <li class="rounded-lg border border-gray-700 bg-gray-900/40 px-4 py-3">{{ entry }}</li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            {% if diagnostics.runtime.mode == 'container_like' %}
+            <p class="text-sm text-gray-400">No sample entries were found in the container comics mount.</p>
+            {% else %}
+            <p class="text-sm text-gray-400">Not present in this runtime, which is normal for local or non-Docker setups using library paths outside `/comics`.</p>
+            {% endif %}
+            {% endif %}
+        </section>
+    </div>
+
+    <div x-data='supportSnapshotPanel({{ support_snapshot|tojson }})' class="rounded-2xl border border-gray-700 bg-gray-800/60 p-6 shadow-xl space-y-4">
+        <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div class="space-y-2">
+                <h2 class="text-lg font-bold text-white">Support Snapshot</h2>
+                <p class="text-sm text-gray-300">Copy or download a structured diagnostics bundle for issue reports and support requests.</p>
+            </div>
+            <div class="flex flex-wrap gap-3">
+                <button
+                    @click="copySnapshot()"
+                    class="rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm font-bold text-blue-200 transition-colors hover:border-blue-400/50 hover:bg-blue-500/20"
+                >
+                    Copy Support Snapshot
+                </button>
+                <button
+                    @click="downloadSnapshot()"
+                    class="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-2 text-sm font-bold text-emerald-200 transition-colors hover:border-emerald-400/50 hover:bg-emerald-500/20"
+                >
+                    Download JSON
+                </button>
+                <a
+                    :href="window.parker.route('stats.startup_support_snapshot')"
+                    class="rounded-lg border border-gray-600 bg-gray-900/40 px-4 py-2 text-sm font-bold text-gray-200 transition-colors hover:border-gray-500 hover:bg-gray-900/70"
+                >
+                    Open Raw JSON
+                </a>
+            </div>
+        </div>
+
+        <p class="text-xs uppercase tracking-[0.2em] text-gray-500" x-text="feedback"></p>
+
+        <div class="rounded-xl border border-gray-700 bg-gray-950/70 p-4">
+            <pre class="max-h-72 overflow-auto whitespace-pre-wrap break-words text-xs leading-6 text-gray-200" x-text="formattedSnapshot"></pre>
+        </div>
+    </div>
+</div>
+
+<script>
+function supportSnapshotPanel(snapshot) {
+    return {
+        snapshot,
+        feedback: 'Structured JSON payload for GitHub issues, Reddit replies, and direct support requests.',
+
+        get formattedSnapshot() {
+            return JSON.stringify(this.snapshot, null, 2);
+        },
+
+        async copySnapshot() {
+            const text = this.formattedSnapshot;
+            try {
+                await navigator.clipboard.writeText(text);
+                this.feedback = 'Support snapshot copied to clipboard.';
+                if (window.parker?.showToast) {
+                    window.parker.showToast('Support snapshot copied.', 'success');
+                }
+            } catch (error) {
+                this.feedback = 'Copy failed. You can still download the JSON below.';
+                if (window.parker?.showToast) {
+                    window.parker.showToast('Unable to copy support snapshot.', 'error');
+                }
+            }
+        },
+
+        downloadSnapshot() {
+            const blob = new Blob([this.formattedSnapshot], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const anchor = document.createElement('a');
+            const timestamp = (this.snapshot.generated_at_utc || 'snapshot')
+                .replace(/[:]/g, '-')
+                .replace(/\.\d+/, '')
+                .replace('+00:00', 'Z');
+
+            anchor.href = url;
+            anchor.download = `parker-support-snapshot-${timestamp}.json`;
+            document.body.appendChild(anchor);
+            anchor.click();
+            document.body.removeChild(anchor);
+            URL.revokeObjectURL(url);
+
+            this.feedback = 'Support snapshot downloaded as JSON.';
+        },
+    };
+}
+</script>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -3,9 +3,9 @@
 {% block title %}Home - Parker{% endblock %}
 
 {% block content %}
-<div class="space-y-12" x-data="homePage()">
+<div class="space-y-12" x-data='homePage({{ {"startupNotice": startup_notice}|tojson }})'>
 
-    <div x-show="!isLoading && !isLibraryEmpty" class="space-y-16 pb-12" x-cloak>
+    <div x-show="!isLoading && !showStartupNotice && !isLibraryEmpty" class="space-y-16 pb-12" x-cloak>
 
         <div x-show="!loading.resume && resumeComics.length > 0">
             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
@@ -173,7 +173,52 @@
 
     </div>
 
-    <template x-if="!isLoading && isLibraryEmpty">
+    <template x-if="!isLoading && showStartupNotice">
+        <div class="max-w-4xl mx-auto py-12 px-6">
+            <div class="bg-amber-950/30 border border-amber-500/30 rounded-2xl p-8 md:p-12 text-center space-y-8 shadow-2xl">
+                <div class="inline-flex items-center justify-center w-20 h-20 bg-amber-500/10 rounded-full mb-4">
+                    <span class="text-5xl">⚠</span>
+                </div>
+
+                <div class="space-y-3">
+                    <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight" x-text="startupNotice.title"></h1>
+                    <p class="text-amber-100/80 text-lg max-w-2xl mx-auto" x-text="startupNotice.summary"></p>
+                </div>
+
+                <div class="max-w-3xl mx-auto text-left space-y-3" x-show="startupNotice.recommended_actions?.length">
+                    <template x-for="action in startupNotice.recommended_actions" :key="action">
+                        <div class="rounded-xl border border-amber-500/20 bg-black/20 px-4 py-3 text-sm text-gray-200" x-text="action"></div>
+                    </template>
+                </div>
+
+                <div class="grid md:grid-cols-2 gap-6 text-left max-w-2xl mx-auto" x-show="startupNotice.is_admin">
+                    <a :href="startupNotice.diagnostics_url" class="group p-6 bg-gray-900/50 border border-amber-500/20 rounded-xl hover:border-amber-400/50 transition-all">
+                        <div class="flex items-start gap-4">
+                            <div class="text-2xl">🩺</div>
+                            <div>
+                                <h3 class="font-bold text-white group-hover:text-amber-200 transition-colors">Open Diagnostics</h3>
+                                <p class="text-sm text-gray-400 mt-1">Inspect the active database path, counts, and comics mount sample.</p>
+                            </div>
+                        </div>
+                    </a>
+
+                    <a :href="window.parker.url('/admin/libraries')" class="group p-6 bg-gray-900/50 border border-amber-500/20 rounded-xl hover:border-amber-400/50 transition-all">
+                        <div class="flex items-start gap-4">
+                            <div class="text-2xl">📁</div>
+                            <div>
+                                <h3 class="font-bold text-white group-hover:text-amber-200 transition-colors">Library Admin</h3>
+                                <p class="text-sm text-gray-400 mt-1">Avoid adding new libraries until you've verified the current storage path.</p>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+
+                <p class="text-xs text-amber-200/60 uppercase tracking-widest pt-4" x-show="!startupNotice.is_admin">Please contact your Parker administrator before changing anything.</p>
+            </div>
+        </div>
+    </template>
+
+    <template x-if="!isLoading && !showStartupNotice && isLibraryEmpty">
 
         <div class="max-w-4xl mx-auto py-12 px-6">
             <div class="bg-gray-800/50 border border-gray-700 rounded-2xl p-8 md:p-12 text-center space-y-8 shadow-2xl">
@@ -223,8 +268,9 @@
 </div>
 
 <script>
-function homePage() {
+function homePage(bootstrap = {}) {
     return {
+        startupNotice: bootstrap.startupNotice || null,
         recentSeries: [],
         updatedSeries: [],
         starredSeries: [],
@@ -264,7 +310,18 @@ function homePage() {
                 && this.starredSeries.length === 0;
         },
 
+        get showStartupNotice() {
+            return !!this.startupNotice;
+        },
+
         init() {
+            if (this.showStartupNotice) {
+                Object.keys(this.loading).forEach(key => {
+                    this.loading[key] = false;
+                });
+                return;
+            }
+
             this.fetchStarred();
             this.fetchRecent();
             this.fetchUpdated();

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -1,0 +1,57 @@
+def test_home_page_shows_storage_warning_for_admin_when_startup_looks_suspicious(admin_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.routers.pages.collect_startup_diagnostics",
+        lambda db, database_url: {
+            "status": "storage_mismatch_suspected",
+            "status_title": "Storage Mismatch Suspected",
+            "status_summary": "Parker can see comics but the database has no libraries configured.",
+            "recommended_actions": ["Verify /app/storage"],
+        },
+    )
+
+    response = admin_client.get("/")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Storage Mismatch Suspected" in body
+    assert "Open Diagnostics" in body
+    assert "storage_mismatch_suspected" in body
+
+
+def test_home_page_keeps_normal_onboarding_when_startup_state_is_healthy(admin_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.routers.pages.collect_startup_diagnostics",
+        lambda db, database_url: {
+            "status": "healthy",
+            "status_title": "Healthy",
+            "status_summary": "Healthy",
+            "recommended_actions": [],
+        },
+    )
+
+    response = admin_client.get("/")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Welcome to Parker!" in body
+    assert "storage_mismatch_suspected" not in body
+
+
+def test_admin_dashboard_links_to_diagnostics(admin_client):
+    response = admin_client.get("/admin")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Diagnostics" in body
+    assert "Inspect the active database" in body
+
+
+def test_admin_diagnostics_page_exposes_support_snapshot_actions(admin_client):
+    response = admin_client.get("/admin/diagnostics")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Copy Support Snapshot" in body
+    assert "Download JSON" in body
+    assert "Open Raw JSON" in body
+    assert "parker_startup_diagnostics" in body

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -19,11 +19,14 @@ def _create_series_volume(db, *, prefix: str, series_suffix: str):
 def test_stats_endpoints_require_admin(auth_client):
     system = auth_client.get("/api/stats/")
     genres = auth_client.get("/api/stats/genres")
+    startup = auth_client.get("/api/stats/startup")
 
     assert system.status_code == 400
     assert genres.status_code == 400
+    assert startup.status_code == 400
     assert "privileges" in system.json()["detail"].lower()
     assert "privileges" in genres.json()["detail"].lower()
+    assert "privileges" in startup.json()["detail"].lower()
 
 
 def test_system_stats_empty_defaults(admin_client):
@@ -40,6 +43,41 @@ def test_system_stats_empty_defaults(admin_client):
     }
     assert payload["storage"]["total_bytes"] == 0
     assert payload["activity"] == {"pages_read": 0, "completed_books": 0}
+
+
+def test_startup_diagnostics_endpoint_returns_collected_payload(admin_client, monkeypatch):
+    sentinel = {
+        "status": "storage_mismatch_suspected",
+        "status_title": "Storage Mismatch Suspected",
+        "status_summary": "Mismatch summary",
+        "is_suspicious": True,
+        "database": {"path": "/app/storage/database/comics.db"},
+        "counts": {"users": 1, "libraries": 0, "series": 0, "comics": 0},
+        "default_admin_present": True,
+        "library_sample": [],
+        "comics_root": {"path": "/comics", "exists": True, "sample": ["Marvel/"]},
+        "recommended_actions": ["Check storage"],
+    }
+
+    monkeypatch.setattr("app.api.stats.collect_startup_diagnostics", lambda db, database_url: sentinel)
+
+    response = admin_client.get("/api/stats/startup")
+
+    assert response.status_code == 200
+    assert response.json() == sentinel
+
+
+def test_startup_support_snapshot_endpoint_returns_structured_snapshot(admin_client, monkeypatch):
+    sentinel = {"status": "healthy"}
+    snapshot = {"snapshot_type": "parker_startup_diagnostics", "schema_version": 1}
+
+    monkeypatch.setattr("app.api.stats.collect_startup_diagnostics", lambda db, database_url: sentinel)
+    monkeypatch.setattr("app.api.stats.build_support_snapshot", lambda diagnostics, app_version: snapshot)
+
+    response = admin_client.get("/api/stats/startup/support-snapshot")
+
+    assert response.status_code == 200
+    assert response.json() == snapshot
 
 
 def test_system_stats_aggregates_counts_storage_and_activity(admin_client, db, admin_user):

--- a/tests/services/test_startup_diagnostics.py
+++ b/tests/services/test_startup_diagnostics.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 
 from app.models.comic import Comic, Volume
@@ -6,6 +7,13 @@ from app.models.library import Library
 from app.models.series import Series
 from app.models.user import User
 from app.services.startup_diagnostics import (
+    RUNTIME_MODE_CONTAINER,
+    RUNTIME_MODE_LOCAL,
+    STARTUP_STATUS_HEALTHY,
+    STARTUP_STATUS_STORAGE_MISMATCH,
+    build_home_startup_notice,
+    build_support_snapshot,
+    collect_startup_diagnostics,
     log_startup_diagnostics,
     resolve_sqlite_db_path,
 )
@@ -46,14 +54,12 @@ def test_log_startup_diagnostics_warns_for_effectively_empty_database(db, caplog
         comics_root=comics_root,
     )
 
-    assert any("counts users=1 libraries=0 series=0 comics=0" in record.message for record in caplog.records)
     assert any(
-        "effectively empty database" in record.message
+        "status=storage_mismatch_suspected counts users=1 libraries=0 series=0 comics=0" in record.message
         for record in caplog.records
-        if record.levelno == logging.WARNING
     )
     assert any(
-        "database has no libraries configured" in record.message
+        "active database has no libraries configured" in record.message
         for record in caplog.records
         if record.levelno == logging.WARNING
     )
@@ -92,10 +98,127 @@ def test_log_startup_diagnostics_logs_populated_database_summary(db, caplog, tmp
         comics_root=tmp_path / "comics",
     )
 
-    assert any("counts users=1 libraries=1 series=1 comics=1" in record.message for record in caplog.records)
+    assert any("status=healthy counts users=1 libraries=1 series=1 comics=1" in record.message for record in caplog.records)
     assert any("library_sample=[{'name': 'Main Library', 'path': '/comics/main'}]" in record.message for record in caplog.records)
     assert not any(
-        "effectively empty database" in record.message
+        "active database has no libraries configured" in record.message
         for record in caplog.records
         if record.levelno == logging.WARNING
     )
+
+
+def test_collect_startup_diagnostics_classifies_storage_mismatch(db, tmp_path):
+    db.add(
+        User(
+            username="admin",
+            email="admin@example.com",
+            hashed_password="fakehash",
+            is_superuser=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    db_path = tmp_path / "comics.db"
+    db_path.write_bytes(b"x" * 432)
+    comics_root = tmp_path / "comics"
+    comics_root.mkdir()
+    (comics_root / "DC").mkdir()
+
+    diagnostics = collect_startup_diagnostics(
+        db,
+        database_url=f"sqlite:///{db_path.as_posix()}",
+        comics_root=comics_root,
+    )
+
+    assert diagnostics["status"] == STARTUP_STATUS_STORAGE_MISMATCH
+    assert diagnostics["is_suspicious"] is True
+    assert diagnostics["recommended_actions"]
+    assert diagnostics["runtime"]["mode"] == RUNTIME_MODE_LOCAL
+
+
+def test_build_home_startup_notice_returns_admin_notice_for_storage_mismatch():
+    diagnostics = {
+        "status": STARTUP_STATUS_STORAGE_MISMATCH,
+        "status_title": "Storage Mismatch Suspected",
+        "status_summary": "Mismatch summary",
+        "recommended_actions": ["Check storage"],
+    }
+
+    notice = build_home_startup_notice(diagnostics, is_admin=True)
+
+    assert notice is not None
+    assert notice["diagnostics_url"] == "/admin/diagnostics"
+    assert notice["is_admin"] is True
+
+
+def test_build_home_startup_notice_ignores_healthy_state():
+    diagnostics = {
+        "status": STARTUP_STATUS_HEALTHY,
+        "status_title": "Healthy",
+        "status_summary": "Healthy summary",
+        "recommended_actions": [],
+    }
+
+    assert build_home_startup_notice(diagnostics, is_admin=True) is None
+
+
+def test_build_support_snapshot_wraps_diagnostics_with_metadata():
+    diagnostics = {
+        "status": "healthy",
+        "status_title": "Healthy",
+        "status_summary": "Everything looks good.",
+        "is_suspicious": False,
+        "runtime": {"mode": RUNTIME_MODE_LOCAL, "label": "Local filesystem"},
+        "database": {"path": "/tmp/comics.db"},
+        "counts": {"users": 1, "libraries": 2, "series": 3, "comics": 4},
+        "default_admin_present": True,
+        "library_sample": [{"name": "Main", "path": "C:/Comics"}],
+        "comics_root": {"path": "/comics", "exists": False, "sample": []},
+        "recommended_actions": [],
+    }
+
+    snapshot = build_support_snapshot(
+        diagnostics,
+        app_version="0.1.18",
+        generated_at=datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert snapshot["snapshot_type"] == "parker_startup_diagnostics"
+    assert snapshot["schema_version"] == 1
+    assert snapshot["generated_at_utc"] == "2026-07-13T12:00:00+00:00"
+    assert snapshot["app_version"] == "0.1.18"
+    assert snapshot["status"]["code"] == "healthy"
+    assert snapshot["configured_library_sample"] == [{"name": "Main", "path": "C:/Comics"}]
+
+
+def test_collect_startup_diagnostics_marks_default_comics_root_as_container_runtime(db, tmp_path):
+    library = Library(name="Container Library", path="/comics/main")
+    db.add(library)
+    db.commit()
+
+    db_path = tmp_path / "comics.db"
+    db_path.write_bytes(b"x" * 128)
+
+    diagnostics = collect_startup_diagnostics(
+        db,
+        database_url=f"sqlite:///{db_path.as_posix()}",
+    )
+
+    assert diagnostics["runtime"]["mode"] == RUNTIME_MODE_CONTAINER
+
+
+def test_collect_startup_diagnostics_marks_missing_default_comics_root_as_local_when_library_paths_are_local(db, tmp_path):
+    library = Library(name="Local Library", path="C:/Users/test/MyComics")
+    db.add(library)
+    db.commit()
+
+    db_path = tmp_path / "comics.db"
+    db_path.write_bytes(b"x" * 128)
+
+    diagnostics = collect_startup_diagnostics(
+        db,
+        database_url=f"sqlite:///{db_path.as_posix()}",
+    )
+
+    assert diagnostics["runtime"]["mode"] == RUNTIME_MODE_LOCAL


### PR DESCRIPTION
Adds a startup diagnostics and support workflow for suspicious empty-state issues, especially cases where Parker starts successfully but appears to have “lost” libraries because it is reading a different or newly initialized storage directory.

What Changed
- Added startup storage diagnostics logging
   - logs DB path, DB/WAL/SHM sizes, alembic version, object counts, library samples, and comics-path samples
   - warns when Parker appears freshly initialized or when /comics content is visible but the DB has no libraries

- Added a shared startup-state classifier
   - classifies states like healthy, fresh_install, empty_database, and storage_mismatch_suspected
   - reused across logs, API responses, and UI

- Added admin diagnostics surfaces
   - new admin diagnostics page
   - new admin dashboard card linking to it
   - new diagnostics API endpoints:
      - /api/stats/startup
      - /api/stats/startup/support-snapshot

- Improved the home page empty-state behavior
   - when startup looks suspicious, admins now see a warning page instead of the generic onboarding experience
   - warning points them to diagnostics instead of encouraging immediate reconfiguration

- Added a support snapshot workflow
   - copy-to-clipboard support snapshot
   - downloadable JSON support snapshot
   - raw JSON endpoint for support cases
   - structured payload includes status, runtime mode, DB details, counts, library sample, comics probe, and recommended actions

- Made diagnostics runtime-aware
   - distinguishes container-like vs local filesystem runs
   - avoids misleading “Container Comics Mount” messaging in local/non-Docker setups

Why

This is aimed at reducing ambiguity during upgrade/support incidents. The goal is to make “wrong/new storage directory” problems obvious in both logs and UI, and to give users a single artifact they can share instead of requiring manual environment reconstruction.


