### PR TITLE
Add following management and arrival flows for volumes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,3 +29,8 @@ This file captures follow-up work that should not get lost between releases.
   Context: The current warning logic is much more useful than before, but we lost the original reporter's environment after they rebuilt from scratch, so we no longer have a live repro to interrogate.
   Current risk: A fresh install with a valid comics mount and no configured libraries can still look superficially similar to a "wrong storage directory" situation.
   Follow-up goal: Reassess the signals used for `storage_mismatch_suspected` once we have another real-world report or a better synthetic repro, and tune the messaging so first-run onboarding is not mistaken for a broken upgrade.
+
+- Decide the long-term policy for inaccessible followed volumes.
+  Context: `user_volume_follows` rows currently remain persisted even if a user's library access or age-rating settings later hide that volume from all user-facing follow surfaces.
+  Current behavior: The follow is filtered out of the `Following` page, the `New from Following` home rail, and direct volume access checks, but the row is not pruned automatically.
+  Follow-up goal: Confirm whether Parker should keep this hidden-and-persisted behavior, surface inaccessible follows in a disabled state, or automatically prune them after some explicit rule.

--- a/alembic/versions/9f1a2c6b4d10_add_user_volume_follows_table.py
+++ b/alembic/versions/9f1a2c6b4d10_add_user_volume_follows_table.py
@@ -1,0 +1,34 @@
+"""add_user_volume_follows_table
+
+Revision ID: 9f1a2c6b4d10
+Revises: 7d3f4a6c9b21
+Create Date: 2026-07-17 11:55:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9f1a2c6b4d10"
+down_revision: Union[str, None] = "7d3f4a6c9b21"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_volume_follows",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("volume_id", sa.Integer(), nullable=False),
+        sa.Column("followed_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["volume_id"], ["volumes.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "volume_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_volume_follows")

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends
-from sqlalchemy import Float
+from sqlalchemy import Float, and_, or_
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.sql.expression import func, desc, cast
 from typing import List
@@ -8,9 +8,10 @@ from collections import defaultdict
 
 from app.core.settings_loader import get_cached_setting
 from app.api.deps import SessionDep, CurrentUser
-from app.core.comic_helpers import get_smart_cover, get_series_age_restriction, get_thumbnail_url
+from app.core.comic_helpers import get_format_filters, get_smart_cover, get_series_age_restriction, get_thumbnail_url
 from app.models.comic import Comic, Volume
 from app.models.interactions import UserComicRating
+from app.models.interactions import UserVolumeFollow
 from app.models.series import Series
 from app.models.user import User
 from app.models.reading_progress import ReadingProgress
@@ -364,6 +365,67 @@ def get_resume_reading(
         .all()
 
     return [format_home_item(c, p) for c, p in results]
+
+
+@router.get("/following-arrivals", response_model=List[ComicSearchItem], name="following_arrivals")
+def get_following_arrivals(
+        db: SessionDep,
+        current_user: CurrentUser,
+        limit: int = 10,
+):
+    """
+    Get newly arrived plain issues from followed volumes.
+    Uses the follow timestamp as the baseline and excludes comics the user has
+    already started or completed.
+    """
+
+    is_plain, _, _ = get_format_filters()
+
+    not_started_or_read = or_(
+        ReadingProgress.id == None,
+        and_(
+            ReadingProgress.completed == False,
+            or_(ReadingProgress.current_page == None, ReadingProgress.current_page <= 0),
+        ),
+    )
+
+    query = (
+        db.query(Comic)
+        .join(UserVolumeFollow, UserVolumeFollow.volume_id == Comic.volume_id)
+        .join(Volume).join(Series)
+        .outerjoin(
+            ReadingProgress,
+            and_(
+                ReadingProgress.comic_id == Comic.id,
+                ReadingProgress.user_id == current_user.id,
+            ),
+        )
+        .options(joinedload(Comic.volume).joinedload(Volume.series))
+        .filter(UserVolumeFollow.user_id == current_user.id)
+        .filter(Comic.created_at > UserVolumeFollow.followed_at)
+        .filter(is_plain)
+        .filter(not_started_or_read)
+    )
+
+    if not current_user.is_superuser:
+        allowed_ids = [lib.id for lib in current_user.accessible_libraries]
+        query = query.filter(Series.library_id.in_(allowed_ids))
+
+    age_filter = get_series_age_restriction(current_user)
+    if age_filter is not None:
+        query = query.filter(age_filter)
+
+    results = (
+        query.order_by(
+            desc(Comic.created_at),
+            desc(cast(Comic.number, Float)),
+            desc(Comic.number),
+        )
+        .limit(limit)
+        .all()
+    )
+
+    return [format_home_item(comic) for comic in results]
 
 
 @router.get("/trending", response_model=List[dict], name="trending")

--- a/app/api/volumes.py
+++ b/app/api/volumes.py
@@ -1,11 +1,14 @@
+from datetime import datetime, timezone
+
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func, case, Float, Integer, literal, or_
+from sqlalchemy import func, case, Float, Integer, literal, or_, and_, cast, desc
 from sqlalchemy.orm import joinedload
 
 from typing import List, Annotated
 
 from app.core.comic_helpers import (get_format_filters, get_smart_cover, get_reading_time,
                                     REVERSE_NUMBERING_SERIES, get_age_rating_config, get_thumbnail_url,
+                                    get_series_age_restriction,
                                     get_resume_target)
 
 from app.api.deps import SessionDep, CurrentUser, VolumeDep
@@ -14,6 +17,7 @@ from app.api.deps import PaginationParams, PaginatedResponse
 from app.models.comic import Comic, Volume
 from app.models.series import Series
 from app.models.credits import Person, ComicCredit
+from app.models.interactions import UserVolumeFollow
 from app.models.tags import Character, Team, Location
 from app.models.reading_progress import ReadingProgress
 
@@ -32,6 +36,214 @@ def comic_to_simple_dict(comic: Comic):
     }
 
 
+def _assert_volume_allowed_for_user(volume_id: int, db, current_user) -> None:
+    if current_user.is_superuser or not current_user.max_age_rating:
+        return
+
+    allowed_ratings, banned_ratings = get_age_rating_config(current_user)
+
+    # Build the "Banned" filter
+    ban_conditions = [Comic.age_rating.in_(banned_ratings)]
+
+    # If user explicitly disallows Unknowns, treat them as banned
+    if not current_user.allow_unknown_age_ratings:
+        ban_conditions.append(or_(
+            Comic.age_rating == None,
+            Comic.age_rating == "",
+            func.lower(Comic.age_rating) == "unknown"
+        ))
+
+    # Run the check: Does a banned comic exist in this volume?
+    has_banned_content = db.query(Comic.id).filter(
+        Comic.volume_id == volume_id,
+        or_(*ban_conditions)
+    ).first()
+
+    if has_banned_content:
+        raise HTTPException(status_code=403, detail="Volume contains age-restricted content")
+
+
+@router.get("/following", name="following_list")
+def get_followed_volumes(
+        db: SessionDep,
+        current_user: CurrentUser,
+):
+    """List followed volumes the user can still access, with lightweight arrival context."""
+
+    is_plain, _, _ = get_format_filters()
+    not_started_or_read = or_(
+        ReadingProgress.id == None,
+        and_(
+            ReadingProgress.completed == False,
+            or_(ReadingProgress.current_page == None, ReadingProgress.current_page <= 0),
+        ),
+    )
+
+    new_arrivals_count_sq = (
+        db.query(func.count(Comic.id))
+        .outerjoin(
+            ReadingProgress,
+            and_(
+                ReadingProgress.comic_id == Comic.id,
+                ReadingProgress.user_id == current_user.id,
+            ),
+        )
+        .filter(Comic.volume_id == Volume.id)
+        .filter(Comic.created_at > UserVolumeFollow.followed_at)
+        .filter(is_plain)
+        .filter(not_started_or_read)
+        .correlate(Volume, UserVolumeFollow)
+        .scalar_subquery()
+    )
+
+    latest_arrival_created_at_sq = (
+        db.query(func.max(Comic.created_at))
+        .outerjoin(
+            ReadingProgress,
+            and_(
+                ReadingProgress.comic_id == Comic.id,
+                ReadingProgress.user_id == current_user.id,
+            ),
+        )
+        .filter(Comic.volume_id == Volume.id)
+        .filter(Comic.created_at > UserVolumeFollow.followed_at)
+        .filter(is_plain)
+        .filter(not_started_or_read)
+        .correlate(Volume, UserVolumeFollow)
+        .scalar_subquery()
+    )
+
+    latest_arrival_id_sq = (
+        db.query(Comic.id)
+        .outerjoin(
+            ReadingProgress,
+            and_(
+                ReadingProgress.comic_id == Comic.id,
+                ReadingProgress.user_id == current_user.id,
+            ),
+        )
+        .filter(Comic.volume_id == Volume.id)
+        .filter(Comic.created_at > UserVolumeFollow.followed_at)
+        .filter(is_plain)
+        .filter(not_started_or_read)
+        .order_by(
+            desc(Comic.created_at),
+            desc(cast(Comic.number, Float)),
+            desc(Comic.number),
+        )
+        .limit(1)
+        .correlate(Volume, UserVolumeFollow)
+        .scalar_subquery()
+    )
+
+    latest_arrival_title_sq = (
+        db.query(Comic.title)
+        .outerjoin(
+            ReadingProgress,
+            and_(
+                ReadingProgress.comic_id == Comic.id,
+                ReadingProgress.user_id == current_user.id,
+            ),
+        )
+        .filter(Comic.volume_id == Volume.id)
+        .filter(Comic.created_at > UserVolumeFollow.followed_at)
+        .filter(is_plain)
+        .filter(not_started_or_read)
+        .order_by(
+            desc(Comic.created_at),
+            desc(cast(Comic.number, Float)),
+            desc(Comic.number),
+        )
+        .limit(1)
+        .correlate(Volume, UserVolumeFollow)
+        .scalar_subquery()
+    )
+
+    latest_arrival_number_sq = (
+        db.query(Comic.number)
+        .outerjoin(
+            ReadingProgress,
+            and_(
+                ReadingProgress.comic_id == Comic.id,
+                ReadingProgress.user_id == current_user.id,
+            ),
+        )
+        .filter(Comic.volume_id == Volume.id)
+        .filter(Comic.created_at > UserVolumeFollow.followed_at)
+        .filter(is_plain)
+        .filter(not_started_or_read)
+        .order_by(
+            desc(Comic.created_at),
+            desc(cast(Comic.number, Float)),
+            desc(Comic.number),
+        )
+        .limit(1)
+        .correlate(Volume, UserVolumeFollow)
+        .scalar_subquery()
+    )
+
+    query = (
+        db.query(
+            UserVolumeFollow,
+            new_arrivals_count_sq.label("new_arrivals_count"),
+            latest_arrival_created_at_sq.label("latest_arrival_created_at"),
+            latest_arrival_id_sq.label("latest_arrival_id"),
+            latest_arrival_title_sq.label("latest_arrival_title"),
+            latest_arrival_number_sq.label("latest_arrival_number"),
+        )
+        .join(Volume, Volume.id == UserVolumeFollow.volume_id)
+        .join(Series, Series.id == Volume.series_id)
+        .options(
+            joinedload(UserVolumeFollow.volume)
+            .joinedload(Volume.series)
+            .joinedload(Series.library)
+        )
+        .filter(UserVolumeFollow.user_id == current_user.id)
+    )
+
+    if not current_user.is_superuser:
+        allowed_ids = [lib.id for lib in current_user.accessible_libraries]
+        query = query.filter(Series.library_id.in_(allowed_ids))
+
+    series_age_filter = get_series_age_restriction(current_user)
+    if series_age_filter is not None:
+        query = query.filter(series_age_filter)
+
+    rows = query.order_by(
+        desc(new_arrivals_count_sq),
+        desc(latest_arrival_created_at_sq),
+        desc(UserVolumeFollow.followed_at),
+        Series.name.asc(),
+        Volume.volume_number.asc(),
+    ).all()
+
+    payload = []
+    for follow, new_arrivals_count, latest_arrival_created_at, latest_arrival_id, latest_arrival_title, latest_arrival_number in rows:
+        payload.append(
+            {
+                "volume_id": follow.volume_id,
+                "volume_number": follow.volume.volume_number,
+                "series_id": follow.volume.series_id,
+                "series_name": follow.volume.series.name,
+                "library_id": follow.volume.series.library_id,
+                "library_name": follow.volume.series.library.name,
+                "followed_at": follow.followed_at,
+                "new_arrivals_count": int(new_arrivals_count or 0),
+                "latest_arrival": (
+                    {
+                        "comic_id": latest_arrival_id,
+                        "title": latest_arrival_title,
+                        "number": latest_arrival_number,
+                        "created_at": latest_arrival_created_at,
+                    }
+                    if latest_arrival_id is not None else None
+                ),
+            }
+        )
+
+    return payload
+
+
 @router.get("/{volume_id}", name="detail")
 async def get_volume_detail(volume: VolumeDep, db: SessionDep, current_user: CurrentUser):
     """
@@ -42,30 +254,7 @@ async def get_volume_detail(volume: VolumeDep, db: SessionDep, current_user: Cur
     # Note: VolumeDep handles 404, but we need to check restrictions.
     # 0. Check Age Restriction: Poison Pill check
     # If the user has restrictions, we check if this volume contains ANY banned content.
-    if not current_user.is_superuser and current_user.max_age_rating:
-
-        allowed_ratings, banned_ratings = get_age_rating_config(current_user)
-
-        # Build the "Banned" filter
-        ban_conditions = [Comic.age_rating.in_(banned_ratings)]
-
-        # If user explicitly disallows Unknowns, treat them as banned
-        if not current_user.allow_unknown_age_ratings:
-            ban_conditions.append(or_(
-                Comic.age_rating == None,
-                Comic.age_rating == "",
-                func.lower(Comic.age_rating) == "unknown"
-            ))
-
-        # Run the check: Does a banned comic exist in this volume?
-        has_banned_content = db.query(Comic.id).filter(
-            Comic.volume_id == volume.id,
-            or_(*ban_conditions)
-        ).first()
-
-        if has_banned_content:
-            raise HTTPException(status_code=403, detail="Volume contains age-restricted content")
-    # --------------------------------------
+    _assert_volume_allowed_for_user(volume.id, db, current_user)
 
 
 
@@ -252,6 +441,11 @@ async def get_volume_detail(volume: VolumeDep, db: SessionDep, current_user: Cur
     if volume.series:
         is_reverse_series = volume.series.name.lower() in REVERSE_NUMBERING_SERIES
 
+    follow = db.query(UserVolumeFollow).filter(
+        UserVolumeFollow.user_id == current_user.id,
+        UserVolumeFollow.volume_id == volume.id,
+    ).first()
+
     return {
         "id": volume.id,
         "volume_number": volume.volume_number,
@@ -287,9 +481,47 @@ async def get_volume_detail(volume: VolumeDep, db: SessionDep, current_user: Cur
             "comic_id": resume_comic_id,
             "status": read_status
         },
+        "is_following": bool(follow),
         "colors": colors,
         "is_reverse_numbering": is_reverse_series,
     }
+
+
+@router.post("/{volume_id}/follow", name="follow")
+async def follow_volume(volume: VolumeDep, db: SessionDep, current_user: CurrentUser):
+    _assert_volume_allowed_for_user(volume.id, db, current_user)
+
+    follow = db.query(UserVolumeFollow).filter(
+        UserVolumeFollow.user_id == current_user.id,
+        UserVolumeFollow.volume_id == volume.id,
+    ).first()
+
+    if not follow:
+        follow = UserVolumeFollow(
+            user_id=current_user.id,
+            volume_id=volume.id,
+            followed_at=datetime.now(timezone.utc),
+        )
+        db.add(follow)
+        db.commit()
+
+    return {"following": True}
+
+
+@router.delete("/{volume_id}/follow", name="unfollow")
+async def unfollow_volume(volume: VolumeDep, db: SessionDep, current_user: CurrentUser):
+    _assert_volume_allowed_for_user(volume.id, db, current_user)
+
+    follow = db.query(UserVolumeFollow).filter(
+        UserVolumeFollow.user_id == current_user.id,
+        UserVolumeFollow.volume_id == volume.id,
+    ).first()
+
+    if follow:
+        db.delete(follow)
+        db.commit()
+
+    return {"following": False}
 
 
 @router.get("/{volume_id}/issues", response_model=PaginatedResponse, name="issues")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,7 +9,7 @@ from app.models.collection import Collection, CollectionItem
 from app.models.reading_progress import ReadingProgress
 from app.models.job import ScanJob
 from app.models.user import User
-from app.models.interactions import UserSeries, UserComicRating
+from app.models.interactions import UserSeries, UserVolumeFollow, UserComicRating
 from app.models.saved_search import SavedSearch
 from app.models.setting import SystemSetting
 from app.models.pull_list import PullList, PullListItem
@@ -26,7 +26,7 @@ __all__ = [
     'ReadingProgress', 'ActivityLog',
     'ScanJob',
     'User',
-    'UserSeries', 'UserComicRating',
+    'UserSeries', 'UserVolumeFollow', 'UserComicRating',
     'SavedSearch', 'SmartList',
     'SystemSetting',
     'PullList', 'PullListItem',

--- a/app/models/interactions.py
+++ b/app/models/interactions.py
@@ -22,6 +22,25 @@ class UserSeries(Base):
     series = relationship("Series", backref="user_preferences")
 
 
+class UserVolumeFollow(Base):
+    """
+    Junction table for User <-> Volume follow subscriptions.
+    Stores the baseline timestamp used to determine future arrivals.
+    """
+    __tablename__ = "user_volume_follows"
+
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    volume_id = Column(Integer, ForeignKey("volumes.id", ondelete="CASCADE"), primary_key=True)
+    followed_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    user = relationship("User", backref="volume_follows")
+    volume = relationship("Volume", backref="user_follows")
+
+
 class UserComicRating(Base):
     """
     Junction table for User <-> Comic rating interactions.

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -214,6 +214,10 @@ async def pull_list_detail_legacy_redirect(request: Request, list_id: int, user:
 async def dashboard(request: Request, user: CurrentUser):
     return templates.TemplateResponse(request=request, name="user/dashboard.html")
 
+@router.get("/user/following", response_class=HTMLResponse, name="user_following")
+async def following_page(request: Request, user: CurrentUser):
+    return templates.TemplateResponse(request=request, name="user/following.html")
+
 @router.get("/user/settings", response_class=HTMLResponse, name="user_settings")
 async def settings_page(request: Request, user: CurrentUser):
     return templates.TemplateResponse(request=request, name="user/settings.html")

--- a/app/services/workers/metadata_writer.py
+++ b/app/services/workers/metadata_writer.py
@@ -32,6 +32,16 @@ def _apply_metadata_batch(
 
         return number
 
+    def _normalize_volume_number(raw_volume) -> int:
+        """Normalize volume metadata, falling back to volume 1 on invalid input."""
+        if raw_volume in (None, ""):
+            return 1
+
+        try:
+            return int(str(raw_volume).strip())
+        except (TypeError, ValueError):
+            return 1
+
     imported = 0
     updated = 0
     errors = 0
@@ -71,7 +81,7 @@ def _apply_metadata_batch(
         series = get_or_create_series(series_name)
 
         # Get or create volume (Uses Cache)
-        volume_num = int(metadata.get("volume", 1)) if metadata.get("volume") else 1
+        volume_num = _normalize_volume_number(metadata.get("volume"))
         volume = get_or_create_volume(series, volume_num, file_path)
         comic.volume_id = volume.id
 

--- a/app/templates/comics/volume_detail.html
+++ b/app/templates/comics/volume_detail.html
@@ -72,6 +72,17 @@
                                     <template x-if="volume?.resume_to?.comic_id">
                                         {%  include "partials/read_volume_button.html" %}
                                     </template>
+                                    <button
+                                        x-on:click="toggleFollow()"
+                                        :disabled="followSaving"
+                                        class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border transition-colors text-sm font-medium disabled:opacity-60 disabled:cursor-not-allowed"
+                                        :class="volume?.is_following
+                                            ? 'bg-green-900/30 border-green-700 text-green-200 hover:bg-green-900/40'
+                                            : 'bg-gray-700 border-gray-600 text-gray-200 hover:bg-gray-600 hover:text-white'"
+                                        :title="volume?.is_following ? 'Unfollow this volume' : 'Follow this volume'"
+                                    >
+                                        <span x-text="volume?.is_following ? 'Following' : 'Follow'"></span>
+                                    </button>
                                 </div>
 
                                 <div class="mb-4 text-gray-300 flex flex-wrap items-center justify-center md:justify-start gap-2">
@@ -431,6 +442,7 @@ function volumeDetail() {
         paginationMode: '{{ get_system_setting("ui.pagination_mode", "infinite") }}',
 
         error: null,
+        followSaving: false,
 
         async init() {
             await this.loadVolumeSummary();
@@ -514,6 +526,39 @@ function volumeDetail() {
             this.sortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc';
             this.page = 1;
             this.loadItems();
+        },
+
+        async toggleFollow() {
+            if (!this.volume || this.followSaving) return;
+
+            const method = this.volume.is_following ? 'DELETE' : 'POST';
+            this.followSaving = true;
+
+            try {
+                const res = await fetch(
+                    window.parker.route('volumes.follow', { volume_id: this.volumeId }),
+                    { method }
+                );
+
+                if (res.ok) {
+                    this.volume.is_following = !this.volume.is_following;
+                    if (window.parker) {
+                        window.parker.showToast(
+                            this.volume.is_following ? 'Now following volume' : 'Volume unfollowed',
+                            'success'
+                        );
+                    }
+                } else if (window.parker) {
+                    window.parker.showToast('Unable to update follow state', 'error');
+                }
+            } catch (e) {
+                console.error(e);
+                if (window.parker) {
+                    window.parker.showToast('Unable to update follow state', 'error');
+                }
+            } finally {
+                this.followSaving = false;
+            }
         },
 
         formatMissing(issues) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -23,6 +23,24 @@
             </div>
         </div>
 
+        <div x-show="!loading.following && followingArrivals.length > 0">
+            <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
+                <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                    <span>+</span> New from Following
+                </h2>
+                <a :href="window.parker.route('pages.user_following')" class="text-xs text-blue-400 hover:text-white transition-colors">
+                    Manage Following
+                </a>
+            </div>
+
+            <div class="flex space-x-4 overflow-x-auto pb-6 scrollbar-thin scrollbar-thumb-gray-700 scrollbar-track-transparent">
+                <template x-for="comic in followingArrivals" :key="comic.id">
+                    <div class="w-40 flex-shrink-0">
+                        {% include "partials/comic_card.html" %}
+                    </div>
+                </template>
+            </div>
+        </div>
 
         <div x-show="!loading.onDeck && onDeckSeries.length > 0">
             <div class="flex items-center justify-between mb-4 border-b border-gray-700 pb-2">
@@ -287,6 +305,7 @@ function homePage(bootstrap = {}) {
         parkerTopRatedComics: [],
         trendingSeries: [],
         resumeComics: [],
+        followingArrivals: [],
         smartLists: [],
         popularSeries: [],
 
@@ -300,6 +319,7 @@ function homePage(bootstrap = {}) {
             parkerTopRated: true,
             trending: true,
             resume: true,
+            following: true,
             popular: true,
         },
 
@@ -309,6 +329,7 @@ function homePage(bootstrap = {}) {
                 || this.loading.onDeck || this.loading.random
                 || this.loading.topRated || this.loading.resume
                 || this.loading.parkerTopRated
+                || this.loading.following
                 ;
         },
 
@@ -316,7 +337,8 @@ function homePage(bootstrap = {}) {
             // Check all main categories to see if anything exists
             return this.recentSeries.length === 0
                 && this.resumeComics.length === 0
-                && this.starredSeries.length === 0;
+                && this.starredSeries.length === 0
+                && this.followingArrivals.length === 0;
         },
 
         get showStartupNotice() {
@@ -336,6 +358,7 @@ function homePage(bootstrap = {}) {
             this.fetchUpdated();
             this.fetchOnDeck();
             this.fetchResume();
+            this.fetchFollowingArrivals();
             this.fetchRandom();
             this.fetchTopRated();
             this.fetchTopParkerRated();
@@ -396,6 +419,14 @@ function homePage(bootstrap = {}) {
                 if (res.ok) this.resumeComics = await res.json();
             } catch(e) { console.error(e); }
             finally { this.loading.resume = false; }
+        },
+
+        async fetchFollowingArrivals() {
+            try {
+                const res = await fetch(window.parker.route('home.following_arrivals', {}, 'limit=12'));
+                if (res.ok) this.followingArrivals = await res.json();
+            } catch(e) { console.error(e); }
+            finally { this.loading.following = false; }
         },
 
         async fetchRandom() {

--- a/app/templates/user/dashboard.html
+++ b/app/templates/user/dashboard.html
@@ -580,6 +580,23 @@
         <!-- Right Sidebar: OPDS + Stacks -->
         <div class="space-y-6">
 
+            <div class="rounded-2xl border border-gray-700 bg-gradient-to-br from-blue-950/40 via-gray-900 to-gray-900 p-5 shadow-xl">
+                <div class="space-y-2">
+                    <div class="flex items-center gap-2">
+                        <span class="text-2xl">+</span>
+                        <h2 class="text-xl font-bold text-white">Following</h2>
+                    </div>
+                    <p class="text-sm text-gray-400">
+                        Review every followed volume in one place and quickly unfollow books that no longer belong in your incoming queue.
+                    </p>
+                </div>
+
+                <a :href="window.parker.route('pages.user_following')"
+                   class="mt-4 inline-flex w-full items-center justify-center rounded-full bg-blue-600 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-700 transition-colors">
+                    Manage Following
+                </a>
+            </div>
+
             <!-- Stacks -->
             <div>
                 <div class="flex justify-between items-center mb-4">

--- a/app/templates/user/following.html
+++ b/app/templates/user/following.html
@@ -1,0 +1,146 @@
+{% extends "base.html" %}
+
+{% block title %}Following - Parker{% endblock %}
+
+{% block content %}
+<div class="max-w-5xl mx-auto space-y-8" x-data="followingPage()">
+    <div class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div class="space-y-2">
+            <a :href="window.parker.route('pages.user_dashboard')" class="inline-flex items-center gap-2 text-sm text-gray-400 hover:text-white transition-colors">
+                <span>&larr;</span>
+                <span>Back to Dashboard</span>
+            </a>
+            <h1 class="text-3xl md:text-4xl font-black text-white tracking-tight">Following</h1>
+            <p class="max-w-2xl text-gray-400">
+                Manage the volumes Parker is watching for you. New mainline issues still surface on the home page, and you can unfollow here without drilling back through each book.
+            </p>
+        </div>
+        <a :href="window.parker.route('pages.home')" class="inline-flex items-center justify-center rounded-full border border-gray-700 px-4 py-2 text-sm font-semibold text-gray-200 hover:border-blue-400 hover:text-white transition-colors">
+            Browse Library
+        </a>
+    </div>
+
+    <div x-show="loading" class="rounded-2xl border border-gray-800 bg-gray-900/70 p-10 text-center text-gray-400" x-cloak>
+        Loading followed volumes...
+    </div>
+
+    <div x-show="!loading && items.length === 0" class="rounded-3xl border border-dashed border-gray-700 bg-gray-900/60 p-10 text-center space-y-4" x-cloak>
+        <div class="text-5xl">+</div>
+        <h2 class="text-2xl font-bold text-white">Nothing followed yet</h2>
+        <p class="max-w-xl mx-auto text-gray-400">
+            Follow a volume from its detail page and Parker will keep an eye on future mainline arrivals for you.
+        </p>
+        <a :href="window.parker.route('pages.home')" class="inline-flex items-center justify-center rounded-full bg-blue-600 px-5 py-2.5 text-sm font-bold text-white hover:bg-blue-700 transition-colors">
+            Explore Your Library
+        </a>
+    </div>
+
+    <div x-show="!loading && items.length > 0" class="space-y-4" x-cloak>
+        <template x-for="item in items" :key="item.volume_id">
+            <div class="rounded-2xl border border-gray-800 bg-gradient-to-br from-gray-900 via-gray-900 to-gray-800 p-5 shadow-xl">
+                <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div class="space-y-3 min-w-0">
+                        <div class="flex flex-wrap items-center gap-2">
+                            <a :href="window.parker.route('pages.series_detail', { series_id: item.series_id })"
+                               class="text-xl font-bold text-white hover:text-blue-300 transition-colors"
+                               x-text="item.series_name"></a>
+                            <span class="rounded-full border border-gray-700 bg-gray-800 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-gray-300"
+                                  x-text="`Vol. ${item.volume_number}`"></span>
+                            <span x-show="item.new_arrivals_count > 0"
+                                  class="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-emerald-300"
+                                  x-text="item.new_arrivals_count === 1 ? '1 new issue' : `${item.new_arrivals_count} new issues`"></span>
+                        </div>
+
+                        <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-400">
+                            <span x-text="item.library_name"></span>
+                            <span>&bull;</span>
+                            <span x-text="`Following since ${formatFollowedAt(item.followed_at)}`"></span>
+                        </div>
+
+                        <template x-if="item.latest_arrival">
+                            <div class="rounded-xl border border-blue-500/20 bg-blue-500/5 px-4 py-3 text-sm">
+                                <div class="text-xs font-semibold uppercase tracking-[0.18em] text-blue-300">Latest arrival</div>
+                                <div class="mt-1 text-gray-100">
+                                    <span class="font-semibold" x-text="item.latest_arrival.number ? `#${item.latest_arrival.number}` : 'New issue'"></span>
+                                    <span x-show="item.latest_arrival.title" x-text="` - ${item.latest_arrival.title}`"></span>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2 lg:justify-end">
+                        <a :href="window.parker.route('pages.series_detail', { series_id: item.series_id })"
+                           class="inline-flex items-center justify-center rounded-full border border-gray-700 px-4 py-2 text-sm font-semibold text-gray-200 hover:border-gray-500 hover:text-white transition-colors">
+                            Series
+                        </a>
+                        <a :href="window.parker.route('pages.volume_detail', { volume_id: item.volume_id })"
+                           class="inline-flex items-center justify-center rounded-full border border-blue-500/40 bg-blue-500/10 px-4 py-2 text-sm font-semibold text-blue-200 hover:border-blue-400 hover:bg-blue-500/20 hover:text-white transition-colors">
+                            Open Volume
+                        </a>
+                        <button x-on:click="unfollow(item)"
+                                class="inline-flex items-center justify-center rounded-full border border-red-500/30 bg-red-500/10 px-4 py-2 text-sm font-semibold text-red-200 hover:border-red-400 hover:bg-red-500/20 hover:text-white transition-colors">
+                            Unfollow
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </template>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script>
+function followingPage() {
+    return {
+        loading: true,
+        items: [],
+
+        async init() {
+            await this.load();
+        },
+
+        async load() {
+            this.loading = true;
+
+            try {
+                const res = await fetch(window.parker.route('volumes.following_list'));
+                if (!res.ok) throw new Error('Failed to load followed volumes');
+                this.items = await res.json();
+            } catch (error) {
+                console.error(error);
+                window.parker.showToast('Unable to load followed volumes.', 'error');
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        formatFollowedAt(value) {
+            if (!value) return 'recently';
+            return new Date(value).toLocaleDateString(undefined, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+            });
+        },
+
+        async unfollow(item) {
+            try {
+                const res = await fetch(
+                    window.parker.route('volumes.unfollow', { volume_id: item.volume_id }),
+                    { method: 'DELETE' }
+                );
+
+                if (!res.ok) throw new Error('Failed to unfollow volume');
+
+                this.items = this.items.filter((entry) => entry.volume_id !== item.volume_id);
+                window.parker.showToast('Volume unfollowed', 'success');
+            } catch (error) {
+                console.error(error);
+                window.parker.showToast('Unable to unfollow volume.', 'error');
+            }
+        },
+    };
+}
+</script>
+{% endblock %}

--- a/docs/releases/0.1.22.md
+++ b/docs/releases/0.1.22.md
@@ -1,0 +1,109 @@
+# Parker 0.1.22 Release Notes
+
+Status: Planning Draft
+
+`0.1.22` is the next likely place to build on the reader overhaul from `0.1.21` and tackle the larger collection-management gap we identified: separating manual `Stacks` from a true future-issues `Following` workflow.
+
+Implementation outline for the first `Following` slice:
+Data model: Add a user-owned volume-follow relationship, likely analogous to `UserSeries` in `app/models/interactions.py`, with at minimum `user_id`, `volume_id`, and `followed_at`.
+Arrival rule: Treat `followed_at` as the baseline. Only plain/mainline issues in that volume with `Comic.created_at > followed_at` qualify as new arrivals for that user.
+Queue rule: Do not create a separate held-items table in v1 unless query behavior proves insufficient. A first pass can derive the arrival surface from `UserVolumeFollow + Comic.created_at + ReadingProgress`.
+Exit rule: A qualifying arrival leaves the `New from Following` surface once the user starts reading it or marks it read, at which point the normal `Resume Reading` / `Up Next` flows take over.
+Non-plain rule: Exclude annuals and specials by default in v1.
+Sorting rule: Sort followed arrivals primarily by newest `Comic.created_at`, with issue number as secondary display context rather than the main arrival ordering.
+
+Concrete task list by file for the first `Following` slice:
+- `app/models/interactions.py`
+  Add a `UserVolumeFollow`-style model with `user_id`, `volume_id`, and `followed_at`, mirroring the lightweight preference pattern already used for `UserSeries`.
+- `app/models/__init__.py`
+  Export the new follow model so tests and app imports pick it up consistently.
+- `app/api/volumes.py`
+  Expose follow state on the existing volume detail payload and add `POST /{volume_id}/follow` plus `DELETE /{volume_id}/follow`.
+  Keep access rules aligned with existing volume visibility checks.
+- `app/api/home.py`
+  Add a `New from Following` endpoint that derives arrivals from followed volumes, `Comic.created_at`, and `ReadingProgress`.
+  Exclude non-plain issues and anything already started or completed.
+- `app/templates/comics/volume_detail.html`
+  Add the `Follow` / `Following` toggle near the existing primary volume actions and wire it to the new volume follow endpoints.
+- `app/templates/index.html`
+  Add a `New from Following` home rail and fetch path alongside the existing home rails.
+- `tests/api/test_volumes.py`
+  Cover follow/unfollow permissions, volume-detail follow state, and accessible-volume guardrails.
+- `tests/api/test_home.py`
+  Cover arrival derivation rules: no backfill, only later plain issues, and exclusion once reading starts or completes.
+- `tests/browser/`
+  Add or extend browser tests for the volume-detail follow toggle plus the home-rail arrival flow after a simulated later issue import.
+- `app/services/workers/metadata_writer.py`
+  Harden malformed volume parsing so invalid non-empty volume metadata falls back safely instead of breaking the import batch.
+
+## Added
+
+- Planned: Add a real `Following` system oriented around upcoming issues rather than manual curation, starting with volume-level follows so users can track an active run without implicitly subscribing to every historical volume in a series.
+  Product model: Treat `Following` like a comic-shop subscription for a specific run. The user follows a volume, and Parker sets aside later arrivals for that volume instead of asking the user to build or maintain the list manually.
+  Scope note: The first cut should follow volumes, not top-level series, because Parker's data model treats volumes as the actual run-level container and a full series can span many unrelated historical volumes.
+  Behavior note: Following a volume should not backfill the existing library into the user's arrivals queue. The follow action establishes a baseline, and only later qualifying issues should surface as new arrivals.
+  Format note: The first cut should likely target the main numbered run only and avoid making strong assumptions about `Annual` and `Special` handling, since real libraries differ on whether those are modeled as separate series/volumes or as alternate formats within the same run.
+- Planned: Add the first user-facing surfaces for followed books and newly available issues, likely beginning with a simple dashboard or home-page entry point that makes new arrivals easy to find.
+  UX note: A `Follow` / `Following` toggle on the volume detail page is the natural entry point, and the first surfaced payoff should be a simple `New from Following` rail or dashboard section that highlights newly arrived issues from followed volumes.
+  Workflow note: New arrivals should remain in that surface until the user effectively picks them up, with `Resume Reading` and `Up Next` taking over once the user starts or completes the issue.
+  UI outline: The first slice now also includes a dedicated `Following` management page under the user dashboard so users can review all followed volumes and quickly unfollow without drilling back into each volume detail page.
+- Planned: Add browser coverage for follow/unfollow flows and the primary "new issues from followed books" happy paths so the new workflow is exercised in a realistic client environment from day one.
+  Validation note: The browser suite should prove that following a volume, scanning in a later issue, surfacing that issue in the arrival rail, and then transitioning it out of the rail once reading begins all work end to end.
+  API outline: The first pass likely needs `POST /api/volumes/{volume_id}/follow`, `DELETE /api/volumes/{volume_id}/follow`, a follow-state field on the existing volume detail payload, and a home/dashboard endpoint for `New from Following`.
+- Planned: Add exploratory `JPEG XL` support for covers and reader images by wiring in a Pillow decoder extension at process startup, with the goal of letting existing `Image.open(...)` and `ColorThief`-driven image/color workflows inherit support without bespoke format branches.
+  Implementation note: The current leading approach is to add `pillow-jxl-plugin` to `requirements.txt` and import `pillow_jxl` once during early app startup so the codec registers with Pillow before any `Image.open(...)` calls run.
+  Scope note: Treat this first as a backend compatibility improvement so Parker can ingest archives containing `JXL` assets, generate thumbnails, derive colors, and perform other shared image operations without failing, even if browser-native reading support remains limited.
+- Planned: Keep `AVIF` on the compatibility watchlist as a more browser-viable modern lossy format than `JPEG XL`, while validating whether real comic archives actually use it enough to justify dedicated Parker work.
+
+## Changed
+
+- Planned: Keep `Stacks` positioned as manual, curated reading buckets while giving the subscription-like behavior its own distinct `Following` terminology and UI so the two concepts are no longer overloaded.
+  Product note: `Stacks` stay user-composed and intentionally static, while `Following` is the automatic system that reacts to newly imported issues and surfaces them without manual curation.
+- Planned: Start `Following` with conservative matching rules so Parker does not create surprise subscriptions around edge-case metadata conventions for annuals, specials, or other non-plain issue types.
+  Policy note: If Parker later expands follow matching beyond plain issues, it should do so intentionally with explicit product rules or user controls rather than silently inferring a universal convention from inconsistent metadata.
+- Planned: Mirror existing user-preference patterns where practical instead of inventing a separate architecture for follows.
+  Implementation note: `UserSeries` star/unstar behavior in `app/models/interactions.py` and `app/api/series.py` is a strong template for the basic follow/unfollow API shape, while volume detail is the more appropriate UI home for the control itself.
+- Planned: Extend the `0.1.21` reader modularization work only where it supports practical follow-on reader improvements, keeping the existing paged and long-view modes stable rather than reopening broad reader churn.
+- Planned: Reassess whether any additional per-book reader overrides are worth promoting now that the override foundation exists, with `Long View`, `Double Page`, and Manga/RTL already covering the strongest current cases.
+- Planned: Revisit the image-format support story with an eye toward more space-efficient archives, treating `JPEG XL` as an opt-in compatibility enhancement that remains dependent on practical browser support for in-browser reading.
+  Implementation note: A likely integration point is the existing one-time startup/setup path in `main.py` or an equivalent early bootstrap module, rather than format-specific branching in downstream image helpers.
+  Product note: As of July 17, 2026, browser support is still too weak for `JPEG XL` to be treated as a mainstream web-reader format, so any near-term value is more about server-side handling and archive compatibility than headline reader UX.
+- Planned: If Parker sees meaningful real-world demand for modern lossy archive formats, prefer evaluating `AVIF` ahead of `JPEG XL` for direct browser-facing reader scenarios because current browser support is materially stronger.
+
+## Fixed
+
+- Planned: Fix the product-language mismatch where the old pull-list concept has been serving double duty as both a manual reading bucket and an implied future-issue tracker, which is a source of user confusion.
+  Semantics note: The key rule is that `Following` behaves like "hold future issues for me," not "dump every issue from this run into a list." That distinction is what separates it from stacks and makes the feature understandable.
+- Planned: Fix the risk of noisy or surprising follow results by keeping v1 narrowly scoped to the clearest metadata cases instead of trying to normalize every library's handling of annuals and specials on the first pass.
+- Planned: Fix the risk of overengineering the first slice by deriving followed arrivals from existing metadata and reading-progress state before introducing per-issue hold records or more complex subscription bookkeeping.
+  Guardrail: Only add a dedicated held-issue table later if the derived query model cannot support the UX or performance we want.
+- Planned: Fix brittle volume-metadata parsing during import so malformed non-empty volume values do not fail the comic import path.
+  Implementation note: Parker already falls back to `1` when volume metadata is blank, but invalid non-numeric values currently pass through `int(...)` and can fail the import batch. A safer normalization path should treat malformed volume metadata as a recoverable case, likely by falling back to `1` and logging/debugging the anomaly.
+- Planned: Fix gaps in real-world coverage around collection-management workflows by expanding browser tests beyond pure CRUD into the places where users actually discover, follow, and return to books.
+- Planned: Fix the current format-support gap for users experimenting with `JPEG XL`-encoded comic assets, provided the decoder/runtime path proves stable enough in Parker's existing Pillow-based thumbnail, color extraction, and image-serving flows.
+  Implementation note: Any FastAPI image responses serving native `JPEG XL` payloads should also set `media_type="image/jxl"` explicitly so clients receive the correct content type.
+  Future direction: If `JPEG XL` adoption becomes meaningful before browser support catches up, a later release could explore on-demand transcoding for reader delivery to browser-safe formats such as `WebP`, but that should be treated as a heavier follow-on project because of runtime cost, caching complexity, and page-turn performance risk.
+- Planned: Fix the current blind spot around newer image formats by verifying whether `AVIF` needs any Parker-specific handling at all, since current Pillow/browser support may already make it a lower-friction compatibility win than `JPEG XL`.
+
+## Validation
+
+- Planned validation should include focused browser coverage for:
+  - follow/unfollow actions from the volume detail page and any other primary entry surfaces
+  - arrival or "new issue" surfaces for followed books
+  - the dedicated `Following` management page, including quick unfollow flows launched from the dashboard entry point
+  - no-backfill behavior when a user follows a volume that already has existing issues in the library
+  - progression rules proving a newly arrived followed issue leaves the arrival surface once the user starts or completes it
+  - conservative matching behavior proving non-plain issue types do not get auto-included accidentally in the first release
+  - regression coverage proving `Stacks` continue to work as manual lists after `Following` is introduced
+  - reader entry flows launched from both manual stacks and followed-book surfaces
+- Planned validation should also include targeted API/model checks for:
+  - follow creation and deletion for accessible volumes only
+  - correct `followed_at` baseline behavior so pre-existing issues do not appear as arrivals
+  - arrival queries that include later plain issues from followed volumes and exclude annuals, specials, and already-started/read issues
+  - volume-detail payloads correctly exposing follow state for the signed-in user
+- Planned validation should also include targeted image-pipeline checks for:
+  - `JPEG XL` decoding through the shared Pillow-based image helpers
+  - cover thumbnail generation and color extraction for supported `JPEG XL` inputs
+  - graceful handling of archives containing `JPEG XL` assets even when direct browser rendering is not available
+  - browser-facing reader behavior only in environments where rendered `JPEG XL` assets are actually supported end to end
+  - a quick compatibility spike for `AVIF` inputs to determine whether Parker already handles them cleanly through the existing Pillow/browser stack with little or no custom work

--- a/tests/api/test_home.py
+++ b/tests/api/test_home.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from app.api.home import _pick_best_cover, format_home_item
 from app.models.comic import Comic, Volume
-from app.models.interactions import UserComicRating
+from app.models.interactions import UserComicRating, UserVolumeFollow
 from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
@@ -514,6 +514,101 @@ def test_home_resume_applies_staleness_and_progress_percentage(auth_client, db, 
     assert len(payload) == 1
     assert payload[0]["id"] == recent.id
     assert payload[0]["progress_percentage"] == 100.0
+
+
+def test_home_following_arrivals_respects_baseline_formats_and_progress(auth_client, db, normal_user):
+    library, _, volume = _create_series_graph(
+        db,
+        lib_name="home-follow-lib",
+        series_name="Home Follow",
+    )
+    _, _, second_volume = _create_series_graph(
+        db,
+        lib_name="home-follow-lib-two",
+        series_name="Home Follow Two",
+    )
+
+    normal_user.accessible_libraries.extend([library, second_volume.series.library])
+    baseline = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+    old_plain = _add_comic(
+        db,
+        volume,
+        number="1",
+        title="Follow Old Plain",
+        created_at=baseline - timedelta(days=1),
+        format=None,
+    )
+    new_plain = _add_comic(
+        db,
+        volume,
+        number="2",
+        title="Follow New Plain",
+        created_at=baseline + timedelta(hours=1),
+        format=None,
+    )
+    annual = _add_comic(
+        db,
+        volume,
+        number="1",
+        title="Follow Annual",
+        created_at=baseline + timedelta(hours=2),
+        format="annual",
+    )
+    started_plain = _add_comic(
+        db,
+        volume,
+        number="3",
+        title="Follow Started Plain",
+        created_at=baseline + timedelta(hours=3),
+        format=None,
+    )
+    completed_plain = _add_comic(
+        db,
+        volume,
+        number="4",
+        title="Follow Completed Plain",
+        created_at=baseline + timedelta(hours=4),
+        format=None,
+    )
+    newest_plain = _add_comic(
+        db,
+        second_volume,
+        number="5",
+        title="Follow Newest Plain",
+        created_at=baseline + timedelta(hours=5),
+        format=None,
+    )
+
+    db.add_all([
+        UserVolumeFollow(user_id=normal_user.id, volume_id=volume.id, followed_at=baseline),
+        UserVolumeFollow(user_id=normal_user.id, volume_id=second_volume.id, followed_at=baseline),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=started_plain.id,
+            current_page=3,
+            total_pages=20,
+            completed=False,
+        ),
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=completed_plain.id,
+            current_page=20,
+            total_pages=20,
+            completed=True,
+        ),
+    ])
+    db.commit()
+
+    response = auth_client.get("/api/home/following-arrivals?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["id"] for item in payload] == [newest_plain.id, new_plain.id]
+    assert old_plain.id not in [item["id"] for item in payload]
+    assert annual.id not in [item["id"] for item in payload]
+    assert started_plain.id not in [item["id"] for item in payload]
+    assert completed_plain.id not in [item["id"] for item in payload]
 
 
 def test_home_up_next_handles_duplicates_reverse_and_non_numeric(auth_client, db, normal_user):

--- a/tests/api/test_volumes.py
+++ b/tests/api/test_volumes.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 from app.models.comic import Comic, Volume
 from app.models.credits import ComicCredit, Person
+from app.models.interactions import UserVolumeFollow
 from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
@@ -399,6 +400,122 @@ def test_volume_detail_advances_to_next_issue_when_latest_progress_is_completed(
     assert payload["resume_to"] == {"comic_id": issue_three.id, "status": "continue"}
 
 
+def test_volume_follow_toggle_and_detail_state(auth_client, db, normal_user):
+    data = _create_volume_fixture(db, lib_name="follow-lib", series_name="Follow Volume")
+    normal_user.accessible_libraries.append(data["library"])
+    db.commit()
+
+    detail_before = auth_client.get(f"/api/volumes/{data['volume'].id}")
+    assert detail_before.status_code == 200
+    assert detail_before.json()["is_following"] is False
+
+    follow_response = auth_client.post(f"/api/volumes/{data['volume'].id}/follow")
+    assert follow_response.status_code == 200
+    assert follow_response.json() == {"following": True}
+
+    follow = db.query(UserVolumeFollow).filter_by(
+        user_id=normal_user.id,
+        volume_id=data["volume"].id,
+    ).first()
+    assert follow is not None
+    assert follow.followed_at is not None
+
+    detail_after_follow = auth_client.get(f"/api/volumes/{data['volume'].id}")
+    assert detail_after_follow.status_code == 200
+    assert detail_after_follow.json()["is_following"] is True
+
+    unfollow_response = auth_client.delete(f"/api/volumes/{data['volume'].id}/follow")
+    assert unfollow_response.status_code == 200
+    assert unfollow_response.json() == {"following": False}
+
+    assert db.query(UserVolumeFollow).filter_by(
+        user_id=normal_user.id,
+        volume_id=data["volume"].id,
+    ).first() is None
+
+    detail_after_unfollow = auth_client.get(f"/api/volumes/{data['volume'].id}")
+    assert detail_after_unfollow.status_code == 200
+    assert detail_after_unfollow.json()["is_following"] is False
+
+
+def test_following_list_reports_new_arrivals_and_filters_hidden_volumes(auth_client, db, normal_user):
+    visible = _create_volume_fixture(db, lib_name="following-visible-lib", series_name="Visible Follow")
+    hidden = _create_volume_fixture(db, lib_name="following-hidden-lib", series_name="Hidden Follow")
+
+    normal_user.accessible_libraries.append(visible["library"])
+
+    for comic in visible["comics"]:
+        comic.created_at = datetime(2026, 6, 20, 12, 0, tzinfo=timezone.utc)
+    for comic in hidden["comics"]:
+        comic.created_at = datetime(2026, 6, 20, 12, 0, tzinfo=timezone.utc)
+
+    db.flush()
+
+    baseline = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+    db.add_all([
+        UserVolumeFollow(user_id=normal_user.id, volume_id=visible["volume"].id, followed_at=baseline),
+        UserVolumeFollow(user_id=normal_user.id, volume_id=hidden["volume"].id, followed_at=baseline),
+    ])
+    db.flush()
+
+    new_issue = Comic(
+        volume_id=visible["volume"].id,
+        number="11",
+        title="Visible Follow #11",
+        year=2026,
+        created_at=datetime(2026, 7, 2, 12, 0, tzinfo=timezone.utc),
+        filename="visible-follow-11.cbz",
+        file_path="/tmp/visible-follow-11.cbz",
+    )
+    started_issue = Comic(
+        volume_id=visible["volume"].id,
+        number="12",
+        title="Visible Follow #12",
+        year=2026,
+        created_at=datetime(2026, 7, 3, 12, 0, tzinfo=timezone.utc),
+        filename="visible-follow-12.cbz",
+        file_path="/tmp/visible-follow-12.cbz",
+    )
+    annual = Comic(
+        volume_id=visible["volume"].id,
+        number="1",
+        title="Visible Follow Annual",
+        format="annual",
+        year=2026,
+        created_at=datetime(2026, 7, 4, 12, 0, tzinfo=timezone.utc),
+        filename="visible-follow-annual.cbz",
+        file_path="/tmp/visible-follow-annual.cbz",
+    )
+    db.add_all([new_issue, started_issue, annual])
+    db.flush()
+
+    db.add(
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=started_issue.id,
+            current_page=1,
+            total_pages=20,
+            completed=False,
+            last_read_at=datetime(2026, 7, 5, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+    db.commit()
+
+    response = auth_client.get("/api/volumes/following")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 1
+
+    item = payload[0]
+    assert item["series_name"] == "Visible Follow"
+    assert item["volume_id"] == visible["volume"].id
+    assert item["new_arrivals_count"] == 1
+    assert item["latest_arrival"]["comic_id"] == new_issue.id
+    assert item["latest_arrival"]["title"] == "Visible Follow #11"
+    assert item["latest_arrival"]["number"] == "11"
+
+
 def test_volume_issues_returns_404_without_access(auth_client, db):
     data = _create_volume_fixture(db, lib_name="hidden-issues-lib", series_name="Hidden Issues")
 
@@ -406,6 +523,18 @@ def test_volume_issues_returns_404_without_access(auth_client, db):
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Volume not found"}
+
+
+def test_volume_follow_returns_404_without_access(auth_client, db):
+    data = _create_volume_fixture(db, lib_name="hidden-follow-lib", series_name="Hidden Follow")
+
+    follow_response = auth_client.post(f"/api/volumes/{data['volume'].id}/follow")
+    assert follow_response.status_code == 404
+    assert follow_response.json() == {"detail": "Volume not found"}
+
+    unfollow_response = auth_client.delete(f"/api/volumes/{data['volume'].id}/follow")
+    assert unfollow_response.status_code == 404
+    assert unfollow_response.json() == {"detail": "Volume not found"}
 
 
 def test_volume_issues_annual_unread_desc_filter(auth_client, db, normal_user):

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -19,6 +19,7 @@ from app.database import Base
 from app.main import app
 from app.models.comic import Comic, Volume
 from app.models.credits import ComicCredit, Person
+from app.models.interactions import UserVolumeFollow
 from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.reading_list import ReadingList, ReadingListItem
@@ -144,6 +145,7 @@ def browser_seed_data(browser_db_factory):
     data = {
         "user_id": user.id,
         "series_id": series.id,
+        "volume_id": volume.id,
         "series_name": series.name,
         "reading_list_id": reading_list.id,
         "reading_list_name": reading_list.name,
@@ -166,6 +168,7 @@ def browser_seed_data(browser_db_factory):
 def reset_browser_state(browser_db_factory, browser_seed_data):
     session = browser_db_factory()
     try:
+        session.query(UserVolumeFollow).delete()
         session.query(PullListItem).delete()
         session.query(PullList).delete()
         session.query(SavedSearch).delete()

--- a/tests/browser/test_search_and_series_smoke.py
+++ b/tests/browser/test_search_and_series_smoke.py
@@ -37,3 +37,39 @@ def test_series_detail_page_filters_read_items(page, browser_server):
     page.wait_for_timeout(300)
     assert page.locator(f"text={seed['completed_comic_title']}").first.is_visible()
     assert page.locator(f"text={seed['active_comic_title']}").count() == 0
+
+
+@pytest.mark.browser
+def test_volume_detail_follow_toggle_persists_after_reload(page, browser_server):
+    seed = browser_server["seed"]
+    page.goto(f"{browser_server['base_url']}/volumes/{seed['volume_id']}", wait_until="networkidle")
+
+    page.get_by_role("heading", name="Volume 1").wait_for()
+    follow_button = page.get_by_role("button", name="Follow")
+    follow_button.click()
+
+    page.get_by_role("button", name="Following").wait_for()
+
+    page.reload(wait_until="networkidle")
+    page.get_by_role("button", name="Following").wait_for()
+
+
+@pytest.mark.browser
+def test_dashboard_following_page_can_unfollow_volume(page, browser_server):
+    seed = browser_server["seed"]
+    page.goto(f"{browser_server['base_url']}/volumes/{seed['volume_id']}", wait_until="networkidle")
+
+    page.get_by_role("button", name="Follow").click()
+    page.get_by_role("button", name="Following").wait_for()
+
+    page.goto(f"{browser_server['base_url']}/user/dashboard", wait_until="networkidle")
+    page.get_by_role("link", name="Manage Following").click()
+
+    page.wait_for_url("**/user/following")
+    page.get_by_role("heading", name="Following").wait_for()
+    page.wait_for_selector(f"text={seed['series_name']}")
+
+    page.get_by_role("button", name="Unfollow").click()
+
+    page.wait_for_selector("text=Nothing followed yet")
+    assert page.locator(f"text={seed['series_name']}").count() == 0

--- a/tests/services/test_metadata_writer.py
+++ b/tests/services/test_metadata_writer.py
@@ -293,6 +293,64 @@ def test_apply_metadata_batch_disables_optional_metadata_flows(db):
     collection_service.update_comic_collections.assert_not_called()
 
 
+def test_apply_metadata_batch_falls_back_to_volume_one_for_invalid_volume_metadata(db):
+    library = Library(name="writer-invalid-volume-lib", path="/tmp/writer-invalid-volume-lib")
+    db.add(library)
+    db.flush()
+
+    def get_or_create_series(name: str):
+        series = db.query(Series).filter_by(name=name, library_id=library.id).first()
+        if not series:
+            series = Series(name=name, library_id=library.id)
+            db.add(series)
+            db.flush()
+        return series
+
+    def get_or_create_volume(series, volume_num: int, _file_path: str):
+        volume = db.query(Volume).filter_by(series_id=series.id, volume_number=volume_num).first()
+        if not volume:
+            volume = Volume(series_id=series.id, volume_number=volume_num)
+            db.add(volume)
+            db.flush()
+        return volume
+
+    tag_service = SimpleNamespace(
+        get_or_create_characters=MagicMock(return_value=[]),
+        get_or_create_teams=MagicMock(return_value=[]),
+        get_or_create_locations=MagicMock(return_value=[]),
+        get_or_create_genres=MagicMock(return_value=[]),
+    )
+    credit_service = SimpleNamespace(add_credits_to_comic=MagicMock())
+    reading_list_service = SimpleNamespace(update_comic_reading_lists=MagicMock())
+    collection_service = SimpleNamespace(update_comic_collections=MagicMock())
+
+    batch = [{
+        "file_path": "/tmp/invalid-volume.cbz",
+        "mtime": 123.0,
+        "size": 456,
+        "metadata": _metadata(volume="3bbbb", title="Invalid Volume"),
+        "error": False,
+    }]
+
+    stats = metadata_writer_module._apply_metadata_batch(
+        db,
+        batch,
+        {},
+        get_or_create_series,
+        get_or_create_volume,
+        tag_service,
+        credit_service,
+        reading_list_service,
+        collection_service,
+    )
+
+    imported = db.query(Comic).filter_by(file_path="/tmp/invalid-volume.cbz").first()
+    assert stats["imported"] == 1
+    assert stats["errors"] == 0
+    assert imported is not None
+    assert imported.volume.volume_number == 1
+
+
 def test_metadata_writer_batches_and_emits_summary(monkeypatch, tmp_path):
     fake_db = _FakeDB(str(tmp_path / "lib"))
     applied_batches = []


### PR DESCRIPTION
## Summary

This PR introduces the first end-to-end `Following` workflow for volumes.

Users can now follow a volume from its detail page, see newly arrived mainline issues in a `New from Following` home rail, and manage all followed volumes from a dedicated `Following` page without having to drill back into each series/volume to unfollow.

## What Changed

- Added `UserVolumeFollow` plus an Alembic migration for the new `user_volume_follows` table
- Added volume follow/unfollow API endpoints and exposed follow state on the volume detail payload
- Added `New from Following` home rail support driven by follow baseline timestamps
- Added a dedicated user `Following` page with quick unfollow actions and links back to series/volume pages
- Added dashboard and home-page entry points to the new `Following` management page
- Hardened malformed volume metadata parsing so invalid non-empty volume values fall back safely

## Following Behavior

- Following is scoped to volumes, not top-level series
- `followed_at` acts as the baseline, so existing library issues are not backfilled
- Only plain/mainline issues are included in arrival flows
- Items drop out of `New from Following` once reading has started or the issue is marked read
- Inaccessible followed volumes are currently hidden from user-facing surfaces but their follow rows remain persisted

## Testing

- `tests/api/test_volumes.py`
- `tests/api/test_home.py`
- `tests/services/test_metadata_writer.py`
- `tests/browser/test_search_and_series_smoke.py`

## Migration Note

Run:

```powershell
alembic upgrade head
```