### PR TITLE
Add AVIF archive compatibility

### DIFF
--- a/app/api/reader.py
+++ b/app/api/reader.py
@@ -354,6 +354,7 @@ def get_comic_page(
     if not webp and mime_type == "image/png": extension = "png"
     if not webp and mime_type == "image/gif": extension = "gif"
     if not webp and mime_type == "image/jxl": extension = "jxl"
+    if not webp and mime_type == "image/avif": extension = "avif"
 
     # CACHE LOGIC
     headers = {

--- a/app/services/archive.py
+++ b/app/services/archive.py
@@ -71,7 +71,7 @@ class ComicArchive:
     def get_pages(self) -> List[str]:
         """Get sorted list of image files (pages) - filter out non-images"""
         # Valid image extensions
-        image_extensions = {'.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp', '.tiff', '.jxl'}
+        image_extensions = {'.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp', '.tiff', '.jxl', '.avif'}
 
         # Files to explicitly ignore (common in comic archives)
         ignore_patterns = {'thumbs.db', '.ds_store', 'comicinfo.xml', '__macosx'}

--- a/app/services/images.py
+++ b/app/services/images.py
@@ -127,6 +127,7 @@ class ImageService:
                 elif filename.endswith(".webp"): mime_type = "image/webp"
                 elif filename.endswith(".gif"): mime_type = "image/gif"
                 elif filename.endswith(".jxl"): mime_type = "image/jxl"
+                elif filename.endswith(".avif"): mime_type = "image/avif"
 
                 # Logic: Should we Transcode?
                 # Only if requested AND image is large (>500KB) AND not already WebP

--- a/docs/releases/0.1.22.md
+++ b/docs/releases/0.1.22.md
@@ -55,7 +55,9 @@ Concrete task list by file for the first `Following` slice:
   Current scope: The first backend compatibility pass now covers codec registration, archive page discovery for `.jxl`, and native reader response metadata for `image/jxl`.
   Scope note: Treat this first as a backend compatibility improvement so Parker can ingest archives containing `JXL` assets, generate thumbnails, derive colors, and perform other shared image operations without failing, even if browser-native reading support remains limited.
   Release note framing: User-facing notes should call this experimental and make clear that direct reading of native `JXL` pages still depends on browser support.
-- Planned: Keep `AVIF` on the compatibility watchlist as a more browser-viable modern lossy format than `JPEG XL`, while validating whether real comic archives actually use it enough to justify dedicated Parker work.
+- Planned: Add baseline `AVIF` archive compatibility through Parker's existing Pillow-based image pipeline.
+  Implementation note: Pillow `12.3.0` in the current environment already exposes AVIF support, so Parker mainly needs repo-specific handling for archive page discovery, MIME detection, and reader response metadata.
+  Current scope: The first pass should cover `.avif` archive page discovery plus thumbnail generation, palette extraction, and native reader delivery through the same paths now used for other supported image formats.
 
 ## Changed
 

--- a/tests/api/test_reader.py
+++ b/tests/api/test_reader.py
@@ -46,6 +46,15 @@ def _write_jxl_page(path: Path, accent: tuple[int, int, int]) -> None:
     image.save(path, format="JXL")
 
 
+def _write_avif_page(path: Path, accent: tuple[int, int, int]) -> None:
+    image = Image.new("RGB", (48, 72), (245, 245, 245))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 0, 47, 23), fill=accent)
+    draw.rectangle((0, 24, 47, 47), fill=(48, 84, 160))
+    draw.rectangle((0, 48, 47, 71), fill=(200, 64, 112))
+    image.save(path, format="AVIF")
+
+
 def _build_jxl_cbz(tmp_path: Path) -> Path:
     first_page = tmp_path / "01_cover.jxl"
     second_page = tmp_path / "02_story.jxl"
@@ -53,6 +62,21 @@ def _build_jxl_cbz(tmp_path: Path) -> Path:
 
     _write_jxl_page(first_page, (24, 160, 96))
     _write_jxl_page(second_page, (192, 120, 32))
+
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.write(first_page, arcname=first_page.name)
+        archive.write(second_page, arcname=second_page.name)
+
+    return archive_path
+
+
+def _build_avif_cbz(tmp_path: Path) -> Path:
+    first_page = tmp_path / "01_cover.avif"
+    second_page = tmp_path / "02_story.avif"
+    archive_path = tmp_path / "sample-avif.cbz"
+
+    _write_avif_page(first_page, (16, 148, 92))
+    _write_avif_page(second_page, (176, 112, 40))
 
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.write(first_page, arcname=first_page.name)
@@ -294,6 +318,13 @@ def test_reader_page_endpoint_headers_and_errors(client, db):
     assert jxl.headers["content-disposition"] == 'inline; filename="page_6.jxl"'
     assert jxl.headers["content-type"].startswith("image/jxl")
 
+    with patch("app.api.reader.ImageService.get_page_image", return_value=(b"avif-bytes", True, "image/avif")):
+        avif = client.get(f"/api/reader/{comic.id}/page/7")
+
+    assert avif.status_code == 200
+    assert avif.headers["content-disposition"] == 'inline; filename="page_7.avif"'
+    assert avif.headers["content-type"].startswith("image/avif")
+
     with patch("app.api.reader.ImageService.get_page_image", return_value=(None, False, "image/jpeg")):
         no_page = client.get(f"/api/reader/{comic.id}/page/5")
 
@@ -319,4 +350,25 @@ def test_reader_page_endpoint_serves_real_jxl_archive_page(client, db, tmp_path)
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("image/jxl")
     assert response.headers["content-disposition"] == 'inline; filename="page_0.jxl"'
+    assert len(response.content) > 0
+
+
+def test_reader_page_endpoint_serves_real_avif_archive_page(client, db, tmp_path):
+    library, _, volume = _create_graph(db, lib_name="reader-avif-lib", series_name="Reader AVIF")
+    archive_path = _build_avif_cbz(tmp_path)
+    comic = _add_comic(
+        db,
+        volume,
+        number="1",
+        title="AVIF Archive Comic",
+        file_path=str(archive_path),
+    )
+    db.add(library)
+    db.commit()
+
+    response = client.get(f"/api/reader/{comic.id}/page/0")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("image/avif")
+    assert response.headers["content-disposition"] == 'inline; filename="page_0.avif"'
     assert len(response.content) > 0

--- a/tests/services/test_archive.py
+++ b/tests/services/test_archive.py
@@ -13,6 +13,7 @@ def test_comic_archive_get_pages_filtering():
             "02.PNG",
             "03.WEBP",
             "04.jxl",
+            "05.avif",
             "thumbs.db",
             "Thumbs.db",
             "ComicInfo.xml",
@@ -25,7 +26,7 @@ def test_comic_archive_get_pages_filtering():
         pages = archive.get_pages()
         
         # Only valid images should remain, sorted naturally
-        assert pages == ["01.jpg", "02.PNG", "03.WEBP", "04.jxl"]
+        assert pages == ["01.jpg", "02.PNG", "03.WEBP", "04.jxl", "05.avif"]
 
 def test_comic_archive_sort_pages_priority():
     """Test the priority bucketing (covers first, z-pages last)."""

--- a/tests/services/test_images_service.py
+++ b/tests/services/test_images_service.py
@@ -17,6 +17,15 @@ def _write_jxl_page(path: Path, accent: tuple[int, int, int]) -> None:
     image.save(path, format="JXL")
 
 
+def _write_avif_page(path: Path, accent: tuple[int, int, int]) -> None:
+    image = Image.new("RGB", (48, 72), (245, 245, 245))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 0, 47, 23), fill=accent)
+    draw.rectangle((0, 24, 47, 47), fill=(48, 84, 160))
+    draw.rectangle((0, 48, 47, 71), fill=(200, 64, 112))
+    image.save(path, format="AVIF")
+
+
 def _build_jxl_cbz(tmp_path: Path) -> Path:
     first_page = tmp_path / "01_cover.jxl"
     second_page = tmp_path / "02_story.jxl"
@@ -24,6 +33,21 @@ def _build_jxl_cbz(tmp_path: Path) -> Path:
 
     _write_jxl_page(first_page, (24, 160, 96))
     _write_jxl_page(second_page, (192, 120, 32))
+
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.write(first_page, arcname=first_page.name)
+        archive.write(second_page, arcname=second_page.name)
+
+    return archive_path
+
+
+def _build_avif_cbz(tmp_path: Path) -> Path:
+    first_page = tmp_path / "01_cover.avif"
+    second_page = tmp_path / "02_story.avif"
+    archive_path = tmp_path / "sample-avif.cbz"
+
+    _write_avif_page(first_page, (16, 148, 92))
+    _write_avif_page(second_page, (176, 112, 40))
 
     with zipfile.ZipFile(archive_path, "w") as archive:
         archive.write(first_page, arcname=first_page.name)
@@ -65,6 +89,46 @@ def test_image_service_get_page_image_returns_native_jxl_bytes_from_archive(tmp_
 
     assert success is True
     assert mime_type == "image/jxl"
+    assert image_bytes is not None
+    assert len(image_bytes) > 0
+
+    opened = Image.open(BytesIO(image_bytes))
+    assert opened.size == (48, 72)
+
+
+def test_image_service_process_cover_and_extract_palette_from_avif_cbz(tmp_path):
+    archive_path = _build_avif_cbz(tmp_path)
+    thumbnail_path = tmp_path / "generated-avif-cover.webp"
+
+    service = ImageService()
+
+    result = service.process_cover(str(archive_path), thumbnail_path)
+    palette = service.extract_palette(str(archive_path))
+
+    assert result["success"] is True
+    assert thumbnail_path.exists()
+    assert thumbnail_path.stat().st_size > 0
+    assert result["palette"] is not None
+    assert result["palette"]["primary"].startswith("#")
+    assert result["palette"]["secondary"].startswith("#")
+
+    assert palette is not None
+    assert palette["primary"].startswith("#")
+    assert palette["secondary"].startswith("#")
+
+
+def test_image_service_get_page_image_returns_native_avif_bytes_from_archive(tmp_path):
+    archive_path = _build_avif_cbz(tmp_path)
+
+    service = ImageService()
+    image_bytes, success, mime_type = service.get_page_image(
+        str(archive_path),
+        0,
+        transcode_webp=False,
+    )
+
+    assert success is True
+    assert mime_type == "image/avif"
     assert image_bytes is not None
     assert len(image_bytes) > 0
 


### PR DESCRIPTION

This PR adds baseline `AVIF` compatibility to Parker’s existing image pipeline.

Pillow in the current environment already exposes AVIF support, so this change focuses on Parker’s repo-specific handling: recognizing `.avif` pages inside comic archives, preserving the correct MIME type through reader delivery, and validating the real archive/image pipeline with synthetic AVIF-backed test fixtures.

## What Changed

- Added `.avif` to archive page discovery
- Added AVIF MIME detection in `ImageService`
- Added `.avif` filename and `image/avif` response handling in the reader endpoint
- Added synthetic AVIF fixture coverage for:
  - archive page discovery
  - thumbnail generation
  - palette extraction
  - raw image extraction
  - reader delivery

## Scope

This PR is intentionally small and focused:
- no new dependencies
- no startup codec registration changes
- no transcoding or browser-fallback work

The main goal is to ensure Parker can correctly process archives containing AVIF pages through the same backend paths used for other supported image formats.

## Testing

Validated with:
- `tests/services/test_archive.py`
- `tests/services/test_images_service.py`
- `tests/api/test_reader.py`

The synthetic AVIF fixture tests prove that a CBZ containing `.avif` pages can:
- be enumerated correctly by the archive layer
- generate a thumbnail
- generate a palette
- return native AVIF bytes through `ImageService`
- be served by the reader endpoint as `image/avif`

## Notes

Because AVIF support is already present in Pillow in this environment, this PR is mostly Parker-side integration rather than a new codec-enablement project.


