### PR TITLE
Prepare 0.1.20: trending rail, UI polish, scan-write optimization, and pagination fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,3 +322,4 @@ fabric.properties
 
 storage/
 .idea/
+cache/

--- a/.gitignore
+++ b/.gitignore
@@ -323,3 +323,4 @@ fabric.properties
 storage/
 .idea/
 cache/
+AGENTS.md

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,17 @@ This file captures follow-up work that should not get lost between releases.
   Follow-up goal: Refactor the reader into a thinner shared shell plus modular paged/scroll-oriented partials or components so future reader work does not keep accumulating in one template.
   Candidate direction: Keep the existing `/reader/{comic_id}` route, preserve shared archive/progress plumbing where possible, and split the template/JS by interaction model rather than forcing additional conditional branches into the current monolith.
 
+- Keep an eye on pull list detail page scale before it becomes a usability problem.
+  Context: `app/templates/pull_lists/detail.html` currently renders a full list in one view, which is fine for normal pull-list sizes and likely more important to watch than the pull-list index page.
+  Follow-up goal: If real users start building unusually large pull lists, consider pagination, filtering, or virtualization for list contents before the detail view becomes heavy to use.
+  Guardrail: Treat this as a usage-driven optimization, not a default roadmap item, unless real list sizes or UX complaints justify it.
+
+- Keep an eye on smart filter scale before the search load menu gets crowded.
+  Context: Smart filters currently surface mainly in the dashboard management table and the shared "Load" dropdown on `app/templates/search.html`, where they sit alongside saved searches.
+  Follow-up goal: If users start accumulating enough smart filters that discovery or loading becomes awkward, improve those surfaces before adding heavier API pagination.
+  Candidate direction: Start with a bounded scroll area and/or lightweight client-side filtering in the search load menu, then revisit whether the dashboard table needs search, sorting, or pagination based on real usage.
+  Guardrail: Treat this as a usage-driven UX refinement, not a release-blocking task, unless real list counts or complaints show the current UI is straining.
+
 - Revisit frontend route-map generation in `app/core/utils.py`.
   Context: FastAPI `0.137.0` changed `router.routes` from a flat list into a tree of intermediate objects, and the release notes explicitly warn that code iterating `router.routes` directly will be affected.
   Current state: Parker ships a compatibility fix that walks the newer wrapped route structure and is covered by focused regression tests.

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,12 @@ This file captures follow-up work that should not get lost between releases.
 
 ## Technical Debt
 
+- Modularize the reader before adding materially different reading modes.
+  Context: `app/templates/reader.html` has grown into a large all-in-one template that currently mixes paged layout, RTL/LTR behavior, spread logic, swipe handling, controls, and progress wiring in one place.
+  Impetus: The archived vertical-scroll compatibility investigation in `docs/archived-vertical-scroll-scope.md` highlighted that a future tall-page / long-strip reader mode would be much cleaner if the reader were split into shared and mode-specific pieces first.
+  Follow-up goal: Refactor the reader into a thinner shared shell plus modular paged/scroll-oriented partials or components so future reader work does not keep accumulating in one template.
+  Candidate direction: Keep the existing `/reader/{comic_id}` route, preserve shared archive/progress plumbing where possible, and split the template/JS by interaction model rather than forcing additional conditional branches into the current monolith.
+
 - Revisit frontend route-map generation in `app/core/utils.py`.
   Context: FastAPI `0.137.0` changed `router.routes` from a flat list into a tree of intermediate objects, and the release notes explicitly warn that code iterating `router.routes` directly will be affected.
   Current state: Parker ships a compatibility fix that walks the newer wrapped route structure and is covered by focused regression tests.

--- a/alembic/versions/7d3f4a6c9b21_shorten_default_server_display_name.py
+++ b/alembic/versions/7d3f4a6c9b21_shorten_default_server_display_name.py
@@ -1,0 +1,35 @@
+"""Shorten default server display name
+
+Revision ID: 7d3f4a6c9b21
+Revises: 4b8d4f7f6c21
+Create Date: 2026-07-15 10:20:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7d3f4a6c9b21"
+down_revision: Union[str, None] = "4b8d4f7f6c21"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE system_settings
+        SET value = 'Parker'
+        WHERE key = 'general.app_name'
+          AND value = 'Parker Comic Server'
+        """
+    )
+
+
+def downgrade() -> None:
+    # This data migration is intentionally not reversed because we cannot
+    # safely distinguish migrated defaults from intentional user-selected
+    # values of "Parker" during downgrade.
+    pass

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -441,7 +441,7 @@ def get_popular(
         limit: int = 10
 ):
     """
-    Get 'Trending' Series based on other users' reading activity.
+    Get "Popular with Others" series based on other users' reading activity.
     Respects the 'share_progress_enabled' privacy setting.
     Secured for age rating
     """

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -106,6 +106,52 @@ def _pick_best_cover(series_obj, comics_list):
         return pool[0]   # Lowest Number (e.g. Spider-Man #10)
 
 
+def _serialize_series_rail_items(db: Session, series_list):
+    if not series_list:
+        return []
+
+    series_ids = [s.id for s in series_list]
+
+    raw_comics = (
+        db.query(
+            Comic.id,
+            Comic.number,
+            Comic.year,
+            Comic.format,
+            Comic.publisher,
+            Comic.updated_at,
+            Volume.series_id
+        )
+        .join(Volume)
+        .filter(Volume.series_id.in_(series_ids))
+        .all()
+    )
+
+    series_map = defaultdict(list)
+    for rc in raw_comics:
+        series_map[rc.series_id].append(rc)
+
+    results = []
+    for s in series_list:
+        s_comics = series_map.get(s.id, [])
+        first_issue = _pick_best_cover(s, s_comics)
+
+        if not first_issue:
+            continue
+
+        results.append({
+            "id": s.id,
+            "name": s.name,
+            "start_year": first_issue.year,
+            "thumbnail_path": get_thumbnail_url(first_issue.id, first_issue.updated_at),
+            "publisher": first_issue.publisher,
+            "volume_count": len(s.volumes) if s.volumes else 0,
+            "starred": False
+        })
+
+    return results
+
+
 
 @router.get("/random", response_model=List[dict], name="random_gems")
 def get_random_gems(
@@ -320,6 +366,53 @@ def get_resume_reading(
     return [format_home_item(c, p) for c, p in results]
 
 
+@router.get("/trending", response_model=List[dict], name="trending")
+def get_trending(
+        db: SessionDep,
+        current_user: CurrentUser,
+        limit: int = 10
+):
+    """
+    Get time-sensitive trending series based on recent opted-in reading activity.
+    Ranked by recent activity volume, then distinct readers, then freshest activity.
+    """
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=30)
+
+    trending_series_query = (
+        db.query(Series)
+        .join(Volume).join(Comic).join(ReadingProgress)
+        .join(User)
+        .filter(User.share_progress_enabled == True)
+        .filter(ReadingProgress.user_id != current_user.id)
+        .filter(ReadingProgress.last_read_at >= cutoff_date)
+    )
+
+    age_filter = get_series_age_restriction(current_user)
+    if age_filter is not None:
+        trending_series_query = trending_series_query.filter(age_filter)
+
+    trending_series = (
+        trending_series_query.group_by(Series.id)
+        .order_by(
+            desc(func.count(ReadingProgress.id)),
+            desc(func.count(func.distinct(ReadingProgress.user_id))),
+            desc(func.max(ReadingProgress.last_read_at)),
+        )
+        .limit(limit)
+        .all()
+    )
+
+    if len(trending_series) < 4:
+        return []
+
+    results = _serialize_series_rail_items(db, trending_series)
+
+    if len(results) < 4:
+        return []
+
+    return results
+
+
 @router.get("/up-next", response_model=List[ComicSearchItem], name="up_next")
 def get_up_next(
         db: SessionDep,
@@ -474,47 +567,7 @@ def get_popular(
     if len(popular_series) < 4:
         return []
 
-    # 2. Batch Fetch Covers (SQLite Compatible)
-    series_ids = [s.id for s in popular_series]
-
-    raw_comics = (
-        db.query(
-            Comic.id,
-            Comic.number,
-            Comic.year,
-            Comic.format,
-            Comic.publisher,
-            Comic.updated_at,
-            Volume.series_id
-        )
-        .join(Volume)
-        .filter(Volume.series_id.in_(series_ids))
-        .all()
-    )
-
-    series_map = defaultdict(list)
-    for rc in raw_comics:
-        series_map[rc.series_id].append(rc)
-
-
-    # 3. Format Results
-    results = []
-    for s in popular_series:
-        s_comics = series_map.get(s.id, [])
-        first_issue = _pick_best_cover(s, s_comics)
-
-        if not first_issue:
-            continue
-
-        results.append({
-            "id": s.id,
-            "name": s.name,
-            "start_year": first_issue.year,
-            "thumbnail_path": get_thumbnail_url(first_issue.id, first_issue.updated_at),
-            "publisher": first_issue.publisher,
-            "volume_count": len(s.volumes) if s.volumes else 0,
-            "starred": False
-        })
+    results = _serialize_series_rail_items(db, popular_series)
 
     # Secondary Guard: Ensure we still have enough items after cover validation
     if len(results) < 4:

--- a/app/api/progress.py
+++ b/app/api/progress.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone, timedelta
 from sqlalchemy.orm import joinedload
 
 from app.core.settings_loader import get_cached_setting
-from app.api.deps import SessionDep, CurrentUser
+from app.api.deps import SessionDep, CurrentUser, PaginationParams
 from app.models.reading_progress import ReadingProgress
 # Need to import these for joinedload to work
 from app.models.comic import Comic, Volume
@@ -224,7 +224,7 @@ async def get_recent_progress(
         current_user: CurrentUser,
         service: Annotated[ReadingProgressService, Depends(get_progress_service)],
         filter: Annotated[str, Query(pattern="^(recent|in_progress|completed)$")] = "recent",
-        limit: Annotated[int, Query(ge=1, le=100)] = 20
+        params: Annotated[PaginationParams, Depends()] = None
 
 ):
     """
@@ -253,7 +253,14 @@ async def get_recent_progress(
         query = query.filter(ReadingProgress.completed == True)
     # else: "recent" implies all/any status, just sorted by time
 
-    progress_list = query.order_by(ReadingProgress.last_read_at.desc()).limit(limit).all()
+    total = query.count()
+
+    progress_list = (
+        query.order_by(ReadingProgress.last_read_at.desc())
+        .offset(params.skip)
+        .limit(params.size)
+        .all()
+    )
 
     results = []
     for progress in progress_list:
@@ -277,7 +284,10 @@ async def get_recent_progress(
 
     return {
         "filter": filter,
-        "total": len(results),
+        "total": total,
+        "page": params.page,
+        "size": params.size,
+        "items": results,
         "results": results
     }
 

--- a/app/api/series.py
+++ b/app/api/series.py
@@ -8,7 +8,8 @@ from collections import defaultdict
 from app.core.comic_helpers import (get_format_filters, get_smart_cover, get_reading_time,
                                     get_thumbnail_url, get_thumbnail_hash,
                                     NON_PLAIN_FORMATS, REVERSE_NUMBERING_SERIES,
-                                    get_series_age_restriction, get_banned_comic_condition)
+                                    get_series_age_restriction, get_banned_comic_condition,
+                                    get_resume_target)
 from app.api.deps import SessionDep, CurrentUser, AdminUser, SeriesDep
 from app.api.deps import PaginationParams, PaginatedResponse
 
@@ -292,19 +293,13 @@ async def get_series_detail(series: SeriesDep, db: SessionDep, current_user: Cur
     first_issue = get_smart_cover(base_query, series_name=series.name)
     colors = first_issue.color_palette or {} if first_issue else {}
 
-    resume_comic_id = None
-    read_status = "new"
-
-    # Check for last read comic in this series
-    last_read = db.query(ReadingProgress).join(Comic).join(Volume) \
-        .filter(Volume.series_id == series.id, ReadingProgress.user_id == current_user.id) \
-        .order_by(ReadingProgress.last_read_at.desc()).first()
-
-    if last_read:
-        resume_comic_id = last_read.comic_id
-        read_status = "in_progress"
-    elif first_issue:
-        resume_comic_id = first_issue.id
+    resume_comic_id, read_status = get_resume_target(
+        db,
+        user_id=current_user.id,
+        series_id=series.id,
+        series_name=series.name,
+        first_issue_id=first_issue.id if first_issue else None,
+    )
 
     # 7. Volumes Data (Batch Fetch)
     vol_stats = (

--- a/app/api/volumes.py
+++ b/app/api/volumes.py
@@ -5,7 +5,8 @@ from sqlalchemy.orm import joinedload
 from typing import List, Annotated
 
 from app.core.comic_helpers import (get_format_filters, get_smart_cover, get_reading_time,
-                                    REVERSE_NUMBERING_SERIES, get_age_rating_config, get_thumbnail_url)
+                                    REVERSE_NUMBERING_SERIES, get_age_rating_config, get_thumbnail_url,
+                                    get_resume_target)
 
 from app.api.deps import SessionDep, CurrentUser, VolumeDep
 from app.api.deps import PaginationParams, PaginatedResponse
@@ -130,21 +131,13 @@ async def get_volume_detail(volume: VolumeDep, db: SessionDep, current_user: Cur
         colors["primary"] = first_issue.color_primary or "#000000"
         colors["secondary"] = first_issue.color_secondary or "#222222"
 
-    # Resume Logic
-    resume_comic_id = None
-    read_status = "new"
-
-    last_read = db.query(ReadingProgress).join(Comic) \
-        .filter(Comic.volume_id == volume.id) \
-        .filter(ReadingProgress.user_id == current_user.id) \
-        .order_by(ReadingProgress.last_read_at.desc()) \
-        .first()
-
-    if last_read:
-        resume_comic_id = last_read.comic_id
-        read_status = "in_progress"
-    elif first_issue:
-        resume_comic_id = first_issue.id
+    resume_comic_id, read_status = get_resume_target(
+        db,
+        user_id=current_user.id,
+        volume_id=volume.id,
+        series_name=volume.series.name,
+        first_issue_id=first_issue.id if first_issue else None,
+    )
 
     # 5. Status & Missing Issues Logic
     status = "ongoing"

--- a/app/core/comic_helpers.py
+++ b/app/core/comic_helpers.py
@@ -3,13 +3,13 @@ from datetime import datetime, timezone
 from functools import lru_cache
 from sqlalchemy import func, or_, not_, case, cast, Float
 from fastapi import HTTPException
-from sqlalchemy import func, or_, not_, case
 
 from app.api.deps import SessionDep
 from app.models.comic import Comic, Volume
 from app.models.series import Series
 from app.models.tags import Character, Team, Location, Genre
 from app.models.credits import Person, ComicCredit
+from app.models.reading_progress import ReadingProgress
 
 logger = logging.getLogger(__name__)
 
@@ -286,6 +286,91 @@ def get_reading_time(total_pages):
         read_time = f"{total_minutes}m"
 
     return read_time
+
+
+def get_resume_target(
+        db: SessionDep,
+        *,
+        user_id: int,
+        series_name: str | None,
+        first_issue_id: int | None,
+        series_id: int | None = None,
+        volume_id: int | None = None,
+) -> tuple[int | None, str]:
+    """
+    Resolve the best "read next" target for a series or volume detail page.
+
+    Semantics:
+    - If the latest touched comic is still in progress, keep "Continue" behavior.
+    - If the latest touched comic is completed, advance to the next unread comic
+      but keep the container-level "Continue" behavior.
+    - Fall back to the first issue when no progress exists or the run is exhausted.
+    """
+    if (series_id is None) == (volume_id is None):
+        raise ValueError("Exactly one of series_id or volume_id must be provided")
+
+    progress_query = db.query(ReadingProgress).join(Comic)
+    comics_query = db.query(Comic)
+
+    if series_id is not None:
+        progress_query = progress_query.join(Volume).filter(Volume.series_id == series_id)
+        comics_query = comics_query.join(Volume).filter(Volume.series_id == series_id)
+    else:
+        progress_query = progress_query.filter(Comic.volume_id == volume_id)
+        comics_query = comics_query.filter(Comic.volume_id == volume_id)
+
+    latest_progress = (
+        progress_query
+        .filter(ReadingProgress.user_id == user_id)
+        .order_by(ReadingProgress.last_read_at.desc())
+        .first()
+    )
+
+    if not latest_progress:
+        return first_issue_id, "new"
+
+    if not latest_progress.completed and (latest_progress.current_page or 0) > 0:
+        return latest_progress.comic_id, "in_progress"
+
+    completed_ids = {
+        row[0]
+        for row in (
+            progress_query
+            .with_entities(ReadingProgress.comic_id)
+            .filter(
+                ReadingProgress.user_id == user_id,
+                ReadingProgress.completed == True,
+            )
+            .all()
+        )
+    }
+
+    number_direction = cast(Comic.number, Float).desc() if series_name and series_name.lower() in REVERSE_NUMBERING_SERIES else cast(Comic.number, Float).asc()
+    string_direction = Comic.number.desc() if series_name and series_name.lower() in REVERSE_NUMBERING_SERIES else Comic.number.asc()
+
+    if series_id is not None:
+        ordered_comics = comics_query.order_by(
+            Volume.volume_number.asc(),
+            number_direction,
+            string_direction,
+        ).all()
+    else:
+        ordered_comics = comics_query.order_by(
+            number_direction,
+            string_direction,
+        ).all()
+
+    ordered_ids = [comic.id for comic in ordered_comics]
+    try:
+        start_index = ordered_ids.index(latest_progress.comic_id) + 1
+    except ValueError:
+        return first_issue_id, "new"
+
+    for comic_id in ordered_ids[start_index:]:
+        if comic_id not in completed_ids:
+            return comic_id, "continue"
+
+    return first_issue_id, "new"
 
 
 # Helper for SQL Order By

--- a/app/routers/opds.py
+++ b/app/routers/opds.py
@@ -65,7 +65,12 @@ def get_opds_acquisition_type(comic: Comic) -> str:
 def get_opds_download_filename(comic: Comic) -> str:
     """Return a stable export filename that keeps the comic's real extension."""
     suffix = get_comic_archive_suffix(comic) or ".cbz"
-    safe_title = comic.title or comic.filename or f"comic-{comic.id}"
+    if comic.title:
+        safe_title = comic.title
+    elif comic.filename:
+        safe_title = Path(comic.filename).stem or comic.filename
+    else:
+        safe_title = f"comic-{comic.id}"
     return f"{comic.series_group or 'Comic'} - {safe_title}{suffix}"
 
 

--- a/app/services/collection.py
+++ b/app/services/collection.py
@@ -1,5 +1,5 @@
 import logging
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from typing import Optional, Dict
 
 from app.models import Collection, CollectionItem, Comic, Volume, Series
@@ -61,10 +61,36 @@ class CollectionService:
             CollectionItem.comic_id.in_(comic_ids_query)
         ).delete(synchronize_session=False)
 
+    def _get_collection_items_for_comic(self, comic_id: int) -> list[CollectionItem]:
+        return (
+            self.db.query(CollectionItem)
+            .options(joinedload(CollectionItem.collection))
+            .filter(CollectionItem.comic_id == comic_id)
+            .all()
+        )
+
     def update_comic_collections(self, comic: Comic, series_group: Optional[str]):
-        self.remove_comic_from_all_collections(comic.id)
-        if series_group:
-            self.add_comic_to_collection(comic, series_group)
+        target_name = series_group.strip() if series_group and series_group.strip() else None
+        current_items = self._get_collection_items_for_comic(comic.id)
+
+        if not current_items:
+            if target_name:
+                self.add_comic_to_collection(comic, target_name)
+            return
+
+        if (
+            target_name
+            and len(current_items) == 1
+            and current_items[0].collection
+            and current_items[0].collection.name == target_name
+        ):
+            return
+
+        for item in current_items:
+            self.db.delete(item)
+
+        if target_name:
+            self.add_comic_to_collection(comic, target_name)
 
     def cleanup_empty_collections(self):
         empty_collections = self.db.query(Collection).filter(~Collection.items.any()).all()

--- a/app/services/reading_list.py
+++ b/app/services/reading_list.py
@@ -1,5 +1,5 @@
 import logging
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 from typing import Optional, Dict
 from app.models import ReadingList, ReadingListItem, Comic, Volume, Series
 from app.services.enrichment import EnrichmentService
@@ -76,16 +76,50 @@ class ReadingListService:
             ReadingListItem.comic_id.in_(comic_ids_query)
         ).delete(synchronize_session=False)
 
+    def _get_list_items_for_comic(self, comic_id: int) -> list[ReadingListItem]:
+        return (
+            self.db.query(ReadingListItem)
+            .options(joinedload(ReadingListItem.reading_list))
+            .filter(ReadingListItem.comic_id == comic_id)
+            .all()
+        )
+
     def update_comic_reading_lists(self, comic: Comic, alternate_series: Optional[str],
                                    alternate_number: Optional[str]):
-        self.remove_comic_from_all_lists(comic.id)
+        target_name = alternate_series.strip() if alternate_series and alternate_series.strip() else None
+        target_position = None
 
-        if alternate_series and alternate_number:
+        if target_name and alternate_number:
             try:
-                position = float(alternate_number)
-                self.add_comic_to_list(comic, alternate_series, position)
-            except ValueError:
-                pass
+                target_position = float(alternate_number)
+            except (TypeError, ValueError):
+                target_name = None
+        else:
+            target_name = None
+
+        current_items = self._get_list_items_for_comic(comic.id)
+
+        if not current_items:
+            if target_name and target_position is not None:
+                self.add_comic_to_list(comic, target_name, target_position)
+            return
+
+        if (
+            target_name
+            and target_position is not None
+            and len(current_items) == 1
+            and current_items[0].reading_list
+            and current_items[0].reading_list.name == target_name
+        ):
+            if current_items[0].position != target_position:
+                current_items[0].position = target_position
+            return
+
+        for item in current_items:
+            self.db.delete(item)
+
+        if target_name and target_position is not None:
+            self.add_comic_to_list(comic, target_name, target_position)
 
     def cleanup_empty_lists(self):
         # This usually runs at the end of the scan, safe to run logic here

--- a/app/services/scan_manager.py
+++ b/app/services/scan_manager.py
@@ -546,9 +546,9 @@ class ScanManager:
     @staticmethod
     def update_library_last_scanned(library_id: int):
         db = SessionLocal()
-        lib = db.query(Library).get(library_id)
+        lib = db.get(Library, library_id)
         if lib:
-            lib.last_scanned = datetime.utcnow()
+            lib.last_scanned = datetime.now(timezone.utc)
             db.commit()
         db.close()
 

--- a/app/services/settings_service.py
+++ b/app/services/settings_service.py
@@ -60,7 +60,7 @@ class SettingsService:
     # Define defaults here. The app will ensure these exist on startup.
     DEFAULTS = [
         {
-            "key": "general.app_name", "value": "Parker Comic Server",
+            "key": "general.app_name", "value": "Parker",
             "description": f"Display name shown across the server UI. Parker branding remains visible. Max {SERVER_DISPLAY_NAME_MAX_LENGTH} characters.",
             "category": "general", "data_type": "string",
             "label": "Server Display Name"

--- a/app/services/workers/metadata_writer.py
+++ b/app/services/workers/metadata_writer.py
@@ -202,7 +202,7 @@ def metadata_writer(
         db = SessionLocal()
 
         # Get library path for sidecars
-        library = db.query(Library).get(library_id)
+        library = db.get(Library, library_id)
         lib_path = Path(library.path)
 
         # Preload existing comics

--- a/app/templates/admin/about.html
+++ b/app/templates/admin/about.html
@@ -3,8 +3,8 @@
 {% block title %}About - Parker{% endblock %}
 
 {% block content %}
-{% set configured_instance_name = (get_system_setting("general.app_name", "Parker Comic Server") or "")|trim %}
-{% set instance_name = configured_instance_name or "Parker Comic Server" %}
+{% set configured_instance_name = (get_system_setting("general.app_name", "Parker") or "")|trim %}
+{% set instance_name = configured_instance_name or "Parker" %}
 <div class="max-w-4xl mx-auto">
 
     {% from "partials/admin_header.html" import admin_header %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Parker{% endblock %}</title>
-    {% set configured_instance_name = (get_system_setting("general.app_name", "Parker Comic Server") or "")|trim %}
-    {% set instance_name = configured_instance_name or "Parker Comic Server" %}
+    {% set configured_instance_name = (get_system_setting("general.app_name", "Parker") or "")|trim %}
+    {% set instance_name = configured_instance_name or "Parker" %}
 
     {# Used for including context-sensitive path data #}
     {% from "partials/config_context.html" import config_context %}

--- a/app/templates/continue_reading.html
+++ b/app/templates/continue_reading.html
@@ -43,6 +43,23 @@
         </template>
     </div>
 
+    <div class="mt-12 pt-6 border-t border-gray-700" x-show="!loading && total > 0" style="display: none;">
+        <template x-if="mode === 'infinite'">
+            <div x-ref="loadSentinel" class="py-8 text-center">
+                <span x-show="loading" class="text-blue-400 animate-pulse">Loading more...</span>
+                <span x-show="!loading && page >= maxPage()" class="text-gray-600 text-sm">End of results</span>
+            </div>
+        </template>
+
+        <template x-if="mode === 'classic'">
+            <div x-show="total > size" class="flex justify-center items-center space-x-4">
+                <button @click="changePage(page - 1)" :disabled="page === 1" class="btn-pagination">Previous</button>
+                <span class="text-gray-400">Page <span class="text-white font-bold" x-text="page"></span> of <span x-text="maxPage()"></span></span>
+                <button @click="changePage(page + 1)" :disabled="page >= maxPage()" class="btn-pagination">Next</button>
+            </div>
+        </template>
+    </div>
+
     <div x-show="!loading && items.length === 0" class="text-center py-20 text-gray-400">
         <p class="text-lg" x-text="getEmptyMessage()"></p>
         <a :href="window.parker.route('pages.home')" class="text-blue-400 hover:underline mt-2 inline-block">Browse Library</a>
@@ -53,9 +70,18 @@
 <script>
 function continueReading() {
     return {
+        ...window.parker.paginationMixin(
+            'progress.recent_progress',
+            null,
+            {
+                pageSize: 20,
+                mode: '{{ get_system_setting("ui.pagination_mode", "infinite") }}',
+                getQueryParams() {
+                    return { filter: this.filter };
+                }
+            }
+        ),
         filter: 'in_progress',
-        items: [],
-        loading: true,
 
         init() {
             this.loadItems();
@@ -63,24 +89,8 @@ function continueReading() {
 
         async setFilter(newFilter) {
             this.filter = newFilter;
+            this.page = 1;
             await this.loadItems();
-        },
-
-        async loadItems() {
-            this.loading = true;
-            this.items = []; // Clear to prevent flash
-            try {
-                // Fetch JSON from existing API
-                const res = await fetch(window.parker.route('progress.recent_progress', {}, `filter=${this.filter}&limit=50`));
-                if (res.ok) {
-                    const data = await res.json();
-                    this.items = data.results;
-                }
-            } catch (e) {
-                console.error("Failed to load progress", e);
-            } finally {
-                this.loading = false;
-            }
         },
 
         getEmptyMessage() {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -113,7 +113,7 @@
         <div x-show="!loading.popular && popularSeries.length > 0">
             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
-                    <span>🔥</span> Trending
+                    <span>🔥</span> Popular with Others
                 </h2>
             </div>
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -110,6 +110,20 @@
             </div>
         </div>
 
+        <div x-show="!loading.trending && trendingSeries.length > 0">
+            <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
+                <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                    <span>⚡</span> Trending
+                </h2>
+            </div>
+
+            <div class="flex space-x-4 overflow-x-auto pb-6 scrollbar-thin scrollbar-thumb-gray-700 scrollbar-track-transparent">
+                <template x-for="series in trendingSeries" :key="series.id">
+                        {% include "partials/series_card.html" %}
+                </template>
+            </div>
+        </div>
+
         <div x-show="!loading.popular && popularSeries.length > 0">
             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
                 <h2 class="text-xl font-bold text-white flex items-center gap-2">
@@ -271,6 +285,7 @@ function homePage(bootstrap = {}) {
         randomSeries: [],
         topRatedComics: [],
         parkerTopRatedComics: [],
+        trendingSeries: [],
         resumeComics: [],
         smartLists: [],
         popularSeries: [],
@@ -283,6 +298,7 @@ function homePage(bootstrap = {}) {
             random: true,
             topRated: true,
             parkerTopRated: true,
+            trending: true,
             resume: true,
             popular: true,
         },
@@ -323,6 +339,7 @@ function homePage(bootstrap = {}) {
             this.fetchRandom();
             this.fetchTopRated();
             this.fetchTopParkerRated();
+            this.fetchTrending();
             this.fetchSmartLists();
             this.fetchPopular();
         },
@@ -403,6 +420,14 @@ function homePage(bootstrap = {}) {
                 if (res.ok) this.parkerTopRatedComics = await res.json();
             } catch(e) { console.error(e); }
             finally { this.loading.parkerTopRated = false; }
+        },
+
+        async fetchTrending() {
+            try {
+                const res = await fetch(window.parker.route('home.trending', {}, 'limit=12'));
+                if (res.ok) this.trendingSeries = await res.json();
+            } catch(e) { console.error(e); }
+            finally { this.loading.trending = false; }
         },
 
         async fetchSmartLists() {

--- a/app/templates/login_full.html
+++ b/app/templates/login_full.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {% set configured_instance_name = (get_system_setting("general.app_name", "Parker Comic Server") or "")|trim %}
-    {% set instance_name = configured_instance_name or "Parker Comic Server" %}
+    {% set configured_instance_name = (get_system_setting("general.app_name", "Parker") or "")|trim %}
+    {% set instance_name = configured_instance_name or "Parker" %}
     <title>Login - {{ instance_name }} | Parker</title>
 
     {# Used for including context-sensitive path data #}

--- a/app/templates/partials/collection_card.html
+++ b/app/templates/partials/collection_card.html
@@ -8,6 +8,10 @@
 
         <p class="text-sm text-gray-400 line-clamp-2 flex-grow" x-show="col.description" x-text="col.description"></p>
 
+        <div class="mt-4 text-sm text-gray-400">
+            <span x-text="`${col.comic_count || 0} comic${(col.comic_count || 0) === 1 ? '' : 's'}`"></span>
+        </div>
+
         <div class="mt-4 flex items-center text-xs text-gray-500 font-medium uppercase tracking-wider">
             <span>View Collection</span>
             <span class="ml-2 transform group-hover:translate-x-1 transition-transform">→</span>

--- a/app/templates/partials/read_series_button.html
+++ b/app/templates/partials/read_series_button.html
@@ -1,8 +1,8 @@
 <a
     :href="window.parker.route('pages.reader', { comic_id: series?.resume_to.comic_id }, `context_type=series&context_id=${seriesId}`)"
     class="flex items-center gap-2 px-6 py-2 rounded-full font-bold transition-colors shadow-lg"
-    :class="series?.resume_to.status === 'in_progress' ? 'bg-blue-600 hover:bg-blue-500 text-white' : 'bg-green-600 hover:bg-green-500 text-white'"
+    :class="series?.resume_to.status !== 'new' ? 'bg-blue-600 hover:bg-blue-500 text-white' : 'bg-green-600 hover:bg-green-500 text-white'"
 >
-    <span class="text-xl" x-text="series?.resume_to.status === 'in_progress' ? '▶' : '📖'"></span>
-    <span x-text="series?.resume_to.status === 'in_progress' ? 'Continue' : 'Start Reading'"></span>
+    <span class="text-xl" x-text="series?.resume_to.status !== 'new' ? '▶' : '📖'"></span>
+    <span x-text="series?.resume_to.status !== 'new' ? 'Continue' : 'Start Reading'"></span>
 </a>

--- a/app/templates/partials/read_volume_button.html
+++ b/app/templates/partials/read_volume_button.html
@@ -1,8 +1,8 @@
 <a
     :href="window.parker.route('pages.reader', { comic_id: volume?.resume_to?.comic_id }, `context_type=volume&context_id=${volumeId}`)"
     class="flex items-center gap-2 px-6 py-2 rounded-full font-bold transition-colors shadow-lg"
-    :class="volume?.resume_to?.status === 'in_progress' ? 'bg-blue-600 hover:bg-blue-500 text-white' : 'bg-green-600 hover:bg-green-500 text-white'"
+    :class="volume?.resume_to?.status !== 'new' ? 'bg-blue-600 hover:bg-blue-500 text-white' : 'bg-green-600 hover:bg-green-500 text-white'"
 >
-    <span class="text-xl" x-text="volume?.resume_to?.status === 'in_progress' ? '▶' : '📖'"></span>
-    <span x-text="volume?.resume_to?.status === 'in_progress' ? 'Continue' : 'Start Reading'"></span>
+    <span class="text-xl" x-text="volume?.resume_to?.status !== 'new' ? '▶' : '📖'"></span>
+    <span x-text="volume?.resume_to?.status !== 'new' ? 'Continue' : 'Start Reading'"></span>
 </a>

--- a/app/templates/partials/reading_list_card.html
+++ b/app/templates/partials/reading_list_card.html
@@ -8,6 +8,10 @@
 
         <p class="text-sm text-gray-400 line-clamp-2 flex-grow" x-show="list.description" x-text="list.description"></p>
 
+        <div class="mt-4 text-sm text-gray-400">
+            <span x-text="`${list.comic_count || 0} comic${(list.comic_count || 0) === 1 ? '' : 's'}`"></span>
+        </div>
+
         <div class="mt-4 flex items-center text-xs text-gray-500 font-medium uppercase tracking-wider">
             <span>Start Reading</span>
             <span class="ml-2 transform group-hover:translate-x-1 transition-transform">→</span>

--- a/app/templates/user/dashboard.html
+++ b/app/templates/user/dashboard.html
@@ -689,12 +689,56 @@ function dashboard() {
             }
         },
 
+        fallbackCopyText(text) {
+            const textarea = document.createElement('textarea');
+            const selection = document.getSelection();
+            const originalRange = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+
+            textarea.value = text;
+            textarea.setAttribute('readonly', '');
+            textarea.style.position = 'fixed';
+            textarea.style.top = '0';
+            textarea.style.left = '-9999px';
+            textarea.style.opacity = '0';
+
+            document.body.appendChild(textarea);
+            textarea.focus();
+            textarea.select();
+            textarea.setSelectionRange(0, textarea.value.length);
+
+            let copied = false;
+
+            try {
+                copied = document.execCommand('copy');
+            } finally {
+                document.body.removeChild(textarea);
+
+                if (originalRange && selection) {
+                    selection.removeAllRanges();
+                    selection.addRange(originalRange);
+                }
+            }
+
+            return copied;
+        },
+
         async copyToClipboard(text) {
             try {
-                await navigator.clipboard.writeText(text);
+                if (navigator.clipboard?.writeText && window.isSecureContext) {
+                    await navigator.clipboard.writeText(text);
+                } else if (!this.fallbackCopyText(text)) {
+                    throw new Error('Clipboard unavailable');
+                }
+
                 window.parker.showToast("Feed URL copied!", "success");
             } catch (err) {
+                if (this.fallbackCopyText(text)) {
+                    window.parker.showToast("Feed URL copied!", "success");
+                    return;
+                }
+
                 console.error('Failed to copy!', err);
+                window.parker.showToast("Unable to copy feed URL.", "error");
             }
         },
 

--- a/docs/archived-vertical-scroll-scope.md
+++ b/docs/archived-vertical-scroll-scope.md
@@ -19,6 +19,7 @@ Those files may still scan and open today, but the reader is currently optimized
 - optional spread logic for wide pages
 
 That works well for conventional western issues and manga, but it is likely to be awkward for very tall pages or long-strip episodes.
+It is also likely to be awkward for archived "slice" releases where adjacent image files together form a continuous vertical reading flow.
 
 ## Non-Goals
 
@@ -35,10 +36,28 @@ Out of scope for this work:
 The most realistic near-term target is:
 
 - archived files that still contain sequential image assets
-- some or many of those images are unusually tall
 - users want to scroll vertically through the content instead of paging through it screen-by-screen
+- some archives may contain unusually tall pages
+- some archives may instead contain many mobile-sized image slices that reconstruct a vertical-scroll episode when stacked in order
 
 We should validate this assumption against real sample archives before implementation.
+
+### Updated Sample Finding
+
+A real-world gray-area sample reported by the user:
+
+- `Peter Parker Spider-Man - Queens Finest - Infinity Comic 001 (2026) (digital-mobile-Empire).cbz`
+
+Observed behavior:
+
+- the archive is chopped into separate sequential images
+- some panels are intentionally cut across image boundaries and continue in the next image
+
+Implication:
+
+- not all archived vertical-scroll material will appear as one or a few extremely tall images
+- some repackaged releases are better understood as "slice archives"
+- Parker's main need is likely a stacked vertical reading mode for ordered archive images, not only special handling for extreme aspect ratios
 
 ## Current System Constraints
 
@@ -101,12 +120,14 @@ Relevant files:
 - `app/services/reading_progress.py`
 
 This may still be usable for archived vertical-scroll files if progress is mapped to the topmost visible image index rather than a pixel offset.
+For slice archives, this means stored progress would effectively track the last reached image slice rather than a true comic "page," which is probably acceptable for an MVP.
 
 ### Image Processing
 
 The image service optionally transcodes and resizes large images for data savings.
 
 Current behavior uses a maximum dimension cap during WebP transcode. That may be too aggressive for extremely tall pages and could damage readability for archived webtoon-style content.
+This risk may matter less for pre-sliced mobile releases, but still needs validation against real samples.
 
 Relevant file:
 
@@ -130,7 +151,7 @@ The smallest useful implementation would likely be a new reader mode, not a rewr
 
 ### MVP User Story
 
-As a user opening a `.cbz` or `.cbr` archive containing very tall sequential images, I can switch into a vertical-scroll reading mode that makes the content readable without adding support for loose images or new file formats.
+As a user opening a `.cbz` or `.cbr` archive containing either very tall images or many sequential mobile-style slices, I can switch into a vertical-scroll reading mode that makes the content readable without adding support for loose images or new file formats.
 
 ### MVP Behaviors
 
@@ -138,6 +159,7 @@ As a user opening a `.cbz` or `.cbr` archive containing very tall sequential ima
 - render pages in a vertical column instead of a fixed page-turn viewport
 - allow native vertical scrolling
 - preserve existing archive-backed image loading
+- treat archive image boundaries as rendering boundaries, not necessarily meaningful comic page boundaries
 - disable double-page mode and spread pairing while in scroll mode
 - keep LTR / RTL paging concepts out of scroll mode unless sample files prove a need
 - update progress using the topmost visible page index or last meaningfully viewed page index
@@ -203,18 +225,22 @@ Possible future auto-detection signals:
 
 - high proportion of pages exceeding a tall aspect-ratio threshold
 - issue with a very small number of extremely tall pages
+- ComicInfo / metadata hints such as `<Format>WebComic</Format>` or `<Format>Web Comic</Format>`, if real libraries show that those values are used consistently enough to trust
+- issue metadata or filename hints such as `digital-mobile` or known release conventions, if those patterns prove reliable enough to justify using them
 - metadata hints if any appear in real sample archives
 
 For MVP, a user-controlled toggle is safer.
 
 ## Open Questions To Validate With Real Samples
 
-- Are repackaged webcomics usually one huge image per episode, or many medium-height slices?
+- Are repackaged webcomics usually one huge image per episode, or many medium-height/mobile-height slices?
 - Do users expect seamless continuous scrolling, or page-by-page vertical reading?
 - Are sample files mostly JPEG, PNG, or mixed assets?
 - How often are there decorative spacer images that should not affect progress too aggressively?
+- How often do panels intentionally continue across adjacent image files?
 - Does current archive page ordering already match intended reading order?
 - Does data-saver resizing make text unreadable on tall images?
+- How often do real libraries actually populate ComicInfo `<Format>` with values like `WebComic` or `Web Comic`, and how trustworthy are those tags in mixed collections?
 
 ## Recommendation
 

--- a/docs/archived-vertical-scroll-scope.md
+++ b/docs/archived-vertical-scroll-scope.md
@@ -231,6 +231,25 @@ Possible future auto-detection signals:
 
 For MVP, a user-controlled toggle is safer.
 
+## Possible Follow-Up: Per-Comic Reader Overrides
+
+If Parker eventually adds a manual vertical-scroll mode, it may be worth remembering that choice per comic instead of making it a global reader default.
+
+Why this could help:
+
+- a user may want normal paged reading for most comics
+- a specific archived webcomic may always work better in scroll mode
+- restoring that choice on return would reduce repeated mode switching without forcing scroll mode onto unrelated comics
+
+Recommended shape if this is ever explored:
+
+- keep global reader settings as the default behavior
+- allow sparse per-comic overrides only for content-specific settings such as `readingMode`
+- possibly extend that to a very small set of additional settings like `readDirection` or `fitMode` if real use cases justify it
+- prefer a single local-storage map of overrides over one key per comic to avoid unnecessary key sprawl
+
+This should be treated as a later refinement, not an MVP requirement.
+
 ## Open Questions To Validate With Real Samples
 
 - Are repackaged webcomics usually one huge image per episode, or many medium-height/mobile-height slices?

--- a/docs/archived-vertical-scroll-scope.md
+++ b/docs/archived-vertical-scroll-scope.md
@@ -1,0 +1,237 @@
+# Archived Vertical-Scroll Compatibility Scope
+
+Status: Draft
+
+This note sketches a narrow approach for improving support for webcomic / webtoon-style material that has already been packaged into `.cbz` or `.cbr` archives.
+
+The intent is not to add support for loose image folders or native online webcomic sources. The goal is only to improve the reading experience for unusually tall archived pages inside Parker's existing archive-based workflow.
+
+## Why This Exists
+
+Some users may have comics from gray-area or fan-archival sources where originally vertical-scroll material has been repackaged into standard comic archives.
+
+Those files may still scan and open today, but the reader is currently optimized for page-turn reading:
+
+- one or two pages at a time
+- fixed viewport
+- tap zones for next / previous
+- progress tracked by page index
+- optional spread logic for wide pages
+
+That works well for conventional western issues and manga, but it is likely to be awkward for very tall pages or long-strip episodes.
+
+## Non-Goals
+
+Out of scope for this work:
+
+- support for loose image folders
+- support for direct remote webcomic sources
+- changes to library scanning beyond existing `.cbz` / `.cbr` support
+- a general-purpose HTML/web article reader
+- speculative metadata models for "webtoon" as a first-class format before we have sample files
+
+## Working Assumption
+
+The most realistic near-term target is:
+
+- archived files that still contain sequential image assets
+- some or many of those images are unusually tall
+- users want to scroll vertically through the content instead of paging through it screen-by-screen
+
+We should validate this assumption against real sample archives before implementation.
+
+## Current System Constraints
+
+The current reader has several assumptions that are good for paged comics but likely hostile to vertical-scroll material.
+
+### Reader Layout
+
+The reader viewport is fixed and hides overflow:
+
+- `body { overflow: hidden; }`
+- `.reader-content { overflow: hidden; }`
+
+This prevents natural vertical document scrolling.
+
+Relevant file:
+
+- `app/templates/reader.html`
+
+### Navigation Model
+
+Reader interaction is page-turn based:
+
+- left/right tap zones
+- swipe left/right navigation
+- keyboard next / previous
+- scrubber based on `page_count`
+- `currentPage` as the main state anchor
+
+Relevant file:
+
+- `app/templates/reader.html`
+
+### Double-Page / Spread Logic
+
+The reader currently contains logic for:
+
+- single-page mode
+- double-page mode
+- cover offset
+- spread detection based on landscape images
+- manga RTL vs western LTR
+
+Most of that logic is either irrelevant or counterproductive for long-strip reading.
+
+Relevant file:
+
+- `app/templates/reader.html`
+
+### Progress Model
+
+Reading progress is page-based, not scroll-position-based:
+
+- progress updates store `current_page`
+- completion is based on `current_page >= total_pages - 1`
+- activity logging records pages turned
+
+Relevant files:
+
+- `app/templates/reader.html`
+- `app/services/reading_progress.py`
+
+This may still be usable for archived vertical-scroll files if progress is mapped to the topmost visible image index rather than a pixel offset.
+
+### Image Processing
+
+The image service optionally transcodes and resizes large images for data savings.
+
+Current behavior uses a maximum dimension cap during WebP transcode. That may be too aggressive for extremely tall pages and could damage readability for archived webtoon-style content.
+
+Relevant file:
+
+- `app/services/images.py`
+
+## Proposed Framing
+
+We should avoid presenting this as broad "webcomics support."
+
+Better framing:
+
+- `Archived Vertical-Scroll Compatibility`
+- `Tall Page Reader Improvements`
+- `Long-Strip Archive Reading`
+
+This keeps the feature grounded in Parker's actual supported input formats.
+
+## Suggested MVP
+
+The smallest useful implementation would likely be a new reader mode, not a rewrite of the default one.
+
+### MVP User Story
+
+As a user opening a `.cbz` or `.cbr` archive containing very tall sequential images, I can switch into a vertical-scroll reading mode that makes the content readable without adding support for loose images or new file formats.
+
+### MVP Behaviors
+
+- add a `scroll` reader mode alongside current paged modes
+- render pages in a vertical column instead of a fixed page-turn viewport
+- allow native vertical scrolling
+- preserve existing archive-backed image loading
+- disable double-page mode and spread pairing while in scroll mode
+- keep LTR / RTL paging concepts out of scroll mode unless sample files prove a need
+- update progress using the topmost visible page index or last meaningfully viewed page index
+- keep completion based on reaching the last archived page
+
+## Places Likely To Change
+
+### `app/templates/reader.html`
+
+Likely the main work area:
+
+- new `readingMode` state such as `paged` vs `scroll`
+- alternate layout for vertical flow
+- conditional controls and shortcuts
+- conditional hiding of spread-only settings
+- scroll observer logic for progress updates
+- adjusted mobile touch behavior
+
+### `app/services/reading_progress.py`
+
+May need small changes only if current page-based semantics prove insufficient.
+
+Preferred approach:
+
+- keep the persistence model unchanged if possible
+- continue storing page index
+- define scroll progress as "most recently reached page image"
+
+This avoids schema churn.
+
+### `app/services/images.py`
+
+Needs review for data-saver behavior on extreme aspect ratios.
+
+Open questions:
+
+- should tall images skip the current max-dimension shrink path?
+- should resize rules preserve width more aggressively for tall pages?
+- should data-saver be disabled or adjusted in scroll mode?
+
+### Tests
+
+We will likely want focused coverage for:
+
+- reader init with tall-page-friendly mode selection if auto-detection is added
+- progress updates while scrolling
+- completion when final archived page becomes visible
+- data-saver behavior for extreme aspect ratios
+
+Frontend reader behavior may need a mix of template-level regression tests and targeted service tests where possible.
+
+## Auto-Detection vs Manual Toggle
+
+Recommended initial approach: manual toggle.
+
+Why:
+
+- we do not yet know how repackaged files are structured in the wild
+- some archives may mix standard pages and tall pages
+- false positives would be annoying in the main reader
+
+Possible future auto-detection signals:
+
+- high proportion of pages exceeding a tall aspect-ratio threshold
+- issue with a very small number of extremely tall pages
+- metadata hints if any appear in real sample archives
+
+For MVP, a user-controlled toggle is safer.
+
+## Open Questions To Validate With Real Samples
+
+- Are repackaged webcomics usually one huge image per episode, or many medium-height slices?
+- Do users expect seamless continuous scrolling, or page-by-page vertical reading?
+- Are sample files mostly JPEG, PNG, or mixed assets?
+- How often are there decorative spacer images that should not affect progress too aggressively?
+- Does current archive page ordering already match intended reading order?
+- Does data-saver resizing make text unreadable on tall images?
+
+## Recommendation
+
+Do not commit this to a release until we have real sample files.
+
+Once samples are available, the preferred path is:
+
+1. verify that the content arrives inside normal `.cbz` / `.cbr` archives
+2. inspect page dimensions and archive ordering
+3. prototype a manual `scroll mode` in the existing reader
+4. adjust image-transcode rules for tall-page readability if needed
+5. only then decide whether this deserves release-note status
+
+## Release Planning Note
+
+This feels better as a targeted reader enhancement than as a headline format-support feature.
+
+Possible release-note wording later, if validated:
+
+- Added an optional vertical-scroll reader mode for tall-page content inside archived comic formats such as `.cbz` and `.cbr`.

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -1,6 +1,6 @@
 # Parker 0.1.20 Release Notes
 
-Status: In Progress
+Status: Release Candidate
 
 This file tracks the work landing in `0.1.20` so release notes can be built incrementally instead of reconstructed at release time.
 
@@ -20,6 +20,7 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 - Fixed lingering test-suite warnings by replacing legacy SQLAlchemy `Query.get()` usage in the scanner/metadata writer paths, switching `last_scanned` updates to timezone-aware UTC timestamps, and filtering the current upstream Starlette `TestClient` `httpx` deprecation warning until the dependency stack is updated.
 - Fixed the admin Diagnostics `Copy Support Snapshot` action so it now falls back to a legacy textarea-based clipboard flow when the modern Clipboard API is unavailable or blocked, improving reliability on iPad/Safari and other restrictive browser contexts.
 - Fixed the user dashboard OPDS `Copy URL` action so it uses the same legacy clipboard fallback as Diagnostics when the modern Clipboard API is unavailable or blocked, improving feed-url copy reliability in restrictive browser contexts.
+- Fixed the Continue Reading page so long reading-history tabs such as `Completed` now support real pagination instead of silently truncating the view to a fixed first batch.
 - Fixed OPDS issue acquisition entries so they now advertise the comic's real archive type instead of a generic ZIP payload, aligned OPDS download filenames/content types with the actual file extension, and prevented titleless comics from generating doubled extensions like `.cbz.cbz` in download names for better compatibility with readers like Suwatee.
 - Fixed the revamped admin Settings page so it no longer exposes raw internal setting keys like `ui.login_background_style` in the default card UI, keeping the page focused on user-friendly labels and descriptions.
 - Fixed series and volume detail `Continue` actions so a fully completed latest issue now advances to the next unread issue in reading order instead of reopening the issue the user already finished, while still preserving the `Continue` button treatment for readers already working through that series or volume.
@@ -60,6 +61,14 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 .venv\Scripts\python.exe -m pytest tests/services/test_scanner_parallel.py
 ```
 
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_progress.py tests/api/test_pages.py
+```
+
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_pages.py
+```
+
 - Current results:
   - `tests/api/test_pages.py`: `10 passed`
   - `tests/api/test_opds.py`: `8 passed`
@@ -73,3 +82,5 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
   - `tests/api/test_pages.py`: `11 passed`
   - `tests/services/test_generated_container_services.py tests/services/test_metadata_service.py`: `8 passed`
   - `tests/services/test_scanner_parallel.py`: `9 passed`
+  - `tests/api/test_progress.py tests/api/test_pages.py`: `28 passed`
+  - `tests/api/test_pages.py`: `12 passed`

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -13,6 +13,7 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 - Renamed the home reading-activity rail from `Trending` to `Popular with Others` so the UI matches its current all-user social-proof behavior instead of implying time-sensitive ranking.
 - Shortened the default server display name from `Parker Comic Server` to `Parker` and aligned template fallbacks so the default branding behaves better in the top navigation on tighter layouts.
 - Added visible comic counts to the Collections and Reading Lists landing-page cards so those browse screens are easier to scan before opening a container.
+- Optimized auto-generated Collection and Reading List membership updates during scans and metadata rehydrate passes so unchanged comics no longer churn through unnecessary delete-and-reinsert writes.
 
 ## Fixed
 
@@ -51,6 +52,10 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 .venv\Scripts\python.exe -m pytest tests/api/test_pages.py
 ```
 
+```bash
+.venv\Scripts\python.exe -m pytest tests/services/test_generated_container_services.py tests/services/test_metadata_service.py
+```
+
 - Current results:
   - `tests/api/test_pages.py`: `10 passed`
   - `tests/api/test_opds.py`: `8 passed`
@@ -62,3 +67,4 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
   - `tests/api/test_home.py tests/core/test_route_map.py`: `17 passed`
   - `tests/api/test_users.py tests/api/test_pages.py`: `24 passed`
   - `tests/api/test_pages.py`: `11 passed`
+  - `tests/services/test_generated_container_services.py tests/services/test_metadata_service.py`: `8 passed`

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -17,6 +17,7 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 
 - Fixed lingering test-suite warnings by replacing legacy SQLAlchemy `Query.get()` usage in the scanner/metadata writer paths, switching `last_scanned` updates to timezone-aware UTC timestamps, and filtering the current upstream Starlette `TestClient` `httpx` deprecation warning until the dependency stack is updated.
 - Fixed the admin Diagnostics `Copy Support Snapshot` action so it now falls back to a legacy textarea-based clipboard flow when the modern Clipboard API is unavailable or blocked, improving reliability on iPad/Safari and other restrictive browser contexts.
+- Fixed the user dashboard OPDS `Copy URL` action so it uses the same legacy clipboard fallback as Diagnostics when the modern Clipboard API is unavailable or blocked, improving feed-url copy reliability in restrictive browser contexts.
 - Fixed OPDS issue acquisition entries so they now advertise the comic's real archive type instead of a generic ZIP payload, aligned OPDS download filenames/content types with the actual file extension, and prevented titleless comics from generating doubled extensions like `.cbz.cbz` in download names for better compatibility with readers like Suwatee.
 - Fixed the revamped admin Settings page so it no longer exposes raw internal setting keys like `ui.login_background_style` in the default card UI, keeping the page focused on user-friendly labels and descriptions.
 - Fixed series and volume detail `Continue` actions so a fully completed latest issue now advances to the next unread issue in reading order instead of reopening the issue the user already finished, while still preserving the `Continue` button treatment for readers already working through that series or volume.
@@ -41,6 +42,10 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 .venv\Scripts\python.exe -m pytest tests/api/test_home.py tests/core/test_route_map.py
 ```
 
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_users.py tests/api/test_pages.py
+```
+
 - Current results:
   - `tests/api/test_pages.py`: `10 passed`
   - `tests/api/test_opds.py`: `8 passed`
@@ -50,3 +55,4 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
   - Combined detail-page suite: `34 passed`
   - `tests/api/test_settings.py tests/api/test_pages.py`: `21 passed`
   - `tests/api/test_home.py tests/core/test_route_map.py`: `17 passed`
+  - `tests/api/test_users.py tests/api/test_pages.py`: `24 passed`

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -15,7 +15,7 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 ## Fixed
 
 - Fixed the admin Diagnostics `Copy Support Snapshot` action so it now falls back to a legacy textarea-based clipboard flow when the modern Clipboard API is unavailable or blocked, improving reliability on iPad/Safari and other restrictive browser contexts.
-- Fixed OPDS issue acquisition entries so they now advertise the comic's real archive type instead of a generic ZIP payload, and aligned OPDS download filenames/content types with the actual file extension to improve compatibility with readers like Suwatee.
+- Fixed OPDS issue acquisition entries so they now advertise the comic's real archive type instead of a generic ZIP payload, aligned OPDS download filenames/content types with the actual file extension, and prevented titleless comics from generating doubled extensions like `.cbz.cbz` in download names for better compatibility with readers like Suwatee.
 - Fixed the revamped admin Settings page so it no longer exposes raw internal setting keys like `ui.login_background_style` in the default card UI, keeping the page focused on user-friendly labels and descriptions.
 
 ## Validation
@@ -23,13 +23,10 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 - Verified with:
 
 ```bash
-.venv\Scripts\pytest.exe tests/api/test_pages.py -q
-```
-
-```bash
-.venv\Scripts\pytest.exe tests/api/test_opds.py -q
+.venv\Scripts\python.exe -m pytest tests/api/test_pages.py tests/api/test_opds.py
 ```
 
 - Current results:
   - `tests/api/test_pages.py`: `10 passed`
-  - `tests/api/test_opds.py`: `7 passed`
+  - `tests/api/test_opds.py`: `8 passed`
+  - Combined targeted suite: `18 passed`

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -1,0 +1,19 @@
+# Parker 0.1.20 Release Notes
+
+Status: In Progress
+
+This file tracks the work landing in `0.1.20` so release notes can be built incrementally instead of reconstructed at release time.
+
+## Added
+
+## Changed
+
+- Renamed the home reading-activity rail from `Trending` to `Popular with Others` so the UI matches its current all-user social-proof behavior instead of implying time-sensitive ranking.
+
+## Fixed
+
+## Validation
+
+- Verified with:
+
+- Current results:

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -11,6 +11,7 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 ## Changed
 
 - Renamed the home reading-activity rail from `Trending` to `Popular with Others` so the UI matches its current all-user social-proof behavior instead of implying time-sensitive ranking.
+- Shortened the default server display name from `Parker Comic Server` to `Parker` and aligned template fallbacks so the default branding behaves better in the top navigation on tighter layouts.
 
 ## Fixed
 
@@ -31,6 +32,10 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 .venv\Scripts\python.exe -m pytest tests/api/test_series.py tests/api/test_volumes.py
 ```
 
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_settings.py tests/api/test_pages.py
+```
+
 - Current results:
   - `tests/api/test_pages.py`: `10 passed`
   - `tests/api/test_opds.py`: `8 passed`
@@ -38,3 +43,4 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
   - `tests/api/test_series.py`: `26 passed`
   - `tests/api/test_volumes.py`: `8 passed`
   - Combined detail-page suite: `34 passed`
+  - `tests/api/test_settings.py tests/api/test_pages.py`: `21 passed`

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -15,6 +15,7 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 
 ## Fixed
 
+- Fixed lingering test-suite warnings by replacing legacy SQLAlchemy `Query.get()` usage in the scanner/metadata writer paths, switching `last_scanned` updates to timezone-aware UTC timestamps, and filtering the current upstream Starlette `TestClient` `httpx` deprecation warning until the dependency stack is updated.
 - Fixed the admin Diagnostics `Copy Support Snapshot` action so it now falls back to a legacy textarea-based clipboard flow when the modern Clipboard API is unavailable or blocked, improving reliability on iPad/Safari and other restrictive browser contexts.
 - Fixed OPDS issue acquisition entries so they now advertise the comic's real archive type instead of a generic ZIP payload, aligned OPDS download filenames/content types with the actual file extension, and prevented titleless comics from generating doubled extensions like `.cbz.cbz` in download names for better compatibility with readers like Suwatee.
 - Fixed the revamped admin Settings page so it no longer exposes raw internal setting keys like `ui.login_background_style` in the default card UI, keeping the page focused on user-friendly labels and descriptions.

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -56,6 +56,10 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 .venv\Scripts\python.exe -m pytest tests/services/test_generated_container_services.py tests/services/test_metadata_service.py
 ```
 
+```bash
+.venv\Scripts\python.exe -m pytest tests/services/test_scanner_parallel.py
+```
+
 - Current results:
   - `tests/api/test_pages.py`: `10 passed`
   - `tests/api/test_opds.py`: `8 passed`
@@ -68,3 +72,4 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
   - `tests/api/test_users.py tests/api/test_pages.py`: `24 passed`
   - `tests/api/test_pages.py`: `11 passed`
   - `tests/services/test_generated_container_services.py tests/services/test_metadata_service.py`: `8 passed`
+  - `tests/services/test_scanner_parallel.py`: `9 passed`

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -6,7 +6,7 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 
 ## Added
 
-- No entries yet.
+- Added a new time-sensitive `Trending` home rail driven by opted-in recent reading activity from the last 30 days, ranked by recent activity volume, then distinct readers, then freshest activity.
 
 ## Changed
 
@@ -36,6 +36,10 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 .venv\Scripts\python.exe -m pytest tests/api/test_settings.py tests/api/test_pages.py
 ```
 
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_home.py tests/core/test_route_map.py
+```
+
 - Current results:
   - `tests/api/test_pages.py`: `10 passed`
   - `tests/api/test_opds.py`: `8 passed`
@@ -44,3 +48,4 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
   - `tests/api/test_volumes.py`: `8 passed`
   - Combined detail-page suite: `34 passed`
   - `tests/api/test_settings.py tests/api/test_pages.py`: `21 passed`
+  - `tests/api/test_home.py tests/core/test_route_map.py`: `17 passed`

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -17,6 +17,7 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 - Fixed the admin Diagnostics `Copy Support Snapshot` action so it now falls back to a legacy textarea-based clipboard flow when the modern Clipboard API is unavailable or blocked, improving reliability on iPad/Safari and other restrictive browser contexts.
 - Fixed OPDS issue acquisition entries so they now advertise the comic's real archive type instead of a generic ZIP payload, aligned OPDS download filenames/content types with the actual file extension, and prevented titleless comics from generating doubled extensions like `.cbz.cbz` in download names for better compatibility with readers like Suwatee.
 - Fixed the revamped admin Settings page so it no longer exposes raw internal setting keys like `ui.login_background_style` in the default card UI, keeping the page focused on user-friendly labels and descriptions.
+- Fixed series and volume detail `Continue` actions so a fully completed latest issue now advances to the next unread issue in reading order instead of reopening the issue the user already finished, while still preserving the `Continue` button treatment for readers already working through that series or volume.
 
 ## Validation
 
@@ -26,7 +27,14 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 .venv\Scripts\python.exe -m pytest tests/api/test_pages.py tests/api/test_opds.py
 ```
 
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_series.py tests/api/test_volumes.py
+```
+
 - Current results:
   - `tests/api/test_pages.py`: `10 passed`
   - `tests/api/test_opds.py`: `8 passed`
   - Combined targeted suite: `18 passed`
+  - `tests/api/test_series.py`: `26 passed`
+  - `tests/api/test_volumes.py`: `8 passed`
+  - Combined detail-page suite: `34 passed`

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -1,6 +1,6 @@
 # Parker 0.1.20 Release Notes
 
-Status: Release Candidate
+Status: Ready for Release
 
 This file tracks the work landing in `0.1.20` so release notes can be built incrementally instead of reconstructed at release time.
 

--- a/docs/releases/0.1.20.md
+++ b/docs/releases/0.1.20.md
@@ -12,6 +12,7 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 
 - Renamed the home reading-activity rail from `Trending` to `Popular with Others` so the UI matches its current all-user social-proof behavior instead of implying time-sensitive ranking.
 - Shortened the default server display name from `Parker Comic Server` to `Parker` and aligned template fallbacks so the default branding behaves better in the top navigation on tighter layouts.
+- Added visible comic counts to the Collections and Reading Lists landing-page cards so those browse screens are easier to scan before opening a container.
 
 ## Fixed
 
@@ -46,6 +47,10 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
 .venv\Scripts\python.exe -m pytest tests/api/test_users.py tests/api/test_pages.py
 ```
 
+```bash
+.venv\Scripts\python.exe -m pytest tests/api/test_pages.py
+```
+
 - Current results:
   - `tests/api/test_pages.py`: `10 passed`
   - `tests/api/test_opds.py`: `8 passed`
@@ -56,3 +61,4 @@ This file tracks the work landing in `0.1.20` so release notes can be built incr
   - `tests/api/test_settings.py tests/api/test_pages.py`: `21 passed`
   - `tests/api/test_home.py tests/core/test_route_map.py`: `17 passed`
   - `tests/api/test_users.py tests/api/test_pages.py`: `24 passed`
+  - `tests/api/test_pages.py`: `11 passed`

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 pythonpath = .
 testpaths = tests
 addopts = --cov=app --cov-report=term-missing
+filterwarnings =
+    ignore:Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead\.:starlette.exceptions.StarletteDeprecationWarning

--- a/tests/api/test_home.py
+++ b/tests/api/test_home.py
@@ -278,6 +278,208 @@ def test_home_top_parker_rated_applies_age_filter(auth_client, db, normal_user):
     assert {item["id"] for item in payload} == {safe.id, safe_two.id, safe_three.id, safe_four.id}
 
 
+def test_home_trending_returns_empty_below_threshold(auth_client, db):
+    sharer = _add_user(
+        db,
+        username="trending-threshold-sharer",
+        email="trending-threshold-sharer@example.com",
+        share_progress_enabled=True,
+    )
+
+    now = datetime.now(timezone.utc)
+    comics = []
+    for idx in range(1, 4):
+        _, _, volume = _create_series_graph(
+            db,
+            lib_name=f"home-trending-threshold-lib-{idx}",
+            series_name=f"Home Trending Threshold {idx}",
+        )
+        comics.append(_add_comic(db, volume, number="1", title=f"Trending Threshold #{idx}"))
+
+    for comic in comics:
+        db.add(
+            ReadingProgress(
+                user_id=sharer.id,
+                comic_id=comic.id,
+                current_page=5,
+                total_pages=10,
+                completed=False,
+                last_read_at=now - timedelta(days=2),
+            )
+        )
+
+    db.commit()
+
+    response = auth_client.get("/api/home/trending?limit=10")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_home_trending_orders_by_recent_activity_then_readers_then_latest(auth_client, db, normal_user):
+    now = datetime.now(timezone.utc)
+
+    sharer_a = _add_user(
+        db,
+        username="trending-sharer-a",
+        email="trending-sharer-a@example.com",
+        share_progress_enabled=True,
+    )
+    sharer_b = _add_user(
+        db,
+        username="trending-sharer-b",
+        email="trending-sharer-b@example.com",
+        share_progress_enabled=True,
+    )
+    sharer_c = _add_user(
+        db,
+        username="trending-sharer-c",
+        email="trending-sharer-c@example.com",
+        share_progress_enabled=True,
+    )
+    hidden = _add_user(
+        db,
+        username="trending-hidden",
+        email="trending-hidden@example.com",
+        share_progress_enabled=False,
+    )
+
+    _, top_series, top_volume = _create_series_graph(db, lib_name="home-trending-top-lib", series_name="Trending Top")
+    top_comics = [
+        _add_comic(db, top_volume, number="1", title="Trending Top #1", year=2024, publisher="Trending Pub"),
+        _add_comic(db, top_volume, number="2", title="Trending Top #2", year=2024, publisher="Trending Pub"),
+        _add_comic(db, top_volume, number="3", title="Trending Top #3", year=2024, publisher="Trending Pub"),
+    ]
+
+    _, tiebreak_series, tiebreak_volume = _create_series_graph(db, lib_name="home-trending-tiebreak-lib", series_name="Trending Tiebreak")
+    tiebreak_comics = [
+        _add_comic(db, tiebreak_volume, number="1", title="Trending Tiebreak #1", year=2024, publisher="Trending Pub"),
+        _add_comic(db, tiebreak_volume, number="2", title="Trending Tiebreak #2", year=2024, publisher="Trending Pub"),
+        _add_comic(db, tiebreak_volume, number="3", title="Trending Tiebreak #3", year=2024, publisher="Trending Pub"),
+    ]
+
+    _, fresh_series, fresh_volume = _create_series_graph(db, lib_name="home-trending-fresh-lib", series_name="Trending Fresh")
+    fresh_comics = [
+        _add_comic(db, fresh_volume, number="1", title="Trending Fresh #1", year=2024, publisher="Trending Pub"),
+        _add_comic(db, fresh_volume, number="2", title="Trending Fresh #2", year=2024, publisher="Trending Pub"),
+    ]
+
+    _, minimal_series, minimal_volume = _create_series_graph(db, lib_name="home-trending-minimal-lib", series_name="Trending Minimal")
+    minimal_comic = _add_comic(db, minimal_volume, number="1", title="Trending Minimal #1", year=2024, publisher="Trending Pub")
+
+    _, stale_series, stale_volume = _create_series_graph(db, lib_name="home-trending-stale-lib", series_name="Trending Stale")
+    stale_comics = [
+        _add_comic(db, stale_volume, number="1", title="Trending Stale #1", year=2024, publisher="Trending Pub"),
+        _add_comic(db, stale_volume, number="2", title="Trending Stale #2", year=2024, publisher="Trending Pub"),
+        _add_comic(db, stale_volume, number="3", title="Trending Stale #3", year=2024, publisher="Trending Pub"),
+    ]
+
+    db.add_all([
+        ReadingProgress(user_id=sharer_a.id, comic_id=top_comics[0].id, current_page=6, total_pages=10, completed=False, last_read_at=now - timedelta(hours=3)),
+        ReadingProgress(user_id=sharer_b.id, comic_id=top_comics[1].id, current_page=10, total_pages=10, completed=True, last_read_at=now - timedelta(hours=2)),
+        ReadingProgress(user_id=sharer_a.id, comic_id=top_comics[2].id, current_page=8, total_pages=10, completed=False, last_read_at=now - timedelta(hours=1)),
+
+        ReadingProgress(user_id=sharer_c.id, comic_id=tiebreak_comics[0].id, current_page=4, total_pages=10, completed=False, last_read_at=now - timedelta(minutes=20)),
+        ReadingProgress(user_id=sharer_c.id, comic_id=tiebreak_comics[1].id, current_page=5, total_pages=10, completed=False, last_read_at=now - timedelta(minutes=10)),
+        ReadingProgress(user_id=sharer_c.id, comic_id=tiebreak_comics[2].id, current_page=10, total_pages=10, completed=True, last_read_at=now - timedelta(minutes=5)),
+
+        ReadingProgress(user_id=sharer_a.id, comic_id=fresh_comics[0].id, current_page=6, total_pages=10, completed=False, last_read_at=now - timedelta(minutes=3)),
+        ReadingProgress(user_id=sharer_b.id, comic_id=fresh_comics[1].id, current_page=10, total_pages=10, completed=True, last_read_at=now - timedelta(minutes=2)),
+
+        ReadingProgress(user_id=sharer_b.id, comic_id=minimal_comic.id, current_page=5, total_pages=10, completed=False, last_read_at=now - timedelta(minutes=1)),
+
+        ReadingProgress(user_id=sharer_a.id, comic_id=stale_comics[0].id, current_page=5, total_pages=10, completed=False, last_read_at=now - timedelta(days=45)),
+        ReadingProgress(user_id=sharer_b.id, comic_id=stale_comics[1].id, current_page=5, total_pages=10, completed=False, last_read_at=now - timedelta(days=44)),
+        ReadingProgress(user_id=sharer_c.id, comic_id=stale_comics[2].id, current_page=5, total_pages=10, completed=False, last_read_at=now - timedelta(days=43)),
+        ReadingProgress(user_id=hidden.id, comic_id=top_comics[0].id, current_page=10, total_pages=10, completed=True, last_read_at=now),
+        ReadingProgress(user_id=normal_user.id, comic_id=fresh_comics[0].id, current_page=9, total_pages=10, completed=False, last_read_at=now),
+    ])
+    db.commit()
+
+    response = auth_client.get("/api/home/trending?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["id"] for item in payload] == [
+        top_series.id,
+        tiebreak_series.id,
+        fresh_series.id,
+        minimal_series.id,
+    ]
+    assert stale_series.id not in [item["id"] for item in payload]
+
+
+def test_home_trending_applies_age_filter(auth_client, db, normal_user):
+    now = datetime.now(timezone.utc)
+    sharer_a = _add_user(
+        db,
+        username="trending-age-a",
+        email="trending-age-a@example.com",
+        share_progress_enabled=True,
+    )
+    sharer_b = _add_user(
+        db,
+        username="trending-age-b",
+        email="trending-age-b@example.com",
+        share_progress_enabled=True,
+    )
+
+    safe_ids = set()
+    safe_comics = []
+    for idx in range(1, 5):
+        _, series, volume = _create_series_graph(
+            db,
+            lib_name=f"home-trending-age-safe-lib-{idx}",
+            series_name=f"Home Trending Age Safe {idx}",
+        )
+        comic = _add_comic(
+            db,
+            volume,
+            number="1",
+            title=f"Trending Age Safe #{idx}",
+            age_rating="Teen",
+            year=2024,
+            publisher="Trending Pub",
+        )
+        safe_ids.add(series.id)
+        safe_comics.append(comic)
+
+    _, banned_series, banned_volume = _create_series_graph(
+        db,
+        lib_name="home-trending-age-banned-lib",
+        series_name="Home Trending Age Banned",
+    )
+    banned_comics = [
+        _add_comic(db, banned_volume, number="1", title="Trending Age Banned #1", age_rating="Mature 17+", year=2024, publisher="Trending Pub"),
+        _add_comic(db, banned_volume, number="2", title="Trending Age Banned #2", age_rating="Mature 17+", year=2024, publisher="Trending Pub"),
+    ]
+
+    db.add_all([
+        ReadingProgress(user_id=sharer_a.id, comic_id=safe_comics[0].id, current_page=6, total_pages=10, completed=False, last_read_at=now - timedelta(days=1)),
+        ReadingProgress(user_id=sharer_b.id, comic_id=safe_comics[0].id, current_page=10, total_pages=10, completed=True, last_read_at=now - timedelta(hours=20)),
+        ReadingProgress(user_id=sharer_a.id, comic_id=safe_comics[1].id, current_page=6, total_pages=10, completed=False, last_read_at=now - timedelta(days=2)),
+        ReadingProgress(user_id=sharer_b.id, comic_id=safe_comics[1].id, current_page=10, total_pages=10, completed=True, last_read_at=now - timedelta(days=2, hours=1)),
+        ReadingProgress(user_id=sharer_a.id, comic_id=safe_comics[2].id, current_page=6, total_pages=10, completed=False, last_read_at=now - timedelta(days=3)),
+        ReadingProgress(user_id=sharer_b.id, comic_id=safe_comics[2].id, current_page=10, total_pages=10, completed=True, last_read_at=now - timedelta(days=3, hours=1)),
+        ReadingProgress(user_id=sharer_a.id, comic_id=safe_comics[3].id, current_page=6, total_pages=10, completed=False, last_read_at=now - timedelta(days=4)),
+        ReadingProgress(user_id=sharer_b.id, comic_id=safe_comics[3].id, current_page=10, total_pages=10, completed=True, last_read_at=now - timedelta(days=4, hours=1)),
+        ReadingProgress(user_id=sharer_a.id, comic_id=banned_comics[0].id, current_page=8, total_pages=10, completed=False, last_read_at=now - timedelta(minutes=2)),
+        ReadingProgress(user_id=sharer_b.id, comic_id=banned_comics[1].id, current_page=10, total_pages=10, completed=True, last_read_at=now - timedelta(minutes=1)),
+    ])
+
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    response = auth_client.get("/api/home/trending?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 4
+    assert {item["id"] for item in payload} == safe_ids
+    assert banned_series.id not in {item["id"] for item in payload}
+
+
 def test_home_resume_applies_staleness_and_progress_percentage(auth_client, db, normal_user):
     _, _, volume = _create_series_graph(db, lib_name="home-resume-lib", series_name="Home Resume")
 

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -237,3 +237,35 @@ def test_opds_download_uses_real_archive_type_and_extension(client, db, normal_u
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/vnd.comicbook-rar")
     assert 'filename="Comic - First Blast.cbr"' in response.headers["content-disposition"]
+
+
+def test_opds_download_uses_filename_stem_when_title_missing(client, db, normal_user, tmp_path):
+    _enable_opds(db)
+
+    archive_path = tmp_path / "titleless-special.cbz"
+    archive_path.write_bytes(b"fake-zip")
+
+    library = Library(name="Titleless Library", path=str(tmp_path / "titleless-library"))
+    series = Series(name="Titleless Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    comic = Comic(
+        volume=volume,
+        number="2",
+        title=None,
+        filename="titleless-special.cbz",
+        file_path=str(archive_path),
+    )
+    db.add_all([library, series, volume, comic])
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    from unittest.mock import patch
+
+    with patch("app.api.opds_deps.verify_password", return_value=True):
+        response = client.get(
+            f"/opds/download/{comic.id}",
+            auth=(normal_user.username, "any_password")
+        )
+
+    assert response.status_code == 200
+    assert 'filename="Comic - titleless-special.cbz"' in response.headers["content-disposition"]

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -121,6 +121,18 @@ def test_collection_and_reading_list_pages_expose_comic_count_labels(auth_client
     assert "list.comic_count || 0" in reading_lists_response.text
 
 
+def test_continue_reading_page_exposes_pagination_controls(auth_client):
+    response = auth_client.get("/continue-reading")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "window.parker.paginationMixin(" in body
+    assert "'progress.recent_progress'" in body
+    assert "mode: 'infinite'" in body
+    assert "x-ref=\"loadSentinel\"" in body
+    assert "Page <span class=\"text-white font-bold\" x-text=\"page\"></span> of" in body
+
+
 def test_user_settings_page_renders_for_authenticated_user(auth_client):
     response = auth_client.get("/user/settings")
 

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -110,6 +110,17 @@ def test_advanced_search_page_exposes_full_creator_filter_set(auth_client):
     assert '<option value="cover_artist">Cover Artist</option>' in body
 
 
+def test_collection_and_reading_list_pages_expose_comic_count_labels(auth_client):
+    collections_response = auth_client.get("/collections")
+    reading_lists_response = auth_client.get("/reading-lists")
+
+    assert collections_response.status_code == 200
+    assert "col.comic_count || 0" in collections_response.text
+
+    assert reading_lists_response.status_code == 200
+    assert "list.comic_count || 0" in reading_lists_response.text
+
+
 def test_user_settings_page_renders_for_authenticated_user(auth_client):
     response = auth_client.get("/user/settings")
 

--- a/tests/api/test_progress.py
+++ b/tests/api/test_progress.py
@@ -291,6 +291,64 @@ def test_recent_progress_filters_completed_and_in_progress(auth_client, db, norm
     assert in_progress_payload["results"][0]["comic_id"] == data["second"].id
 
 
+def test_recent_progress_paginates_results(auth_client, db, normal_user):
+    data = _seed_progress_data(db, lib_name="progress-pagination", series_name="Pagination Progress")
+
+    third = Comic(
+        volume_id=data["volume"].id,
+        number="3",
+        title="Pagination Progress #3",
+        year=2026,
+        filename="Pagination-3.cbz",
+        file_path="/tmp/Pagination-3-progress-pagination.cbz",
+        page_count=14,
+    )
+    db.add(third)
+    db.flush()
+
+    now = datetime.now(timezone.utc)
+    db.add_all([
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=data["first"].id,
+            current_page=9,
+            total_pages=10,
+            completed=True,
+            last_read_at=now - timedelta(minutes=3),
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=data["second"].id,
+            current_page=8,
+            total_pages=12,
+            completed=True,
+            last_read_at=now - timedelta(minutes=2),
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=third.id,
+            current_page=13,
+            total_pages=14,
+            completed=True,
+            last_read_at=now - timedelta(minutes=1),
+        ),
+    ])
+    db.commit()
+
+    response = auth_client.get("/api/progress/?filter=completed&page=2&size=2")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["filter"] == "completed"
+    assert payload["page"] == 2
+    assert payload["size"] == 2
+    assert payload["total"] == 3
+    assert len(payload["items"]) == 1
+    assert len(payload["results"]) == 1
+    assert payload["results"][0]["comic_id"] == data["first"].id
+    assert payload["items"][0]["comic_id"] == data["first"].id
+
+
 def test_on_deck_only_returns_started_unfinished_items(auth_client, db, normal_user):
     data = _seed_progress_data(db, lib_name="progress-deck", series_name="Deck Progress")
 

--- a/tests/api/test_series.py
+++ b/tests/api/test_series.py
@@ -731,6 +731,66 @@ def test_series_detail_non_reverse_cover_logic_and_resume_default(auth_client, d
     assert payload["resume_to"]["comic_id"] == payload["first_issue_id"]
 
 
+def test_series_detail_advances_to_next_issue_when_latest_progress_is_completed(auth_client, db, normal_user):
+    library = Library(name="series-detail-next-lib", path="/tmp/series-detail-next-lib")
+    series = Series(name="Series Next Logic", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([library, series, volume])
+    db.flush()
+
+    issue_one = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="Series Next #1",
+        filename="series-next-1.cbz",
+        file_path="/tmp/series-next-1.cbz",
+    )
+    issue_two = Comic(
+        volume_id=volume.id,
+        number="2",
+        title="Series Next #2",
+        filename="series-next-2.cbz",
+        file_path="/tmp/series-next-2.cbz",
+    )
+    issue_three = Comic(
+        volume_id=volume.id,
+        number="3",
+        title="Series Next #3",
+        filename="series-next-3.cbz",
+        file_path="/tmp/series-next-3.cbz",
+    )
+    db.add_all([issue_one, issue_two, issue_three])
+
+    normal_user.accessible_libraries.append(library)
+    db.flush()
+
+    db.add_all([
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=issue_one.id,
+            current_page=20,
+            total_pages=20,
+            completed=True,
+            last_read_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=issue_two.id,
+            current_page=22,
+            total_pages=22,
+            completed=True,
+            last_read_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        ),
+    ])
+    db.commit()
+
+    response = auth_client.get(f"/api/series/{series.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["resume_to"] == {"comic_id": issue_three.id, "status": "continue"}
+
+
 def test_series_detail_filters_related_containers_with_banned_content(auth_client, db, normal_user):
     library = Library(name="series-detail-ban-lib", path="/tmp/series-detail-ban-lib")
 

--- a/tests/api/test_settings.py
+++ b/tests/api/test_settings.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from app.models.setting import SystemSetting
 from app.services.settings_service import SettingsService, SERVER_DISPLAY_NAME_MAX_LENGTH
 from app.api.deps import get_current_user_optional
 from app.main import app
@@ -97,3 +98,33 @@ def test_update_setting_rejects_server_display_name_that_is_too_long(admin_clien
 
     assert response.status_code == 422
     assert f"{SERVER_DISPLAY_NAME_MAX_LENGTH} characters or fewer" in response.json()["detail"]
+
+
+def test_initialize_defaults_seeds_short_server_display_name(db):
+    service = SettingsService(db)
+
+    service.initialize_defaults()
+
+    assert service.get("general.app_name") == "Parker"
+
+
+def test_initialize_defaults_preserves_existing_custom_server_display_name(db):
+    db.add(
+        SystemSetting(
+            key="general.app_name",
+            value="Fortress Comics",
+            category="general",
+            data_type="string",
+            label="Old Label",
+            description="Old description",
+        )
+    )
+    db.commit()
+
+    service = SettingsService(db)
+    service.initialize_defaults()
+
+    setting = db.query(SystemSetting).filter(SystemSetting.key == "general.app_name").first()
+    assert setting is not None
+    assert setting.value == "Fortress Comics"
+    assert setting.label == "Server Display Name"

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -65,6 +65,7 @@ def test_user_dashboard_page_shows_base_aware_opds_url(auth_client):
     assert response.status_code == 200
     assert "window.parker.url('/opds/')" in response.text
     assert "/api/opds/" not in response.text
+    assert "document.execCommand('copy')" in response.text
 
 
 def test_get_and_update_preferences(auth_client):

--- a/tests/api/test_volumes.py
+++ b/tests/api/test_volumes.py
@@ -339,6 +339,66 @@ def test_volume_detail_marks_standalone_without_plain_issues(auth_client, db, no
     assert payload["expected_count"] is None
 
 
+def test_volume_detail_advances_to_next_issue_when_latest_progress_is_completed(auth_client, db, normal_user):
+    library = Library(name="volume-next-lib", path="/tmp/volume-next-lib")
+    series = Series(name="Volume Next Logic", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([library, series, volume])
+    db.flush()
+
+    issue_one = Comic(
+        volume_id=volume.id,
+        number="1",
+        title="Volume Next #1",
+        filename="volume-next-1.cbz",
+        file_path="/tmp/volume-next-1.cbz",
+    )
+    issue_two = Comic(
+        volume_id=volume.id,
+        number="2",
+        title="Volume Next #2",
+        filename="volume-next-2.cbz",
+        file_path="/tmp/volume-next-2.cbz",
+    )
+    issue_three = Comic(
+        volume_id=volume.id,
+        number="3",
+        title="Volume Next #3",
+        filename="volume-next-3.cbz",
+        file_path="/tmp/volume-next-3.cbz",
+    )
+    db.add_all([issue_one, issue_two, issue_three])
+
+    normal_user.accessible_libraries.append(library)
+    db.flush()
+
+    db.add_all([
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=issue_one.id,
+            current_page=20,
+            total_pages=20,
+            completed=True,
+            last_read_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=issue_two.id,
+            current_page=22,
+            total_pages=22,
+            completed=True,
+            last_read_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        ),
+    ])
+    db.commit()
+
+    response = auth_client.get(f"/api/volumes/{volume.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["resume_to"] == {"comic_id": issue_three.id, "status": "continue"}
+
+
 def test_volume_issues_returns_404_without_access(auth_client, db):
     data = _create_volume_fixture(db, lib_name="hidden-issues-lib", series_name="Hidden Issues")
 

--- a/tests/core/test_route_map.py
+++ b/tests/core/test_route_map.py
@@ -31,7 +31,7 @@ def test_get_route_map_uses_flattened_routes():
     route_map = get_route_map(app)
     admin_route_map = get_route_map(app, with_admin_routes=True)
 
-    assert route_map["libraries"]["list"] == "/api/libraries/"
+    assert route_map["libraries"]["list"] == "/api/libraries"
     assert route_map["pages"]["login"] == "/login"
     assert route_map["login"] == "/login"
     assert "admin" not in route_map
@@ -49,6 +49,10 @@ def test_get_route_map_supports_included_router_wrappers():
     def top_parker_rated():
         return []
 
+    @router.get("/trending", name="trending")
+    def trending():
+        return []
+
     wrapped_router = SimpleNamespace(
         original_router=router,
         include_context=SimpleNamespace(prefix="/api/home", tags=["home"]),
@@ -60,6 +64,7 @@ def test_get_route_map_supports_included_router_wrappers():
 
     assert route_map["home"]["random_gems"] == "/api/home/random"
     assert route_map["home"]["top_parker_rated"] == "/api/home/parker-rated"
+    assert route_map["home"]["trending"] == "/api/home/trending"
 
 
 def test_flat_alias_does_not_override_namespace():
@@ -81,5 +86,5 @@ def test_flat_alias_does_not_override_namespace():
 
     route_map = get_route_map(app)
 
-    assert route_map["series"]["list"] == "/api/series/"
+    assert route_map["series"]["list"] == "/api/series"
     assert route_map["libraries"]["series"] == "/api/libraries/{library_id}/series"

--- a/tests/services/test_generated_container_services.py
+++ b/tests/services/test_generated_container_services.py
@@ -1,0 +1,139 @@
+from app.models import (
+    CollectionItem,
+    Comic,
+    Library,
+    ReadingListItem,
+    Series,
+    Volume,
+)
+from app.services.collection import CollectionService
+from app.services.reading_list import ReadingListService
+
+
+def _create_comic(db, suffix: str) -> Comic:
+    library = Library(name=f"Library {suffix}", path=f"/library/{suffix}")
+    series = Series(name=f"Series {suffix}", library=library)
+    volume = Volume(series=series, volume_number=1)
+    comic = Comic(
+        volume=volume,
+        filename=f"{suffix}.cbz",
+        file_path=f"/library/{suffix}/{suffix}.cbz",
+        page_count=24,
+    )
+    db.add_all([library, series, volume, comic])
+    db.commit()
+    db.refresh(comic)
+    return comic
+
+
+def test_update_comic_collections_noops_when_membership_matches(db):
+    comic = _create_comic(db, "collection-noop")
+    service = CollectionService(db)
+
+    service.update_comic_collections(comic, "Marvel Knights")
+    db.commit()
+
+    original_item = db.query(CollectionItem).filter(CollectionItem.comic_id == comic.id).one()
+
+    service.update_comic_collections(comic, "Marvel Knights")
+    db.commit()
+
+    items = db.query(CollectionItem).filter(CollectionItem.comic_id == comic.id).all()
+    assert len(items) == 1
+    assert items[0].id == original_item.id
+    assert items[0].collection.name == "Marvel Knights"
+
+
+def test_update_comic_collections_reassigns_when_membership_changes(db):
+    comic = _create_comic(db, "collection-reassign")
+    service = CollectionService(db)
+
+    service.update_comic_collections(comic, "Marvel Knights")
+    db.commit()
+
+    service.update_comic_collections(comic, "Street Level")
+    db.commit()
+
+    items = db.query(CollectionItem).filter(CollectionItem.comic_id == comic.id).all()
+    assert len(items) == 1
+    assert items[0].collection.name == "Street Level"
+
+
+def test_update_comic_collections_removes_membership_when_group_clears(db):
+    comic = _create_comic(db, "collection-clear")
+    service = CollectionService(db)
+
+    service.update_comic_collections(comic, "Marvel Knights")
+    db.commit()
+
+    service.update_comic_collections(comic, None)
+    db.commit()
+
+    assert db.query(CollectionItem).filter(CollectionItem.comic_id == comic.id).count() == 0
+
+
+def test_update_comic_reading_lists_noops_when_name_and_position_match(db):
+    comic = _create_comic(db, "list-noop")
+    service = ReadingListService(db)
+
+    service.update_comic_reading_lists(comic, "Civil War", "3")
+    db.commit()
+
+    original_item = db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).one()
+
+    service.update_comic_reading_lists(comic, "Civil War", "3")
+    db.commit()
+
+    items = db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).all()
+    assert len(items) == 1
+    assert items[0].id == original_item.id
+    assert items[0].reading_list.name == "Civil War"
+    assert items[0].position == 3.0
+
+
+def test_update_comic_reading_lists_updates_position_in_place(db):
+    comic = _create_comic(db, "list-position")
+    service = ReadingListService(db)
+
+    service.update_comic_reading_lists(comic, "Civil War", "3")
+    db.commit()
+
+    original_item = db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).one()
+
+    service.update_comic_reading_lists(comic, "Civil War", "4")
+    db.commit()
+
+    items = db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).all()
+    assert len(items) == 1
+    assert items[0].id == original_item.id
+    assert items[0].position == 4.0
+    assert items[0].reading_list.name == "Civil War"
+
+
+def test_update_comic_reading_lists_reassigns_when_list_changes(db):
+    comic = _create_comic(db, "list-reassign")
+    service = ReadingListService(db)
+
+    service.update_comic_reading_lists(comic, "Civil War", "3")
+    db.commit()
+
+    service.update_comic_reading_lists(comic, "Secret Invasion", "1")
+    db.commit()
+
+    items = db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).all()
+    assert len(items) == 1
+    assert items[0].reading_list.name == "Secret Invasion"
+    assert items[0].position == 1.0
+
+
+def test_update_comic_reading_lists_clears_membership_when_number_is_invalid(db):
+    comic = _create_comic(db, "list-clear-invalid")
+    service = ReadingListService(db)
+
+    service.update_comic_reading_lists(comic, "Civil War", "3")
+    db.commit()
+
+    service.update_comic_reading_lists(comic, "Civil War", "not-a-number")
+    db.commit()
+
+    assert db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).count() == 0

--- a/tests/services/test_metadata_writer.py
+++ b/tests/services/test_metadata_writer.py
@@ -57,6 +57,9 @@ class _FakeDB:
         self.library_obj = SimpleNamespace(path=library_path)
         self.closed = False
 
+    def get(self, _model, _library_id):
+        return self.library_obj
+
     def query(self, model):
         return _FakeQuery(model, self.library_obj)
 

--- a/tests/services/test_scanner_parallel.py
+++ b/tests/services/test_scanner_parallel.py
@@ -1,9 +1,15 @@
+import multiprocessing
+import zipfile
 from queue import Empty
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 import app.services.scanner as scanner_module
+from app.database import Base
+from app.models import Collection, CollectionItem, Comic, Library, ReadingList, ReadingListItem
 from app.services.scanner import LibraryScanner
 
 
@@ -115,6 +121,40 @@ def _create_file(path):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(b"x")
     return path
+
+
+def _create_cbz_with_comicinfo(
+    path,
+    *,
+    series: str,
+    number: str,
+    title: str,
+    series_group: str | None = None,
+    alternate_series: str | None = None,
+    alternate_number: str | None = None,
+):
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    parts = [
+        "<ComicInfo>",
+        f"<Series>{series}</Series>",
+        f"<Number>{number}</Number>",
+        f"<Title>{title}</Title>",
+    ]
+
+    if series_group:
+        parts.append(f"<SeriesGroup>{series_group}</SeriesGroup>")
+    if alternate_series:
+        parts.append(f"<AlternateSeries>{alternate_series}</AlternateSeries>")
+    if alternate_number:
+        parts.append(f"<AlternateNumber>{alternate_number}</AlternateNumber>")
+
+    parts.append("</ComicInfo>")
+    xml = "".join(parts)
+
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("001.jpg", b"not-a-real-image-but-good-enough-for-page-detection")
+        archive.writestr("ComicInfo.xml", xml.encode("utf-8"))
 
 
 def _disable_container_cleanup(scanner):
@@ -443,3 +483,73 @@ def test_scan_parallel_passes_library_metadata_flags_to_writer(monkeypatch, tmp_
     assert writer_kwargs["parse_reading_lists"] is False
     assert writer_kwargs["parse_collections"] is False
     assert writer_kwargs["parse_story_arcs"] is False
+
+
+def test_scan_parallel_real_pool_and_writer_smoke(monkeypatch, tmp_path):
+    library_path = tmp_path / "library"
+    _create_cbz_with_comicinfo(
+        library_path / "alpha.cbz",
+        series="Smoke Series",
+        number="1",
+        title="Alpha",
+        series_group="Smoke Collection",
+        alternate_series="Smoke Event",
+        alternate_number="1",
+    )
+    _create_cbz_with_comicinfo(
+        library_path / "beta.cbz",
+        series="Smoke Series",
+        number="2",
+        title="Beta",
+        series_group="Smoke Collection",
+        alternate_series="Smoke Event",
+        alternate_number="2",
+    )
+
+    db_path = tmp_path / "parallel-smoke.db"
+    db_url = f"sqlite:///{db_path.as_posix()}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+
+    # Force a fresh-import spawn context so the real writer process resolves the
+    # temp DATABASE_URL consistently on both Windows and Linux.
+    spawn_ctx = multiprocessing.get_context("spawn")
+    monkeypatch.setattr(scanner_module, "Queue", spawn_ctx.Queue)
+    monkeypatch.setattr(scanner_module.multiprocessing, "Process", spawn_ctx.Process)
+    monkeypatch.setattr(scanner_module.multiprocessing, "Pool", spawn_ctx.Pool)
+
+    engine = create_engine(
+        db_url,
+        connect_args={"check_same_thread": False, "timeout": 60},
+    )
+    SessionLocal = sessionmaker(autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+    try:
+        library = Library(name="Parallel Smoke", path=str(library_path))
+        db.add(library)
+        db.commit()
+        db.refresh(library)
+
+        scanner = LibraryScanner(library, db)
+        result = scanner.scan_parallel(force=False, worker_limit=2)
+
+        assert result["imported"] == 2
+        assert result["updated"] == 0
+        assert result["deleted"] == 0
+        assert result["errors"] == 0
+    finally:
+        db.close()
+
+    verify_db = SessionLocal()
+    try:
+        assert verify_db.query(Comic).count() == 2
+
+        collection = verify_db.query(Collection).filter(Collection.name == "Smoke Collection").one()
+        reading_list = verify_db.query(ReadingList).filter(ReadingList.name == "Smoke Event").one()
+
+        assert verify_db.query(CollectionItem).filter(CollectionItem.collection_id == collection.id).count() == 2
+        assert verify_db.query(ReadingListItem).filter(ReadingListItem.reading_list_id == reading_list.id).count() == 2
+    finally:
+        verify_db.close()
+        engine.dispose()


### PR DESCRIPTION
## Summary

This release tightens up Parker's home-page semantics, improves a few day-to-day UX details, and cleans up some backend behavior that was doing unnecessary work during scans.

## Highlights

- adds a new time-sensitive `Trending` home rail based on opted-in recent reading activity from the last 30 days
- renames the old reading-activity rail from `Trending` to `Popular with Others` so its label matches its long-tail social-proof behavior
- shortens the default app name from `Parker Comic Server` to `Parker`, including a migration path that preserves customized installs
- adds visible comic counts to Collection and Reading List landing cards
- optimizes auto-generated Collection and Reading List membership updates so unchanged comics no longer churn through unnecessary delete/reinsert writes
- adds a real multiprocessing smoke test for the parallel scanner pipeline
- fixes clipboard fallback behavior for Diagnostics and the dashboard OPDS `Copy URL` action
- fixes Continue Reading so larger history tabs now paginate correctly and honor the site's pagination mode
- fixes lingering SQLAlchemy/datetime/test warnings and a few other detail-page and OPDS correctness issues landed on this branch
- Series and volume `Continue` actions now properly move forward to the next unread issue when the latest issue is already fully completed.


## Validation

- `tests/api/test_pages.py tests/api/test_opds.py`
- `tests/api/test_series.py tests/api/test_volumes.py`
- `tests/api/test_settings.py tests/api/test_pages.py`
- `tests/api/test_home.py tests/core/test_route_map.py`
- `tests/api/test_users.py tests/api/test_pages.py`
- `tests/services/test_generated_container_services.py tests/services/test_metadata_service.py`
- `tests/services/test_scanner_parallel.py`
- `tests/api/test_progress.py tests/api/test_pages.py`