### PR TITLE
Prepare Parker 0.1.19 with settings, branding, and search polish

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,3 +19,8 @@ This file captures follow-up work that should not get lost between releases.
   Key request/runtime settings that commonly affect support cases (`base_url`, selected proxy-related settings, maybe a few safe env-derived values).
   Light filesystem health checks for storage/cache/cover directories.
   Guardrails: Avoid secrets, tokens, full env dumps, or overly large payloads.
+
+- Revisit the startup diagnostics mismatch heuristic for true first-run versus rebuilt-storage scenarios.
+  Context: The current warning logic is much more useful than before, but we lost the original reporter's environment after they rebuilt from scratch, so we no longer have a live repro to interrogate.
+  Current risk: A fresh install with a valid comics mount and no configured libraries can still look superficially similar to a "wrong storage directory" situation.
+  Follow-up goal: Reassess the signals used for `storage_mismatch_suspected` once we have another real-world report or a better synthetic repro, and tune the messaging so first-run onboarding is not mistaken for a broken upgrade.

--- a/app/api/comics.py
+++ b/app/api/comics.py
@@ -25,6 +25,7 @@ from app.models.interactions import UserComicRating
 from app.schemas.search import SearchRequest, SearchResponse
 from app.services.search import SearchService
 from app.services.comic_ratings import build_parker_rating_state
+from app.services.social_insights import get_visible_comic_reader_count
 
 
 
@@ -65,6 +66,17 @@ def _ensure_user_can_view_comic(current_user: CurrentUser, comic: Comic):
         if not current_user.allow_unknown_age_ratings:
             if not comic.age_rating or comic.age_rating == "" or comic.age_rating.lower() == "unknown":
                 raise HTTPException(status_code=403, detail="Content restricted by age rating")
+
+
+def _get_web_link_presentation(web_url: str | None) -> tuple[str | None, str | None]:
+    """Returns the label and tooltip copy for a comic metadata web link."""
+    if not web_url:
+        return None, None
+
+    if "comicvine" in web_url.lower():
+        return "ComicVine", "View on ComicVine"
+
+    return "Web Link", "Open web link"
 
 @router.post("/search", response_model=SearchResponse, name="search")
 async def search_comics(request: SearchRequest, db: SessionDep, current_user: CurrentUser):
@@ -152,6 +164,9 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
         read_status = "in_progress"
 
     parker_rating = build_parker_rating_state(db, comic.id, current_user.id)
+    parker_readers_count = get_visible_comic_reader_count(db, comic.id)
+
+    web_label, web_title = _get_web_link_presentation(comic.web)
 
     return {
         "id": comic.id,
@@ -172,6 +187,8 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
         "title": comic.title,
         "summary": comic.summary,
         "web": comic.web,
+        "web_label": web_label,
+        "web_title": web_title,
         "notes": comic.notes,
 
         # Date
@@ -222,6 +239,9 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
 
         # Parker rating
         **parker_rating,
+
+        # Parker social activity
+        "parker_readers_count": parker_readers_count,
     }
 
 

--- a/app/api/series.py
+++ b/app/api/series.py
@@ -24,6 +24,7 @@ from app.models.tags import Character, Team, Location, Genre, comic_genres
 from app.models.interactions import UserSeries
 from app.models.reading_progress import ReadingProgress
 
+from app.services.social_insights import get_visible_series_reader_count
 from app.services.thumbnailer import ThumbnailService
 
 router = APIRouter()
@@ -168,7 +169,8 @@ async def get_series_detail(series: SeriesDep, db: SessionDep, current_user: Cur
         # (Return empty structure - kept same as original)
         return {
             "id": series.id, "name": series.name, "library_id": series.library_id,
-            "volume_count": 0, "total_issues": 0, "volumes": [], "collections": [], "reading_lists": [], "details": {}
+            "volume_count": 0, "total_issues": 0, "volumes": [], "collections": [], "reading_lists": [], "details": {},
+            "parker_readers_count": None,
         }
 
     # Get centralized filters
@@ -396,6 +398,8 @@ async def get_series_detail(series: SeriesDep, db: SessionDep, current_user: Cur
                                            UserSeries.series_id == series.id).first()
         is_starred = pref.is_starred if pref else False
 
+    parker_readers_count = get_visible_series_reader_count(db, series.id)
+
     return {
         "id": series.id,
         "name": series.name,
@@ -425,6 +429,7 @@ async def get_series_detail(series: SeriesDep, db: SessionDep, current_user: Cur
         "is_admin": current_user.is_superuser,
         "is_reverse_numbering": is_reverse_series,
         "thumbnail_hash": get_thumbnail_hash(first_issue.updated_at),
+        "parker_readers_count": parker_readers_count,
     }
 
 

--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, Depends
 from typing import Dict, List, Any, Optional
 from app.api.deps import SessionDep, AdminUser, CurrentUser, get_current_user_optional
-from app.services.settings_service import SettingsService
+from app.services.settings_service import SettingsService, SettingValidationError
 from app.core.settings_loader import get_cached_setting
 from app.services.scheduler import scheduler_service
 from app.schemas.setting import SettingUpdate, SettingResponse
@@ -58,5 +58,7 @@ def update_setting(key: str, payload: SettingUpdate, db: SessionDep, admin: Admi
 
         return setting
 
+    except SettingValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
     except ValueError:
         raise HTTPException(status_code=404, detail="Setting not found")

--- a/app/config.py
+++ b/app/config.py
@@ -11,7 +11,7 @@ def _split_comma_list(value: str) -> list[str]:
 
 class Settings(BaseSettings):
     app_name: ClassVar[str] = "Parker"
-    version: ClassVar[str] = "0.1.18"
+    version: ClassVar[str] = "0.1.19"
     
     database_url: str = "sqlite:///./storage/database/comics.db"
     #database_url: str = "sqlite:///./storage/database/temp.db"

--- a/app/services/settings_service.py
+++ b/app/services/settings_service.py
@@ -7,6 +7,12 @@ from app.api.deps import SessionDep
 from app.core.settings_loader import invalidate_settings_cache
 from app.core.login_backgrounds import SOLID_COLORS, STATIC_COVERS
 
+SERVER_DISPLAY_NAME_MAX_LENGTH = 32
+
+
+class SettingValidationError(ValueError):
+    """Raised when a setting value is syntactically invalid."""
+
 
 def generate_worker_options():
     """Generate CPU worker options based on available cores"""
@@ -55,9 +61,9 @@ class SettingsService:
     DEFAULTS = [
         {
             "key": "general.app_name", "value": "Parker Comic Server",
-            "description": "Add a prefix to the server name",
+            "description": f"Display name shown across the server UI. Parker branding remains visible. Max {SERVER_DISPLAY_NAME_MAX_LENGTH} characters.",
             "category": "general", "data_type": "string",
-            "label": "Application Name"
+            "label": "Server Display Name"
         },
         {
             "key": "scanning.batch_window", "value": "600",
@@ -319,7 +325,14 @@ class SettingsService:
         if setting.data_type == "bool":
             setting.value = str(value).lower()  # "true"/"false"
         else:
-            setting.value = str(value)
+            normalized_value = str(value).strip()
+
+            if key == "general.app_name" and len(normalized_value) > SERVER_DISPLAY_NAME_MAX_LENGTH:
+                raise SettingValidationError(
+                    f"Server display name must be {SERVER_DISPLAY_NAME_MAX_LENGTH} characters or fewer"
+                )
+
+            setting.value = normalized_value
 
         self.db.commit()
         self.db.refresh(setting)

--- a/app/services/social_insights.py
+++ b/app/services/social_insights.py
@@ -1,0 +1,54 @@
+from sqlalchemy import func, or_
+from sqlalchemy.orm import Session
+
+from app.models.comic import Comic, Volume
+from app.models.reading_progress import ReadingProgress
+from app.models.user import User
+
+
+MIN_VISIBLE_SOCIAL_COUNT = 2
+
+
+def _visible_count(count: int) -> int | None:
+    return count if count >= MIN_VISIBLE_SOCIAL_COUNT else None
+
+
+def get_visible_comic_reader_count(db: Session, comic_id: int) -> int | None:
+    """
+    Return the number of opted-in Parker users who completed this comic.
+    Counts below the public threshold are suppressed.
+    """
+    count = (
+        db.query(func.count(func.distinct(ReadingProgress.user_id)))
+        .select_from(ReadingProgress)
+        .join(User, User.id == ReadingProgress.user_id)
+        .filter(ReadingProgress.comic_id == comic_id)
+        .filter(ReadingProgress.completed == True)
+        .filter(User.share_progress_enabled == True)
+        .scalar()
+        or 0
+    )
+
+    return _visible_count(count)
+
+
+def get_visible_series_reader_count(db: Session, series_id: int) -> int | None:
+    """
+    Return the number of opted-in Parker users who are reading or have read
+    at least one issue in the series. Counts below the public threshold are
+    suppressed.
+    """
+    count = (
+        db.query(func.count(func.distinct(ReadingProgress.user_id)))
+        .select_from(ReadingProgress)
+        .join(User, User.id == ReadingProgress.user_id)
+        .join(Comic, Comic.id == ReadingProgress.comic_id)
+        .join(Volume, Volume.id == Comic.volume_id)
+        .filter(Volume.series_id == series_id)
+        .filter(or_(ReadingProgress.completed == True, ReadingProgress.current_page > 0))
+        .filter(User.share_progress_enabled == True)
+        .scalar()
+        or 0
+    )
+
+    return _visible_count(count)

--- a/app/templates/admin/about.html
+++ b/app/templates/admin/about.html
@@ -3,6 +3,8 @@
 {% block title %}About - Parker{% endblock %}
 
 {% block content %}
+{% set configured_instance_name = (get_system_setting("general.app_name", "Parker Comic Server") or "")|trim %}
+{% set instance_name = configured_instance_name or "Parker Comic Server" %}
 <div class="max-w-4xl mx-auto">
 
     {% from "partials/admin_header.html" import admin_header %}
@@ -15,7 +17,8 @@
         
         <div class="p-8 text-center border-b border-gray-700 bg-gray-900/50">
             <div class="text-6xl mb-4">🕷️</div>
-            <h1 class="text-3xl font-bold text-white mb-2">Parker</h1>
+            <h1 class="text-3xl font-bold text-white mb-2">{{ instance_name }}</h1>
+            <p class="text-sm uppercase tracking-[0.24em] text-gray-500 mb-2">Powered by Parker</p>
             <p class="text-blue-400 font-mono">v{{ app_version }}</p>
         </div>
 

--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -9,74 +9,180 @@
         description="Adjust Parker application settings."
     ) }}
 
-    <template x-for="(groupSettings, category) in settings" :key="category">
-        <div class="mb-8 bg-gray-800 rounded-lg p-6 border border-gray-700">
-            <h2 class="text-xl font-bold text-blue-400 capitalize mb-4" x-text="category"></h2>
-            
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <template x-for="setting in groupSettings" :key="setting.key">
+    <div class="mb-6 rounded-2xl border border-blue-500/20 bg-gradient-to-br from-blue-950/40 via-gray-900 to-gray-900 p-5 shadow-lg">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div class="max-w-2xl">
+                <div class="text-[11px] uppercase tracking-[0.24em] text-blue-300/80 font-bold">Settings Overview</div>
+                <h2 class="mt-2 text-2xl font-bold text-white">Browse by category</h2>
+                <p class="mt-2 text-sm text-gray-300">
+                    Jump to a section or collapse categories to focus on the settings you need.
+                </p>
+            </div>
 
-                    <!-- Only show if no dependency, or if dependency is satisfied -->
-                    <div x-show="!setting.depends_on || isDependent(setting)" class="bg-gray-900 p-4 rounded border border-gray-700">
-                        <label class="block text-sm font-medium text-gray-400 mb-1" x-text="setting.label"></label>
+            <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <div class="rounded-xl border border-gray-700 bg-black/20 px-4 py-3">
+                    <div class="text-[10px] uppercase tracking-[0.2em] text-gray-500">Categories</div>
+                    <div class="mt-1 text-xl font-bold text-white" x-text="categoryList.length"></div>
+                </div>
+                <div class="rounded-xl border border-gray-700 bg-black/20 px-4 py-3">
+                    <div class="text-[10px] uppercase tracking-[0.2em] text-gray-500">Available Settings</div>
+                    <div class="mt-1 text-xl font-bold text-white" x-text="availableSettingTotal()"></div>
+                </div>
+                <button
+                    type="button"
+                    class="rounded-xl border border-gray-700 bg-gray-800/80 px-4 py-3 text-left transition-colors hover:border-blue-400/40 hover:bg-gray-800"
+                    x-on:click="expandAll()"
+                >
+                    <div class="text-[10px] uppercase tracking-[0.2em] text-gray-500">View</div>
+                    <div class="mt-1 text-sm font-semibold text-white">Expand All</div>
+                </button>
+                <button
+                    type="button"
+                    class="rounded-xl border border-gray-700 bg-gray-800/80 px-4 py-3 text-left transition-colors hover:border-blue-400/40 hover:bg-gray-800"
+                    x-on:click="collapseAll()"
+                >
+                    <div class="text-[10px] uppercase tracking-[0.2em] text-gray-500">View</div>
+                    <div class="mt-1 text-sm font-semibold text-white">Collapse All</div>
+                </button>
+            </div>
+        </div>
+    </div>
 
-                        <template x-if="setting.data_type === 'bool'">
-                            <div class="flex items-center mt-2">
-                                <button 
-                                    x-on:click="update(setting, !setting.value)"
-                                    class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
-                                    :class="setting.value ? 'bg-blue-600' : 'bg-gray-700'"
-                                >
-                                    <span 
-                                        class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                                        :class="setting.value ? 'translate-x-5' : 'translate-x-0'"
-                                    ></span>
-                                </button>
-                                <span class="ml-3 text-sm text-gray-300" x-text="setting.value ? 'Enabled' : 'Disabled'"></span>
-                            </div>
-                        </template>
-
-                        <template x-if="setting.data_type === 'select'">
-                            <div class="flex gap-2">
-                                <select
-                                    x-model="setting.tempValue"
-                                    x-on:change="update(setting, $event.target.value)"
-                                    class="bg-gray-800 text-white px-3 py-2 rounded w-full border border-gray-600 focus:border-blue-500 focus:outline-none appearance-none"
-                                >
-                                    <template x-for="opt in getGroupedOptions(setting.options).orphans" :key="opt.value">
-                                        <option :value="opt.value" x-text="opt.label" :selected="opt.value == setting.value"></option>
-                                    </template>
-
-                                    <template x-for="groupName in getGroupedOptions(setting.options).groupOrder" :key="groupName">
-                                        <optgroup :label="groupName">
-                                            <template x-for="opt in getGroupedOptions(setting.options).groups[groupName]" :key="opt.value">
-                                                <option :value="opt.value" x-text="opt.label" :selected="opt.value == setting.value"></option>
-                                            </template>
-                                        </optgroup>
-                                    </template>
-                                </select>
-                                </div>
-                        </template>
-
-                        <template x-if="setting.data_type !== 'bool' && setting.data_type !== 'select'">
-                            <div class="flex gap-2">
-                                <input
-                                    :type="setting.data_type === 'int' ? 'number' : 'text'" 
-                                    x-model="setting.tempValue" 
-                                    x-on:focus="setting.tempValue = setting.value"
-                                    class="bg-gray-800 text-white px-3 py-2 rounded w-full border border-gray-600 focus:border-blue-500 focus:outline-none"
-                                >
-                                <button 
-                                    x-on:click="update(setting, setting.tempValue)"
-                                    class="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded text-sm"
-                                >Save</button>
-                            </div>
-                        </template>
-                        
-                        <p class="text-xs text-gray-500 mt-2" x-text="setting.description"></p>
-                    </div>
+    <div class="mb-6 rounded-2xl border border-gray-800 bg-gray-900/70 p-4 shadow-lg backdrop-blur">
+        <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+                <div class="text-[11px] uppercase tracking-[0.24em] text-gray-500 font-bold">Jump To</div>
+                <p class="mt-1 text-sm text-gray-400">Quick links to each settings category.</p>
+            </div>
+            <div class="flex gap-2 overflow-x-auto pb-1 lg:justify-end">
+                <template x-for="category in categoryList" :key="category">
+                    <button
+                        type="button"
+                        class="whitespace-nowrap rounded-full border px-3 py-2 text-sm transition-colors"
+                        :class="isSectionOpen(category) ? 'border-blue-500/40 bg-blue-500/10 text-blue-200' : 'border-gray-700 bg-gray-800/80 text-gray-300 hover:border-gray-500 hover:text-white'"
+                        x-on:click="jumpToCategory(category)"
+                    >
+                        <span x-text="formatCategory(category)"></span>
+                    </button>
                 </template>
             </div>
+        </div>
+    </div>
+
+    <template x-for="category in categoryList" :key="category">
+        <section
+            class="mb-6 overflow-hidden rounded-2xl border border-gray-800 bg-gray-900/80 shadow-lg"
+            :id="categoryAnchor(category)"
+        >
+            <button
+                type="button"
+                class="flex w-full flex-col gap-4 p-5 text-left transition-colors hover:bg-gray-800/70 sm:flex-row sm:items-center sm:justify-between"
+                x-on:click="toggleSection(category)"
+                :aria-expanded="isSectionOpen(category)"
+            >
+                <div>
+                    <div class="text-[11px] uppercase tracking-[0.24em] text-gray-500 font-bold">Category</div>
+                    <h2 class="mt-1 text-2xl font-bold text-blue-300" x-text="formatCategory(category)"></h2>
+                    <p class="mt-2 text-sm text-gray-400" x-text="categoryDescription(category)"></p>
+                </div>
+
+                <div class="flex items-center gap-3 sm:text-right">
+                    <div class="rounded-xl border border-gray-700 bg-black/20 px-3 py-2">
+                        <div class="text-sm font-semibold text-white" x-text="`${availableSettingsCount(category)} setting${availableSettingsCount(category) === 1 ? '' : 's'}`"></div>
+                    </div>
+                    <div class="flex h-10 w-10 items-center justify-center rounded-full border border-gray-700 bg-gray-800 text-gray-300 transition-transform"
+                         :class="isSectionOpen(category) ? 'rotate-180' : ''">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.51a.75.75 0 01-1.08 0l-4.25-4.51a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                        </svg>
+                    </div>
+                </div>
+            </button>
+
+            <div x-show="isSectionOpen(category)" x-cloak class="border-t border-gray-800 p-5">
+                <div class="grid grid-cols-1 gap-4 xl:grid-cols-2">
+                    <template x-for="setting in settings[category]" :key="setting.key">
+                        <div
+                            x-show="!setting.depends_on || isDependent(setting)"
+                            class="rounded-xl border border-gray-700 bg-gray-950/70 p-4"
+                        >
+                            <div class="flex flex-col gap-3">
+                                <div>
+                                    <div>
+                                        <label class="block text-sm font-semibold text-white" x-text="setting.label"></label>
+                                        <div class="mt-1 text-[11px] uppercase tracking-[0.18em] text-gray-500" x-text="setting.key"></div>
+                                    </div>
+                                </div>
+
+                                <template x-if="setting.data_type === 'bool'">
+                                    <div class="flex items-center justify-between gap-4 rounded-xl border border-gray-800 bg-gray-900/80 px-4 py-3">
+                                        <div>
+                                            <div class="text-sm font-medium text-gray-200" x-text="setting.value ? 'Enabled' : 'Disabled'"></div>
+                                            <p class="mt-1 text-xs text-gray-500">Applies immediately after saving.</p>
+                                        </div>
+                                        <button
+                                            x-on:click="update(setting, !setting.value)"
+                                            class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
+                                            :class="setting.value ? 'bg-blue-600' : 'bg-gray-700'"
+                                        >
+                                            <span
+                                                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                                                :class="setting.value ? 'translate-x-5' : 'translate-x-0'"
+                                            ></span>
+                                        </button>
+                                    </div>
+                                </template>
+
+                                <template x-if="setting.data_type === 'select'">
+                                    <div class="flex flex-col gap-2 sm:flex-row">
+                                        <select
+                                            x-model="setting.tempValue"
+                                            x-on:change="update(setting, $event.target.value)"
+                                            class="w-full rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-white outline-none transition-colors focus:border-blue-500"
+                                        >
+                                            <template x-for="opt in getGroupedOptions(setting.options).orphans" :key="opt.value">
+                                                <option :value="opt.value" x-text="opt.label" :selected="opt.value == setting.value"></option>
+                                            </template>
+
+                                            <template x-for="groupName in getGroupedOptions(setting.options).groupOrder" :key="groupName">
+                                                <optgroup :label="groupName">
+                                                    <template x-for="opt in getGroupedOptions(setting.options).groups[groupName]" :key="opt.value">
+                                                        <option :value="opt.value" x-text="opt.label" :selected="opt.value == setting.value"></option>
+                                                    </template>
+                                                </optgroup>
+                                            </template>
+                                        </select>
+                                    </div>
+                                </template>
+
+                                <template x-if="setting.data_type !== 'bool' && setting.data_type !== 'select'">
+                                    <div class="flex flex-col gap-2 sm:flex-row">
+                                        <input
+                                            :type="setting.data_type === 'int' ? 'number' : 'text'"
+                                            x-model="setting.tempValue"
+                                            x-on:focus="setting.tempValue = setting.value"
+                                            :maxlength="inputMaxLength(setting) || null"
+                                            class="w-full rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-white outline-none transition-colors focus:border-blue-500"
+                                        >
+                                        <button
+                                            x-on:click="update(setting, setting.tempValue)"
+                                            class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-500 sm:w-auto"
+                                        >Save</button>
+                                    </div>
+                                </template>
+
+                                <p class="text-sm leading-relaxed text-gray-400" x-text="setting.description || 'No additional description provided.'"></p>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </div>
+        </section>
+    </template>
+    
+    <template x-if="!categoryList.length">
+        <div class="rounded-2xl border border-gray-800 bg-gray-900 p-8 text-center text-gray-400">
+            No settings available.
         </div>
     </template>
 </div>
@@ -85,33 +191,115 @@
 function settingsManager() {
     return {
         settings: {},
+        categoryList: [],
+        openSections: {},
         
         async init() {
             const res = await fetch(window.parker.route('settings.list'));
             this.settings = await res.json();
-            
+
             // Initialize tempValue for inputs (so we don't bind directly to the committed value until save)
             Object.values(this.settings).flat().forEach(s => {
                 s.tempValue = s.value;
             });
+
+            this.categoryList = Object.keys(this.settings);
+            this.initializeSections();
         },
 
         /**
          * Check if a dependent setting should be shown
          */
         isDependent(setting) {
-            console.log(setting);
             if (!setting.depends_on) return true;
 
             const parentKey = setting.depends_on.key;
             const requiredValue = setting.depends_on.value;
-console.log(parentKey, requiredValue);
+
             // Find the parent setting across all categories
             const parentSetting = Object.values(this.settings)
                 .flat()
                 .find(s => s.key === parentKey);
 
             return parentSetting && parentSetting.value === requiredValue;
+        },
+
+        initializeSections() {
+            const shouldCollapseForMobile = window.matchMedia('(max-width: 767px)').matches;
+            this.openSections = {};
+            this.categoryList.forEach((category, index) => {
+                this.openSections[category] = shouldCollapseForMobile ? index === 0 : true;
+            });
+        },
+
+        formatCategory(category) {
+            return String(category || '')
+                .split(/[_\s-]+/)
+                .filter(Boolean)
+                .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+                .join(' ');
+        },
+
+        categoryDescription(category) {
+            const descriptions = {
+                appearance: 'Reader-facing presentation, background, and browsing behavior.',
+                backup: 'Retention and protection settings for stored backups.',
+                general: 'Core application identity and logging defaults.',
+                scanning: 'How Parker reacts to filesystem activity and scan timing.',
+                server: 'External access and integration features.',
+                system: 'Scheduled maintenance and heavier processing controls.',
+            };
+
+            return descriptions[category] || 'Configuration options for this part of Parker.';
+        },
+
+        categoryAnchor(category) {
+            return `settings-category-${category}`;
+        },
+
+        jumpToCategory(category) {
+            this.openSections[category] = true;
+
+            this.$nextTick(() => {
+                const target = document.getElementById(this.categoryAnchor(category));
+                if (target) {
+                    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            });
+        },
+
+        toggleSection(category) {
+            this.openSections[category] = !this.openSections[category];
+        },
+
+        isSectionOpen(category) {
+            return !!this.openSections[category];
+        },
+
+        expandAll() {
+            this.categoryList.forEach(category => {
+                this.openSections[category] = true;
+            });
+        },
+
+        collapseAll() {
+            this.categoryList.forEach(category => {
+                this.openSections[category] = false;
+            });
+        },
+
+        availableSettingsCount(category) {
+            const group = this.settings[category] || [];
+            return group.filter(setting => !setting.depends_on || this.isDependent(setting)).length;
+        },
+
+        availableSettingTotal() {
+            return this.categoryList.reduce((total, category) => total + this.availableSettingsCount(category), 0);
+        },
+
+        inputMaxLength(setting) {
+            if (setting.key === 'general.app_name') return 32;
+            return null;
         },
 
         /**
@@ -157,9 +345,11 @@ console.log(parentKey, requiredValue);
                 // Refresh local state to match server format
                 const updated = await res.json();
                 setting.value = updated.value; 
+                setting.tempValue = updated.value;
                 window.parker.showToast("Setting saved", "success");
             } catch(e) {
                 setting.value = oldVal; // Revert
+                setting.tempValue = oldVal;
                 window.parker.showToast("Error saving setting", "error");
             }
         },

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Parker{% endblock %}</title>
+    {% set configured_instance_name = (get_system_setting("general.app_name", "Parker Comic Server") or "")|trim %}
+    {% set instance_name = configured_instance_name or "Parker Comic Server" %}
 
     {# Used for including context-sensitive path data #}
     {% from "partials/config_context.html" import config_context %}
@@ -61,8 +63,10 @@
             <div class="flex items-center justify-between h-16">
 
                 <div class="flex items-center gap-8">
-                    <a href="{{ url('/') }}" class="text-2xl font-bold bg-gradient-to-r from-blue-400 to-indigo-400 bg-clip-text text-transparent hover:from-blue-300 hover:to-indigo-300 transition-all">
-                        Parker
+                    <a href="{{ url('/') }}" class="min-w-0 text-2xl font-bold text-white transition-all hover:text-blue-200">
+                        <span class="truncate bg-gradient-to-r from-blue-400 to-indigo-400 bg-clip-text text-transparent hover:from-blue-300 hover:to-indigo-300" title="{{ instance_name }}">
+                            {{ instance_name }}
+                        </span>
                     </a>
 
                     <div class="hidden lg:flex items-center space-x-1">
@@ -93,6 +97,9 @@
                         <template x-if="isAdmin">
                             <a href="{{ url('/admin') }}" class="px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-800 transition-colors">Admin</a>
                         </template>
+                        <span class="ml-2 rounded-full border border-gray-700 bg-gray-800 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.18em] text-gray-300">
+                            Parker
+                        </span>
                     </div>
                 </div>
 

--- a/app/templates/comics/comic_detail.html
+++ b/app/templates/comics/comic_detail.html
@@ -137,8 +137,8 @@
                         </template>
 
                         <template x-if="comic?.web">
-                            <a :href="comic.web" target="_blank" rel="noopener noreferrer" class="flex items-center gap-1 text-green-400 hover:text-green-300 transition-colors border border-green-500/30 px-2 py-1 rounded hover:bg-green-500/10" title="View on ComicVine">
-                                <span>ComicVine</span>
+                            <a :href="comic.web" target="_blank" rel="noopener noreferrer" class="flex items-center gap-1 text-green-400 hover:text-green-300 transition-colors border border-green-500/30 px-2 py-1 rounded hover:bg-green-500/10" :title="comic.web_title || 'Open web link'">
+                                <span x-text="comic.web_label || 'Web Link'"></span>
                                 <span class="text-xs">↗</span>
                             </a>
                         </template>
@@ -200,6 +200,14 @@
                         </div>
                     </div>
                 </div>
+
+                <template x-if="comic?.parker_readers_count">
+                    <div class="bg-blue-950/20 border border-blue-500/20 rounded-xl p-4 shadow-lg">
+                        <div class="text-[10px] uppercase tracking-[0.2em] text-blue-300/80 font-bold">Parker Activity</div>
+                        <div class="mt-1 text-lg font-semibold text-white" x-text="`Read by ${comic.parker_readers_count} Parker users`"></div>
+                        <p class="text-sm text-gray-400 mt-1">Based on opted-in completed reads on this server.</p>
+                    </div>
+                </template>
 
                 <div x-show="comic?.summary" x-data="{ expanded: false, maxLength: 400 }">
                     <h3 class="text-lg font-bold text-gray-200 mb-2">Summary</h3>

--- a/app/templates/comics/series_detail.html
+++ b/app/templates/comics/series_detail.html
@@ -184,6 +184,14 @@
                                 </div>
                             </div>
                         </div>
+
+                        <template x-if="series?.parker_readers_count">
+                            <div class="mt-4 rounded-xl border border-blue-500/20 bg-blue-950/20 px-4 py-3">
+                                <div class="text-[10px] uppercase tracking-[0.2em] text-blue-300/80 font-bold">Parker Activity</div>
+                                <div class="mt-1 text-base font-semibold text-white" x-text="`${series.parker_readers_count} Parker users are reading or have read this series`"></div>
+                                <p class="text-sm text-gray-400 mt-1">Based on opted-in Parker activity across issues in this series.</p>
+                            </div>
+                        </template>
                     </div>
                 </div>
             </div>

--- a/app/templates/login_full.html
+++ b/app/templates/login_full.html
@@ -3,7 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login - Parker</title>
+    {% set configured_instance_name = (get_system_setting("general.app_name", "Parker Comic Server") or "")|trim %}
+    {% set instance_name = configured_instance_name or "Parker Comic Server" %}
+    <title>Login - {{ instance_name }} | Parker</title>
 
     {# Used for including context-sensitive path data #}
     {% from "partials/config_context.html" import config_context %}
@@ -77,8 +79,8 @@
         <div class="w-full max-w-md space-y-8 p-10 bg-black/40 backdrop-blur-md rounded-2xl border border-white/10 shadow-2xl">
 
             <div class="text-center">
-                <h1 class="text-4xl font-bold tracking-tight text-white mb-2">Parker</h1>
-                <p class="text-gray-400 text-sm">Sign in to your comic server</p>
+                <h1 class="text-4xl font-bold tracking-tight text-white mb-2">{{ instance_name }}</h1>
+                <p class="text-gray-400 text-sm">Sign in to your Parker comic server</p>
             </div>
 
             <form class="mt-8 space-y-6" @submit.prevent="login">

--- a/app/templates/partials/footer.html
+++ b/app/templates/partials/footer.html
@@ -1,7 +1,7 @@
 <footer class="w-full py-6 mt-12 border-t border-gray-800 text-center z-20 relative">
-    <p class="text-xs text-gray-600">
+    <p class="text-sm text-gray-500">
         Powered by
-        <a href="https://github.com/parker-server/parker" target="_blank" class="text-gray-500 hover:text-blue-400 font-bold transition-colors">
+        <a href="https://github.com/parker-server/parker" target="_blank" class="text-gray-400 hover:text-blue-400 font-bold transition-colors">
             {{ app_name }}
         </a>
         <span class="mx-1">v{{ app_version }}</span>

--- a/app/templates/partials/search_widget.html
+++ b/app/templates/partials/search_widget.html
@@ -71,7 +71,7 @@
             <div>
                 <div class="px-4 py-2 bg-gray-900/50 text-xs font-bold text-gray-400 uppercase tracking-wider sticky top-0 backdrop-blur-sm">People</div>
                 <template x-for="item in results.people" :key="item.id">
-                    <a :href="window.parker.route('pages.search', {}, `field=writer&value=${encodeURIComponent(item.name)}&operator=contains`)" class="block px-4 py-2 hover:bg-gray-700 transition-colors flex items-center gap-3 group">
+                    <a :href="personSearchHref(item)" class="block px-4 py-2 hover:bg-gray-700 transition-colors flex items-center gap-3 group">
                         <span class="text-xl group-hover:scale-110 transition-transform">👤</span>
                         <div class="font-bold text-white truncate" x-text="item.name"></div>
                     </a>

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -115,6 +115,8 @@
                             <option value="penciller">Penciller</option>
                             <option value="inker">Inker</option>
                             <option value="colorist">Colorist</option>
+                            <option value="letterer">Letterer</option>
+                            <option value="cover_artist">Cover Artist</option>
                             <option value="editor">Editor</option>
                         </optgroup>
                         <optgroup label="Tags">

--- a/app/templates/user/settings.html
+++ b/app/templates/user/settings.html
@@ -24,10 +24,10 @@
                 >
             </div>
             <div>
-                <label for="share_progress" class="font-medium text-white">Contribute to "Popular with Others"</label>
+                <label for="share_progress" class="font-medium text-white">Contribute to Parker Social Insights</label>
                 <p class="text-gray-400 text-sm mt-1">
-                    Allow your reading history to be anonymously aggregated to generate the "What others are reading" rail on the homepage.
-                    No one will see exactly what *you* are reading.
+                    Allow your reading activity to be anonymously included in community features like "Popular with Others"
+                    and reader counts on comics and series. No one will see your individual reading history.
                 </p>
             </div>
         </div>

--- a/docs/releases/0.1.19.md
+++ b/docs/releases/0.1.19.md
@@ -1,0 +1,56 @@
+# Parker 0.1.19 Release Notes
+
+Status: Ready for Release
+
+This file tracks the work landing in `0.1.19` so release notes can be built incrementally instead of reconstructed at release time.
+
+## Added
+
+- Added anonymous Parker social insight counts to comic detail pages with a `Read by X Parker users` callout.
+- Added anonymous Parker social insight counts to series detail pages with a `X Parker users are reading or have read this series` callout.
+- Added a shared social-insights aggregation helper so future aggregate social surfaces can reuse the same visibility and threshold rules.
+- Added focused API coverage for comic and series social reader-count behavior, including opt-in filtering and minimum-count suppression.
+
+## Changed
+
+- Expanded the user `Privacy & Social` opt-in language so the existing setting now clearly covers Parker's anonymous aggregate social features beyond just the `Popular with Others` home rail.
+- Refined the `/admin/settings` layout with quick category navigation, collapsible sections, clearer setting counts, and more compact mobile-friendly settings cards.
+- Updated the general app-name setting to act as a server display name in the UI while preserving clear `Parker` product branding, enforcing a nav-safe length limit, slimming the nav brand pill, moving the watermark into the left-side nav link cluster, and making the footer branding easier to read.
+
+## Fixed
+
+- Fixed user settings page rendering on newer FastAPI/Starlette versions by updating lingering page routes to the explicit `TemplateResponse(request=..., name=...)` form.
+- Fixed password update submission on the user settings page by correcting the client-side `fetch()` wiring.
+- Fixed comic detail external-link labeling so non-ComicVine metadata URLs no longer render a misleading `ComicVine` button label.
+- Fixed quick-search People results so clicking a creator now hands off to Advanced Search across creator roles, and restored missing `Letterer` / `Cover Artist` creator filter options so the hydrated search rules render correctly.
+
+## Validation
+
+- Verified with:
+
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_comics.py tests/api/test_series.py tests/api/test_users.py tests/api/test_pages.py
+```
+
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_comics.py
+```
+
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_pages.py
+```
+
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_settings.py
+```
+
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_comics.py tests/api/test_pages.py tests/api/test_settings.py tests/api/test_search_api.py
+```
+
+- Current results:
+  - `tests/api/test_comics.py tests/api/test_pages.py tests/api/test_settings.py tests/api/test_search_api.py`: `41 passed`
+  - `tests/api/test_comics.py tests/api/test_series.py tests/api/test_users.py tests/api/test_pages.py`: `59 passed`
+  - `tests/api/test_comics.py`: `15 passed`
+  - `tests/api/test_pages.py`: `10 passed`
+  - `tests/api/test_settings.py`: `9 passed`

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -164,9 +164,26 @@ document.addEventListener('alpine:init', () => {
         results: {},
         isOpen: false,
         loading: false,
+        creatorRoleFields: ['writer', 'penciller', 'inker', 'colorist', 'letterer', 'editor', 'cover_artist'],
 
         get hasResults() {
             return Object.values(this.results).some(arr => arr && arr.length > 0);
+        },
+
+        personSearchHref(item) {
+            const name = item?.name?.trim();
+            if (!name) {
+                return window.parker.route('pages.search');
+            }
+
+            return window.parker.searchHandoff.buildUrl({
+                match: 'any',
+                filters: this.creatorRoleFields.map((field) => ({
+                    field,
+                    operator: 'equal',
+                    value: [name]
+                }))
+            });
         },
 
         async fetchResults() {

--- a/tests/api/test_comics.py
+++ b/tests/api/test_comics.py
@@ -175,6 +175,7 @@ def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, d
         number="7",
         title="Detail Issue",
         summary="Issue summary",
+        web="https://comicvine.gamespot.com/detail-issue/4000-7/",
         page_count=20,
         publisher="Detail Pub",
         imprint="Detail Imprint",
@@ -236,10 +237,99 @@ def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, d
     assert payload["locations"] == ["Detail City"]
     assert payload["genres"] == ["Detail Genre"]
     assert payload["read_status"] == "in_progress"
+    assert payload["web"] == "https://comicvine.gamespot.com/detail-issue/4000-7/"
+    assert payload["web_label"] == "ComicVine"
+    assert payload["web_title"] == "View on ComicVine"
     assert payload["source_rating"] == 3.8
     assert payload["parker_rating_average"] is None
     assert payload["parker_rating_count"] == 0
     assert payload["user_rating"] is None
+    assert payload["parker_readers_count"] is None
+
+
+def test_get_comic_detail_uses_generic_label_for_non_comicvine_web_links(auth_client, db, normal_user):
+    library, _, volume = _create_graph(db, lib_name="comic-web-link", series_name="Alt Link Saga")
+
+    comic = Comic(
+        volume_id=volume.id,
+        number="11",
+        title="Alt Link Issue",
+        web="https://leagueofcomicgeeks.com/comic/123456/alt-link-issue",
+        filename="alt-link-11.cbz",
+        file_path="/tmp/alt-link-11.cbz",
+    )
+    db.add(comic)
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.get(f"/api/comics/{comic.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["web"] == "https://leagueofcomicgeeks.com/comic/123456/alt-link-issue"
+    assert payload["web_label"] == "Web Link"
+    assert payload["web_title"] == "Open web link"
+
+
+def test_get_comic_detail_exposes_opted_in_completed_reader_count(auth_client, db, normal_user):
+    library, _, volume = _create_graph(db, lib_name="comic-social", series_name="Social Saga")
+
+    comic = Comic(
+        volume_id=volume.id,
+        number="3",
+        title="Social Issue",
+        filename="social-3.cbz",
+        file_path="/tmp/social-3.cbz",
+        page_count=24,
+    )
+    db.add(comic)
+    db.flush()
+
+    reader_a = User(
+        username="social-reader-a",
+        email="social-reader-a@example.com",
+        hashed_password="fakehash",
+        share_progress_enabled=True,
+        is_active=True,
+    )
+    reader_b = User(
+        username="social-reader-b",
+        email="social-reader-b@example.com",
+        hashed_password="fakehash",
+        share_progress_enabled=True,
+        is_active=True,
+    )
+    hidden_reader = User(
+        username="social-reader-hidden",
+        email="social-reader-hidden@example.com",
+        hashed_password="fakehash",
+        share_progress_enabled=False,
+        is_active=True,
+    )
+    in_progress_only = User(
+        username="social-reader-progress",
+        email="social-reader-progress@example.com",
+        hashed_password="fakehash",
+        share_progress_enabled=True,
+        is_active=True,
+    )
+    db.add_all([reader_a, reader_b, hidden_reader, in_progress_only])
+    normal_user.accessible_libraries.append(library)
+    db.flush()
+
+    db.add_all([
+        ReadingProgress(user_id=reader_a.id, comic_id=comic.id, current_page=24, total_pages=24, completed=True),
+        ReadingProgress(user_id=reader_b.id, comic_id=comic.id, current_page=24, total_pages=24, completed=True),
+        ReadingProgress(user_id=hidden_reader.id, comic_id=comic.id, current_page=24, total_pages=24, completed=True),
+        ReadingProgress(user_id=in_progress_only.id, comic_id=comic.id, current_page=8, total_pages=24, completed=False),
+    ])
+    db.commit()
+
+    response = auth_client.get(f"/api/comics/{comic.id}")
+
+    assert response.status_code == 200
+    assert response.json()["parker_readers_count"] == 2
 
 
 def test_set_comic_rating_creates_and_updates_single_user_row(auth_client, db, normal_user):

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -1,3 +1,6 @@
+from app.core.templates import templates
+
+
 def test_home_page_shows_storage_warning_for_admin_when_startup_looks_suspicious(admin_client, monkeypatch):
     monkeypatch.setattr(
         "app.routers.pages.collect_startup_diagnostics",
@@ -57,6 +60,52 @@ def test_admin_diagnostics_page_exposes_support_snapshot_actions(admin_client):
     assert "Download JSON" in body
     assert "Open Raw JSON" in body
     assert "parker_startup_diagnostics" in body
+
+
+def test_login_page_uses_server_display_name_but_keeps_parker_branding(client, monkeypatch):
+    def fake_get_system_setting(key, default=None):
+        if key == "general.app_name":
+            return "Fortress Comics"
+        return default
+
+    monkeypatch.setitem(templates.env.globals, "get_system_setting", fake_get_system_setting)
+
+    response = client.get("/login")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Fortress Comics" in body
+    assert "Powered by" in body
+    assert "Parker" in body
+
+
+def test_admin_settings_page_exposes_quick_navigation(admin_client):
+    response = admin_client.get("/admin/settings")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Settings Overview" in body
+    assert "Jump To" in body
+    assert "Expand All" in body
+    assert "Collapse All" in body
+
+
+def test_search_widget_people_results_use_generic_creator_handoff(auth_client):
+    response = auth_client.get("/")
+
+    assert response.status_code == 200
+    body = response.text
+    assert 'personSearchHref(item)' in body
+    assert 'field=writer&value=${encodeURIComponent(item.name)}&operator=contains' not in body
+
+
+def test_advanced_search_page_exposes_full_creator_filter_set(auth_client):
+    response = auth_client.get("/search")
+
+    assert response.status_code == 200
+    body = response.text
+    assert '<option value="letterer">Letterer</option>' in body
+    assert '<option value="cover_artist">Cover Artist</option>' in body
 
 
 def test_user_settings_page_renders_for_authenticated_user(auth_client):

--- a/tests/api/test_series.py
+++ b/tests/api/test_series.py
@@ -9,6 +9,7 @@ from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.tags import Character, Location, Team
+from app.models.user import User
 
 
 def _create_series_with_volume(db, *, lib_name: str, series_name: str):
@@ -349,6 +350,7 @@ def test_series_detail_returns_enriched_payload(auth_client, db, normal_user):
     assert payload["details"]["teams"] == ["Series Team"]
     assert payload["details"]["locations"] == ["Series Location"]
     assert [arc["name"] for arc in payload["story_arcs"]] == ["Arc Prime", "Arc Side"]
+    assert payload["parker_readers_count"] is None
 
     assert payload["collections"] == [
         {
@@ -370,6 +372,88 @@ def test_series_detail_returns_enriched_payload(auth_client, db, normal_user):
     assert by_vol[data["vol1"].id]["read"] is True
     assert by_vol[data["vol2"].id]["first_issue_id"] == data["issue_two"].id
     assert by_vol[data["vol2"].id]["read"] is False
+
+
+def test_series_detail_exposes_distinct_opted_in_reader_count(auth_client, db, normal_user):
+    data = _create_series_detail_fixture(db)
+
+    normal_user.accessible_libraries.append(data["library"])
+    db.flush()
+
+    reader_a = User(
+        username="series-reader-a",
+        email="series-reader-a@example.com",
+        hashed_password="fakehash",
+        share_progress_enabled=True,
+        is_active=True,
+    )
+    reader_b = User(
+        username="series-reader-b",
+        email="series-reader-b@example.com",
+        hashed_password="fakehash",
+        share_progress_enabled=True,
+        is_active=True,
+    )
+    hidden_reader = User(
+        username="series-reader-hidden",
+        email="series-reader-hidden@example.com",
+        hashed_password="fakehash",
+        share_progress_enabled=False,
+        is_active=True,
+    )
+    zero_progress_reader = User(
+        username="series-reader-zero",
+        email="series-reader-zero@example.com",
+        hashed_password="fakehash",
+        share_progress_enabled=True,
+        is_active=True,
+    )
+    db.add_all([reader_a, reader_b, hidden_reader, zero_progress_reader])
+    db.flush()
+
+    db.add_all([
+        ReadingProgress(
+            user_id=reader_a.id,
+            comic_id=data["issue_one"].id,
+            current_page=20,
+            total_pages=20,
+            completed=True,
+        ),
+        ReadingProgress(
+            user_id=reader_a.id,
+            comic_id=data["issue_two"].id,
+            current_page=5,
+            total_pages=18,
+            completed=False,
+        ),
+        ReadingProgress(
+            user_id=reader_b.id,
+            comic_id=data["issue_four"].id,
+            current_page=4,
+            total_pages=22,
+            completed=False,
+        ),
+        ReadingProgress(
+            user_id=hidden_reader.id,
+            comic_id=data["annual"].id,
+            current_page=28,
+            total_pages=28,
+            completed=True,
+        ),
+        ReadingProgress(
+            user_id=zero_progress_reader.id,
+            comic_id=data["issue_one"].id,
+            current_page=0,
+            total_pages=20,
+            completed=False,
+        ),
+    ])
+    db.commit()
+
+    response = auth_client.get(f"/api/series/{data['series'].id}")
+
+    assert response.status_code == 200
+    assert response.json()["parker_readers_count"] == 2
 
 
 def test_series_detail_hides_story_arcs_and_related_containers_when_parsing_disabled(auth_client, db, normal_user):

--- a/tests/api/test_settings.py
+++ b/tests/api/test_settings.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from app.services.settings_service import SettingsService, SERVER_DISPLAY_NAME_MAX_LENGTH
 from app.api.deps import get_current_user_optional
 from app.main import app
 
@@ -84,3 +85,15 @@ def test_update_setting_returns_404_when_setting_missing(admin_client):
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Setting not found"
+
+
+def test_update_setting_rejects_server_display_name_that_is_too_long(admin_client, db):
+    SettingsService(db).initialize_defaults()
+
+    response = admin_client.patch(
+        "/api/settings/general.app_name",
+        json={"value": "X" * (SERVER_DISPLAY_NAME_MAX_LENGTH + 1)},
+    )
+
+    assert response.status_code == 422
+    assert f"{SERVER_DISPLAY_NAME_MAX_LENGTH} characters or fewer" in response.json()["detail"]


### PR DESCRIPTION

This PR finishes the `0.1.19` release polish pass across settings, branding, comic metadata links, and advanced search handoff behavior.

## What Changed

- refined `/admin/settings` with quicker category navigation, cleaner collapsible sections, and a more mobile-friendly layout
- removed redundant/dev-facing settings UI labels and tightened the branding presentation
- made `general.app_name` function as a server display name while preserving visible Parker branding
- added validation for overly long server display names to avoid nav breakage
- fixed comic detail external-link labeling so non-ComicVine URLs render as a generic web link instead of always saying `ComicVine`
- fixed quick-search People results so clicking a creator hands off to Advanced Search across creator-role filters instead of only `writer`
- restored missing `Letterer` and `Cover Artist` filter options so hydrated creator searches render correctly

