### PR TITLE
add experimental JPEG XL support

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+from app.core import image_codecs as _image_codecs  # Register optional Pillow codecs.

--- a/app/api/reader.py
+++ b/app/api/reader.py
@@ -353,6 +353,7 @@ def get_comic_page(
     # Check if the original detected type was PNG/GIF for the filename if we didn't transcode
     if not webp and mime_type == "image/png": extension = "png"
     if not webp and mime_type == "image/gif": extension = "gif"
+    if not webp and mime_type == "image/jxl": extension = "jxl"
 
     # CACHE LOGIC
     headers = {

--- a/app/core/image_codecs.py
+++ b/app/core/image_codecs.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    import pillow_jxl  # noqa: F401
+except ImportError:
+    logger.debug("pillow-jxl-plugin not installed; JPEG XL support unavailable.")

--- a/app/services/archive.py
+++ b/app/services/archive.py
@@ -71,7 +71,7 @@ class ComicArchive:
     def get_pages(self) -> List[str]:
         """Get sorted list of image files (pages) - filter out non-images"""
         # Valid image extensions
-        image_extensions = {'.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp', '.tiff'}
+        image_extensions = {'.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp', '.tiff', '.jxl'}
 
         # Files to explicitly ignore (common in comic archives)
         ignore_patterns = {'thumbs.db', '.ds_store', 'comicinfo.xml', '__macosx'}

--- a/app/services/images.py
+++ b/app/services/images.py
@@ -126,6 +126,7 @@ class ImageService:
                 if filename.endswith(".png"): mime_type = "image/png"
                 elif filename.endswith(".webp"): mime_type = "image/webp"
                 elif filename.endswith(".gif"): mime_type = "image/gif"
+                elif filename.endswith(".jxl"): mime_type = "image/jxl"
 
                 # Logic: Should we Transcode?
                 # Only if requested AND image is large (>500KB) AND not already WebP

--- a/docs/releases/0.1.22.md
+++ b/docs/releases/0.1.22.md
@@ -50,9 +50,11 @@ Concrete task list by file for the first `Following` slice:
 - Planned: Add browser coverage for follow/unfollow flows and the primary "new issues from followed books" happy paths so the new workflow is exercised in a realistic client environment from day one.
   Validation note: The browser suite should prove that following a volume, scanning in a later issue, surfacing that issue in the arrival rail, and then transitioning it out of the rail once reading begins all work end to end.
   API outline: The first pass likely needs `POST /api/volumes/{volume_id}/follow`, `DELETE /api/volumes/{volume_id}/follow`, a follow-state field on the existing volume detail payload, and a home/dashboard endpoint for `New from Following`.
-- Planned: Add exploratory `JPEG XL` support for covers and reader images by wiring in a Pillow decoder extension at process startup, with the goal of letting existing `Image.open(...)` and `ColorThief`-driven image/color workflows inherit support without bespoke format branches.
+- Planned: Add experimental `JPEG XL` support for covers and reader images by wiring in a Pillow decoder extension at process startup, with the goal of letting existing `Image.open(...)` and `ColorThief`-driven image/color workflows inherit support without bespoke format branches.
   Implementation note: The current leading approach is to add `pillow-jxl-plugin` to `requirements.txt` and import `pillow_jxl` once during early app startup so the codec registers with Pillow before any `Image.open(...)` calls run.
+  Current scope: The first backend compatibility pass now covers codec registration, archive page discovery for `.jxl`, and native reader response metadata for `image/jxl`.
   Scope note: Treat this first as a backend compatibility improvement so Parker can ingest archives containing `JXL` assets, generate thumbnails, derive colors, and perform other shared image operations without failing, even if browser-native reading support remains limited.
+  Release note framing: User-facing notes should call this experimental and make clear that direct reading of native `JXL` pages still depends on browser support.
 - Planned: Keep `AVIF` on the compatibility watchlist as a more browser-viable modern lossy format than `JPEG XL`, while validating whether real comic archives actually use it enough to justify dedicated Parker work.
 
 ## Changed
@@ -67,6 +69,7 @@ Concrete task list by file for the first `Following` slice:
 - Planned: Reassess whether any additional per-book reader overrides are worth promoting now that the override foundation exists, with `Long View`, `Double Page`, and Manga/RTL already covering the strongest current cases.
 - Planned: Revisit the image-format support story with an eye toward more space-efficient archives, treating `JPEG XL` as an opt-in compatibility enhancement that remains dependent on practical browser support for in-browser reading.
   Implementation note: A likely integration point is the existing one-time startup/setup path in `main.py` or an equivalent early bootstrap module, rather than format-specific branching in downstream image helpers.
+  Current implementation: Parker now registers the Pillow JXL plugin during package import so existing image helpers can pick up decode support without format-specific call sites.
   Product note: As of July 17, 2026, browser support is still too weak for `JPEG XL` to be treated as a mainstream web-reader format, so any near-term value is more about server-side handling and archive compatibility than headline reader UX.
 - Planned: If Parker sees meaningful real-world demand for modern lossy archive formats, prefer evaluating `AVIF` ahead of `JPEG XL` for direct browser-facing reader scenarios because current browser support is materially stronger.
 
@@ -103,6 +106,8 @@ Concrete task list by file for the first `Following` slice:
   - volume-detail payloads correctly exposing follow state for the signed-in user
 - Planned validation should also include targeted image-pipeline checks for:
   - `JPEG XL` decoding through the shared Pillow-based image helpers
+  - archive page enumeration recognizing `.jxl` pages
+  - reader page responses preserving `image/jxl` and `.jxl` filenames when Parker serves native JXL payloads
   - cover thumbnail generation and color extraction for supported `JPEG XL` inputs
   - graceful handling of archives containing `JPEG XL` assets even when direct browser rendering is not available
   - browser-facing reader behavior only in environments where rendered `JPEG XL` assets are actually supported end to end

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ jinja2==3.1.6
 
 # Image & File Processing
 pillow==12.3.0
+pillow-jxl-plugin==1.3.8
 colorthief==0.2.1
 rarfile==4.3
 lxml==6.1.1

--- a/tests/api/test_reader.py
+++ b/tests/api/test_reader.py
@@ -1,4 +1,9 @@
+import zipfile
+from pathlib import Path
 from unittest.mock import patch
+
+import app  # noqa: F401  # Ensure optional Pillow codecs register before creating fixtures.
+from PIL import Image, ImageDraw
 
 from app.api.reader import natural_sort_key
 from app.models.collection import Collection, CollectionItem
@@ -19,17 +24,41 @@ def _create_graph(db, *, lib_name: str, series_name: str, volume_number: int = 1
 
 
 def _add_comic(db, volume: Volume, *, number: str, title: str, **kwargs):
+    kwargs.setdefault("filename", f"{title.replace(' ', '-')}.cbz")
+    kwargs.setdefault("file_path", f"/tmp/{title.replace(' ', '-')}-{volume.id}-{number}.cbz")
     comic = Comic(
         volume_id=volume.id,
         number=number,
         title=title,
-        filename=f"{title.replace(' ', '-')}.cbz",
-        file_path=f"/tmp/{title.replace(' ', '-')}-{volume.id}-{number}.cbz",
         **kwargs,
     )
     db.add(comic)
     db.flush()
     return comic
+
+
+def _write_jxl_page(path: Path, accent: tuple[int, int, int]) -> None:
+    image = Image.new("RGB", (48, 72), (245, 245, 245))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 0, 47, 23), fill=accent)
+    draw.rectangle((0, 24, 47, 47), fill=(32, 64, 128))
+    draw.rectangle((0, 48, 47, 71), fill=(220, 80, 80))
+    image.save(path, format="JXL")
+
+
+def _build_jxl_cbz(tmp_path: Path) -> Path:
+    first_page = tmp_path / "01_cover.jxl"
+    second_page = tmp_path / "02_story.jxl"
+    archive_path = tmp_path / "sample-jxl.cbz"
+
+    _write_jxl_page(first_page, (24, 160, 96))
+    _write_jxl_page(second_page, (192, 120, 32))
+
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.write(first_page, arcname=first_page.name)
+        archive.write(second_page, arcname=second_page.name)
+
+    return archive_path
 
 
 def test_reader_natural_sort_key():
@@ -256,9 +285,38 @@ def test_reader_page_endpoint_headers_and_errors(client, db):
 
     assert webp.status_code == 200
     assert webp.headers["content-disposition"] == 'inline; filename="page_4.webp"'
+    assert webp.headers["content-type"].startswith("image/webp")
+
+    with patch("app.api.reader.ImageService.get_page_image", return_value=(b"jxl-bytes", True, "image/jxl")):
+        jxl = client.get(f"/api/reader/{comic.id}/page/6")
+
+    assert jxl.status_code == 200
+    assert jxl.headers["content-disposition"] == 'inline; filename="page_6.jxl"'
+    assert jxl.headers["content-type"].startswith("image/jxl")
 
     with patch("app.api.reader.ImageService.get_page_image", return_value=(None, False, "image/jpeg")):
         no_page = client.get(f"/api/reader/{comic.id}/page/5")
 
     assert no_page.status_code == 404
     assert no_page.json() == {"detail": "Page not found"}
+
+
+def test_reader_page_endpoint_serves_real_jxl_archive_page(client, db, tmp_path):
+    library, _, volume = _create_graph(db, lib_name="reader-jxl-lib", series_name="Reader JXL")
+    archive_path = _build_jxl_cbz(tmp_path)
+    comic = _add_comic(
+        db,
+        volume,
+        number="1",
+        title="JXL Archive Comic",
+        file_path=str(archive_path),
+    )
+    db.add(library)
+    db.commit()
+
+    response = client.get(f"/api/reader/{comic.id}/page/0")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/jxl")
+    assert response.headers["content-disposition"] == 'inline; filename="page_0.jxl"'
+    assert len(response.content) > 0

--- a/tests/services/test_archive.py
+++ b/tests/services/test_archive.py
@@ -12,6 +12,7 @@ def test_comic_archive_get_pages_filtering():
             "01.jpg",
             "02.PNG",
             "03.WEBP",
+            "04.jxl",
             "thumbs.db",
             "Thumbs.db",
             "ComicInfo.xml",
@@ -24,7 +25,7 @@ def test_comic_archive_get_pages_filtering():
         pages = archive.get_pages()
         
         # Only valid images should remain, sorted naturally
-        assert pages == ["01.jpg", "02.PNG", "03.WEBP"]
+        assert pages == ["01.jpg", "02.PNG", "03.WEBP", "04.jxl"]
 
 def test_comic_archive_sort_pages_priority():
     """Test the priority bucketing (covers first, z-pages last)."""

--- a/tests/services/test_images_service.py
+++ b/tests/services/test_images_service.py
@@ -1,0 +1,72 @@
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+import app  # noqa: F401  # Ensure optional Pillow codecs register before creating fixtures.
+from PIL import Image, ImageDraw
+
+from app.services.images import ImageService
+
+
+def _write_jxl_page(path: Path, accent: tuple[int, int, int]) -> None:
+    image = Image.new("RGB", (48, 72), (245, 245, 245))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 0, 47, 23), fill=accent)
+    draw.rectangle((0, 24, 47, 47), fill=(32, 64, 128))
+    draw.rectangle((0, 48, 47, 71), fill=(220, 80, 80))
+    image.save(path, format="JXL")
+
+
+def _build_jxl_cbz(tmp_path: Path) -> Path:
+    first_page = tmp_path / "01_cover.jxl"
+    second_page = tmp_path / "02_story.jxl"
+    archive_path = tmp_path / "sample-jxl.cbz"
+
+    _write_jxl_page(first_page, (24, 160, 96))
+    _write_jxl_page(second_page, (192, 120, 32))
+
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.write(first_page, arcname=first_page.name)
+        archive.write(second_page, arcname=second_page.name)
+
+    return archive_path
+
+
+def test_image_service_process_cover_and_extract_palette_from_jxl_cbz(tmp_path):
+    archive_path = _build_jxl_cbz(tmp_path)
+    thumbnail_path = tmp_path / "generated-cover.webp"
+
+    service = ImageService()
+
+    result = service.process_cover(str(archive_path), thumbnail_path)
+    palette = service.extract_palette(str(archive_path))
+
+    assert result["success"] is True
+    assert thumbnail_path.exists()
+    assert thumbnail_path.stat().st_size > 0
+    assert result["palette"] is not None
+    assert result["palette"]["primary"].startswith("#")
+    assert result["palette"]["secondary"].startswith("#")
+
+    assert palette is not None
+    assert palette["primary"].startswith("#")
+    assert palette["secondary"].startswith("#")
+
+
+def test_image_service_get_page_image_returns_native_jxl_bytes_from_archive(tmp_path):
+    archive_path = _build_jxl_cbz(tmp_path)
+
+    service = ImageService()
+    image_bytes, success, mime_type = service.get_page_image(
+        str(archive_path),
+        0,
+        transcode_webp=False,
+    )
+
+    assert success is True
+    assert mime_type == "image/jxl"
+    assert image_bytes is not None
+    assert len(image_bytes) > 0
+
+    opened = Image.open(BytesIO(image_bytes))
+    assert opened.size == (48, 72)


### PR DESCRIPTION

## Summary

This PR adds the first experimental `JPEG XL` support slice for Parker’s image pipeline.

The goal of this pass is backend/archive compatibility rather than a full browser-agnostic reader solution. Parker can now recognize `.jxl` pages inside comic archives, register JPEG XL support with Pillow at startup, generate thumbnails and palettes from JXL-backed archives, and serve native reader pages as `image/jxl` where the client/browser supports it.

## What Changed

- Added `pillow-jxl-plugin==1.3.8` to `requirements.txt`
- Added early codec registration via `pillow_jxl` so existing Pillow-based image helpers can pick up JXL support automatically
- Extended archive page detection to include `.jxl` files
- Extended reader page delivery to preserve native `image/jxl` responses and `.jxl` filenames
- Added synthetic JXL fixture coverage to validate the real image pipeline end to end

## Scope

This PR is intentionally limited to backend compatibility:
- archive page discovery
- image decoding through Pillow
- thumbnail generation
- palette extraction
- native reader delivery metadata

This PR does not add:
- browser fallback/transcoding for unsupported clients
- any guarantee that every browser can render native JXL pages
- broader format-conversion or caching work

## Testing

Validated with:
- `tests/services/test_archive.py`
- `tests/services/test_images_service.py`
- `tests/api/test_reader.py`

The synthetic JXL fixture tests now prove that a CBZ containing `.jxl` pages can:
- be enumerated correctly
- generate a thumbnail
- generate a palette
- return native JXL bytes through `ImageService`
- be served by the reader endpoint as `image/jxl`
