### PR TITLE
Add bookmark system first pass

### DIFF
--- a/alembic/versions/5466f87f7df4_add_bookmarks_table.py
+++ b/alembic/versions/5466f87f7df4_add_bookmarks_table.py
@@ -1,0 +1,47 @@
+"""Add bookmarks table
+
+Revision ID: 5466f87f7df4
+Revises: 9f1a2c6b4d10
+Create Date: 2026-07-17 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5466f87f7df4"
+down_revision: Union[str, None] = "9f1a2c6b4d10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "bookmarks",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("comic_id", sa.Integer(), nullable=False),
+        sa.Column("page_index", sa.Integer(), nullable=False),
+        sa.Column("label", sa.String(length=120), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["comic_id"], ["comics.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "comic_id", "page_index", name="unique_user_comic_bookmark_page"),
+    )
+    op.create_index(op.f("ix_bookmarks_comic_id"), "bookmarks", ["comic_id"], unique=False)
+    op.create_index(op.f("ix_bookmarks_created_at"), "bookmarks", ["created_at"], unique=False)
+    op.create_index(op.f("ix_bookmarks_id"), "bookmarks", ["id"], unique=False)
+    op.create_index(op.f("ix_bookmarks_user_id"), "bookmarks", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_bookmarks_user_id"), table_name="bookmarks")
+    op.drop_index(op.f("ix_bookmarks_id"), table_name="bookmarks")
+    op.drop_index(op.f("ix_bookmarks_created_at"), table_name="bookmarks")
+    op.drop_index(op.f("ix_bookmarks_comic_id"), table_name="bookmarks")
+    op.drop_table("bookmarks")

--- a/app/api/bookmarks.py
+++ b/app/api/bookmarks.py
@@ -1,0 +1,161 @@
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import joinedload
+
+from app.api.deps import CurrentUser, SessionDep
+from app.core.comic_helpers import get_comic_age_restriction
+from app.models.bookmark import Bookmark
+from app.models.comic import Comic, Volume
+from app.services.bookmarks import BookmarkService
+
+router = APIRouter()
+
+
+class SaveBookmarkRequest(BaseModel):
+    page_index: int = Field(ge=0)
+    label: Optional[str] = Field(default=None, max_length=120)
+
+
+class UpdateBookmarkRequest(BaseModel):
+    label: Optional[str] = Field(default=None, max_length=120)
+
+
+def get_bookmark_service(
+    db: SessionDep,
+    user: CurrentUser,
+) -> BookmarkService:
+    return BookmarkService(db, user_id=user.id)
+
+
+def serialize_bookmark(bookmark: Bookmark) -> dict:
+    return {
+        "id": bookmark.id,
+        "comic_id": bookmark.comic_id,
+        "page_index": bookmark.page_index,
+        "label": bookmark.label,
+        "created_at": bookmark.created_at,
+        "updated_at": bookmark.updated_at,
+    }
+
+
+def ensure_bookmark_comic_access(db: SessionDep, current_user: CurrentUser, comic_id: int) -> Comic:
+    comic = (
+        db.query(Comic)
+        .options(joinedload(Comic.volume).joinedload(Volume.series))
+        .filter(Comic.id == comic_id)
+        .first()
+    )
+
+    if not comic:
+        raise HTTPException(status_code=404, detail=f"Comic {comic_id} not found")
+
+    if not current_user.is_superuser:
+        allowed_library_ids = {library.id for library in current_user.accessible_libraries}
+        if comic.volume.series.library_id not in allowed_library_ids:
+            raise HTTPException(status_code=404, detail=f"Comic {comic_id} not found")
+
+    comic_age_filter = get_comic_age_restriction(current_user)
+    if comic_age_filter is not None:
+        allowed = db.query(Comic.id).filter(Comic.id == comic_id, comic_age_filter).first()
+        if not allowed:
+            raise HTTPException(status_code=403, detail="Content restricted by age rating")
+
+    return comic
+
+
+@router.get("/comic/{comic_id}", name="comic_bookmarks")
+async def get_comic_bookmarks(
+    comic_id: int,
+    service: Annotated[BookmarkService, Depends(get_bookmark_service)],
+    db: SessionDep,
+    current_user: CurrentUser,
+):
+    ensure_bookmark_comic_access(db, current_user, comic_id)
+    return [serialize_bookmark(bookmark) for bookmark in service.list_for_comic(comic_id)]
+
+
+@router.post("/comic/{comic_id}", name="save_comic_bookmark")
+async def save_comic_bookmark(
+    comic_id: int,
+    request: SaveBookmarkRequest,
+    service: Annotated[BookmarkService, Depends(get_bookmark_service)],
+    db: SessionDep,
+    current_user: CurrentUser,
+):
+    comic = ensure_bookmark_comic_access(db, current_user, comic_id)
+
+    if comic.page_count is not None and comic.page_count > 0 and request.page_index >= comic.page_count:
+        raise HTTPException(status_code=422, detail="Bookmark page is out of range")
+
+    try:
+        bookmark, created = service.save_bookmark(
+            comic_id=comic_id,
+            page_index=request.page_index,
+            label=request.label,
+        )
+        db.commit()
+        db.refresh(bookmark)
+        return {
+            "created": created,
+            "bookmark": serialize_bookmark(bookmark),
+        }
+    except Exception as exc:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.patch("/{bookmark_id}", name="update_bookmark")
+async def update_bookmark(
+    bookmark_id: int,
+    request: UpdateBookmarkRequest,
+    service: Annotated[BookmarkService, Depends(get_bookmark_service)],
+    db: SessionDep,
+    current_user: CurrentUser,
+):
+    bookmark = service.get_bookmark(bookmark_id)
+    if not bookmark:
+        raise HTTPException(status_code=404, detail="Bookmark not found")
+
+    ensure_bookmark_comic_access(db, current_user, bookmark.comic_id)
+
+    try:
+        updated = service.rename_bookmark(bookmark_id, request.label)
+        db.commit()
+        db.refresh(updated)
+        return serialize_bookmark(updated)
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(status_code=404, detail=str(exc))
+    except Exception as exc:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.delete("/{bookmark_id}", name="delete_bookmark")
+async def delete_bookmark(
+    bookmark_id: int,
+    service: Annotated[BookmarkService, Depends(get_bookmark_service)],
+    db: SessionDep,
+    current_user: CurrentUser,
+):
+    bookmark = service.get_bookmark(bookmark_id)
+    if not bookmark:
+        raise HTTPException(status_code=404, detail="Bookmark not found")
+
+    ensure_bookmark_comic_access(db, current_user, bookmark.comic_id)
+
+    try:
+        deleted = service.delete_bookmark(bookmark_id)
+        db.commit()
+        return {
+            "bookmark_id": deleted.id,
+            "message": "Bookmark deleted",
+        }
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(status_code=404, detail=str(exc))
+    except Exception as exc:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/app/main.py
+++ b/app/main.py
@@ -32,7 +32,7 @@ from app.models.user import User
 from app.services.watcher import library_watcher
 
 # API Routes
-from app.api import libraries, comics, reader, progress, series, volumes, search
+from app.api import libraries, comics, reader, progress, series, volumes, search, bookmarks
 from app.api import reading_lists, collections
 from app.api import auth, users, saved_searches, smart_lists
 from app.api import tasks, jobs, stats, settings as settings_api
@@ -234,6 +234,7 @@ app.include_router(series.router, prefix="/api/series", tags=["series"])
 app.include_router(volumes.router, prefix="/api/volumes", tags=["volumes"])
 app.include_router(comics.router, prefix="/api/comics", tags=["comics"])
 app.include_router(reader.router, prefix="/api/reader", tags=["reader"])
+app.include_router(bookmarks.router, prefix="/api/bookmarks", tags=["bookmarks"])
 app.include_router(reading_lists.router, prefix="/api/reading-lists", tags=["reading-lists"])
 app.include_router(collections.router, prefix="/api/collections", tags=["collections"])
 app.include_router(progress.router, prefix="/api/progress", tags=["progress"])

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.credits import Person, ComicCredit
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.collection import Collection, CollectionItem
 from app.models.reading_progress import ReadingProgress
+from app.models.bookmark import Bookmark
 from app.models.job import ScanJob
 from app.models.user import User
 from app.models.interactions import UserSeries, UserVolumeFollow, UserComicRating
@@ -23,7 +24,7 @@ __all__ = [
     'Person', 'ComicCredit',
     'ReadingList', 'ReadingListItem',
     'Collection', 'CollectionItem',
-    'ReadingProgress', 'ActivityLog',
+    'ReadingProgress', 'ActivityLog', 'Bookmark',
     'ScanJob',
     'User',
     'UserSeries', 'UserVolumeFollow', 'UserComicRating',

--- a/app/models/bookmark.py
+++ b/app/models/bookmark.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class Bookmark(Base):
+    """Persist user-saved page markers without affecting resume progress."""
+
+    __tablename__ = "bookmarks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    comic_id = Column(Integer, ForeignKey("comics.id", ondelete="CASCADE"), nullable=False, index=True)
+    page_index = Column(Integer, nullable=False)
+    label = Column(String(120), nullable=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
+    updated_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "comic_id", "page_index", name="unique_user_comic_bookmark_page"),
+    )
+
+    comic = relationship("Comic", back_populates="bookmarks")
+    user = relationship("User", back_populates="bookmarks")

--- a/app/models/comic.py
+++ b/app/models/comic.py
@@ -94,6 +94,7 @@ class Comic(Base):
     reading_list_items = relationship("ReadingListItem", back_populates="comic", cascade="all, delete-orphan")
     collection_items = relationship("CollectionItem", back_populates="comic", cascade="all, delete-orphan")
     reading_progress = relationship("ReadingProgress", back_populates="comic", cascade="all, delete-orphan")
+    bookmarks = relationship("Bookmark", back_populates="comic", cascade="all, delete-orphan")
     pull_list_items = relationship("PullListItem", back_populates="comic", cascade="all, delete-orphan")
 
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -40,6 +40,7 @@ class User(Base):
 
     # When a user is deleted, delete their reading history too
     reading_progress = relationship("ReadingProgress", back_populates="user", cascade="all, delete-orphan")
+    bookmarks = relationship("Bookmark", back_populates="user", cascade="all, delete-orphan")
 
     # Many-to-Many Relationship
     # We use a string "Library" to avoid circular imports if Library imports User

--- a/app/services/bookmarks.py
+++ b/app/services/bookmarks.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.bookmark import Bookmark
+
+
+class BookmarkService:
+    """Manage user bookmarks independently from reading progress."""
+
+    def __init__(self, db: Session, user_id: int):
+        self.db = db
+        self.user_id = user_id
+
+    def list_for_comic(self, comic_id: int) -> List[Bookmark]:
+        return (
+            self.db.query(Bookmark)
+            .filter(
+                Bookmark.user_id == self.user_id,
+                Bookmark.comic_id == comic_id,
+            )
+            .order_by(Bookmark.page_index.asc(), Bookmark.created_at.asc())
+            .all()
+        )
+
+    def get_bookmark(self, bookmark_id: int) -> Optional[Bookmark]:
+        return (
+            self.db.query(Bookmark)
+            .filter(
+                Bookmark.id == bookmark_id,
+                Bookmark.user_id == self.user_id,
+            )
+            .first()
+        )
+
+    def save_bookmark(self, comic_id: int, page_index: int, label: Optional[str] = None) -> tuple[Bookmark, bool]:
+        normalized_label = (label or "").strip() or None
+        bookmark = (
+            self.db.query(Bookmark)
+            .filter(
+                Bookmark.user_id == self.user_id,
+                Bookmark.comic_id == comic_id,
+                Bookmark.page_index == page_index,
+            )
+            .first()
+        )
+
+        if bookmark:
+            if bookmark.label != normalized_label:
+                bookmark.label = normalized_label
+                bookmark.updated_at = datetime.now(timezone.utc)
+                self.db.flush()
+            return bookmark, False
+
+        bookmark = Bookmark(
+            user_id=self.user_id,
+            comic_id=comic_id,
+            page_index=page_index,
+            label=normalized_label,
+        )
+        self.db.add(bookmark)
+        self.db.flush()
+        return bookmark, True
+
+    def rename_bookmark(self, bookmark_id: int, label: Optional[str]) -> Bookmark:
+        bookmark = self.get_bookmark(bookmark_id)
+        if not bookmark:
+            raise ValueError("Bookmark not found")
+
+        bookmark.label = (label or "").strip() or None
+        bookmark.updated_at = datetime.now(timezone.utc)
+        self.db.flush()
+        return bookmark
+
+    def delete_bookmark(self, bookmark_id: int) -> Bookmark:
+        bookmark = self.get_bookmark(bookmark_id)
+        if not bookmark:
+            raise ValueError("Bookmark not found")
+
+        self.db.delete(bookmark)
+        self.db.flush()
+        return bookmark

--- a/app/templates/reader.html
+++ b/app/templates/reader.html
@@ -15,6 +15,7 @@
      x-on:touchend="handleTouchEnd($event)">
 
     {% include "reader/partials/_toolbar.html" %}
+    {% include "reader/partials/_bookmark_detour_banner.html" %}
     {% include "reader/partials/_settings_panel.html" %}
 
     <div class="hover-zone"

--- a/app/templates/reader.html
+++ b/app/templates/reader.html
@@ -27,6 +27,7 @@
     {% include "reader/partials/_paged_content.html" %}
     {% include "reader/partials/_scroll_content.html" %}
     {% include "reader/partials/_goto_modal.html" %}
+    {% include "reader/partials/_bookmarks_modal.html" %}
 </div>
 {% endblock %}
 

--- a/app/templates/reader/partials/_bookmark_detour_banner.html
+++ b/app/templates/reader/partials/_bookmark_detour_banner.html
@@ -1,0 +1,26 @@
+<div x-show="isBookmarkDetourActive"
+     x-cloak
+     data-bookmark-detour
+     class="bookmark-detour-banner px-4 py-3 text-amber-50 shadow-lg shadow-black/35">
+    <div class="mx-auto flex max-w-5xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+            <p class="text-sm font-semibold">Bookmark detour active</p>
+            <p class="text-sm text-amber-100/90">
+                Resume progress is still saved at page <span x-text="bookmarkDetourOriginPage + 1"></span>.
+            </p>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2">
+            <button x-on:click="returnFromBookmarkDetour()"
+                    data-bookmark-detour-return
+                    class="rounded-lg border border-amber-300/50 bg-gray-950/80 px-3 py-2 text-sm font-semibold text-amber-100 shadow-lg shadow-black/35 backdrop-blur-md transition-colors hover:bg-gray-950">
+                Return to page <span x-text="bookmarkDetourOriginPage + 1"></span>
+            </button>
+            <button x-on:click="resumeProgressFromHere()"
+                    data-bookmark-detour-resume
+                    class="rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-lg shadow-black/30 transition-colors hover:bg-blue-500">
+                Resume from here
+            </button>
+        </div>
+    </div>
+</div>

--- a/app/templates/reader/partials/_bookmark_detour_banner.html
+++ b/app/templates/reader/partials/_bookmark_detour_banner.html
@@ -1,25 +1,33 @@
 <div x-show="isBookmarkDetourActive"
      x-cloak
      data-bookmark-detour
-     class="bookmark-detour-banner px-4 py-3 text-amber-50 shadow-lg shadow-black/35">
-    <div class="mx-auto flex max-w-5xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-            <p class="text-sm font-semibold">Bookmark detour active</p>
-            <p class="text-sm text-amber-100/90">
-                Resume progress is still saved at page <span x-text="bookmarkDetourOriginPage + 1"></span>.
-            </p>
+     class="bookmark-detour-banner px-4 py-2 text-slate-100 shadow-lg shadow-black/35">
+    <div class="mx-auto flex max-w-5xl flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex items-center gap-3 min-w-0">
+            <div class="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full border border-amber-300/35 bg-amber-300/10 text-amber-200">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-4-7 4V5z" />
+                </svg>
+            </div>
+
+            <div class="min-w-0">
+                <p class="text-sm font-semibold tracking-tight text-white">Bookmark detour active</p>
+                <p class="truncate text-xs text-slate-300">
+                    Resume stays at page <span class="font-semibold text-amber-200" x-text="bookmarkDetourOriginPage + 1"></span> until you choose otherwise.
+                </p>
+            </div>
         </div>
 
-        <div class="flex flex-wrap items-center gap-2">
+        <div class="flex flex-wrap items-center gap-2 sm:flex-nowrap">
             <button x-on:click="returnFromBookmarkDetour()"
                     data-bookmark-detour-return
-                    class="rounded-lg border border-amber-300/50 bg-gray-950/80 px-3 py-2 text-sm font-semibold text-amber-100 shadow-lg shadow-black/35 backdrop-blur-md transition-colors hover:bg-gray-950">
-                Return to page <span x-text="bookmarkDetourOriginPage + 1"></span>
+                    class="rounded-lg border border-slate-600/80 bg-slate-950/85 px-3 py-2 text-sm font-semibold text-slate-100 shadow-lg shadow-black/35 backdrop-blur-md transition-colors hover:border-slate-500 hover:bg-slate-900">
+                Return to page <span class="text-amber-200" x-text="bookmarkDetourOriginPage + 1"></span>
             </button>
             <button x-on:click="resumeProgressFromHere()"
                     data-bookmark-detour-resume
                     class="rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-lg shadow-black/30 transition-colors hover:bg-blue-500">
-                Resume from here
+                Resume here
             </button>
         </div>
     </div>

--- a/app/templates/reader/partials/_bookmarks_modal.html
+++ b/app/templates/reader/partials/_bookmarks_modal.html
@@ -1,0 +1,97 @@
+<div x-show="showBookmarks" x-cloak
+     data-bookmarks-modal
+     class="fixed inset-0 z-[70] flex items-center justify-center bg-black/80 backdrop-blur-sm px-4"
+     x-transition:enter="transition ease-out duration-200"
+     x-transition:enter-start="opacity-0"
+     x-transition:enter-end="opacity-100"
+     x-transition:leave="transition ease-in duration-100"
+     x-transition:leave-start="opacity-100"
+     x-transition:leave-end="opacity-0"
+     x-on:click.self="closeBookmarks()">
+
+    <div class="w-full max-w-xl rounded-xl border border-gray-700 bg-gray-950/95 shadow-2xl"
+         x-transition:enter="transition ease-out duration-200"
+         x-transition:enter-start="scale-95 opacity-0"
+         x-transition:enter-end="scale-100 opacity-100">
+
+        <div class="flex items-start justify-between gap-4 border-b border-gray-800 px-6 py-5">
+            <div>
+                <h3 class="text-lg font-bold text-white">Bookmarks</h3>
+                <p class="mt-1 text-sm text-gray-400">Save intentional page markers without affecting Continue progress.</p>
+            </div>
+            <button x-on:click="closeBookmarks()" data-close-bookmarks class="rounded p-2 text-gray-400 transition-colors hover:bg-white/10 hover:text-white" title="Close Bookmarks">
+                <span class="sr-only">Close bookmarks</span>
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </div>
+
+        <div class="border-b border-gray-800 px-6 py-5">
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
+                <div class="flex-1">
+                    <label class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">Label (Optional)</label>
+                    <input x-ref="bookmarkLabelInput"
+                           type="text"
+                           maxlength="120"
+                           x-model="bookmarkLabelValue"
+                           placeholder="Favorite splash page"
+                           class="w-full rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-sm text-white placeholder:text-gray-500 focus:border-blue-500 focus:outline-none">
+                </div>
+                <div class="flex items-center justify-between gap-3 sm:flex-col sm:items-end">
+                    <span class="rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-sm font-semibold text-blue-300">
+                        Page <span x-text="currentPage + 1"></span>
+                    </span>
+                    <button x-on:click="saveBookmark()"
+                            data-save-bookmark
+                            class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-bold text-white transition-colors hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                            :disabled="isIncognito || isBookmarkBusy || meta.page_count <= 0"
+                            x-text="currentBookmark ? 'Update Bookmark' : 'Save Bookmark'">
+                    </button>
+                </div>
+            </div>
+
+            <p x-show="isIncognito" class="mt-3 text-xs text-amber-300">
+                Incognito mode is read-only for bookmarks.
+            </p>
+        </div>
+
+        <div class="max-h-[22rem] overflow-y-auto px-6 py-5">
+            <template x-if="bookmarks.length === 0">
+                <div class="rounded-xl border border-dashed border-gray-700 px-5 py-10 text-center">
+                    <p class="text-sm font-medium text-white">No bookmarks yet.</p>
+                    <p class="mt-1 text-sm text-gray-400">Save the current page to keep a reusable jump point.</p>
+                </div>
+            </template>
+
+            <div class="space-y-3" x-show="bookmarks.length > 0">
+                <template x-for="bookmark in bookmarks" :key="bookmark.id">
+                    <div data-bookmark-item
+                         :data-page-index="bookmark.page_index"
+                         class="flex items-center gap-3 rounded-xl border border-gray-800 bg-gray-900/80 p-3">
+
+                        <button x-on:click="jumpToBookmark(bookmark.page_index)"
+                                class="flex-1 text-left transition-colors hover:text-white">
+                            <div class="flex items-center gap-2">
+                                <span class="text-sm font-bold text-blue-300" x-text="`Page ${bookmark.page_index + 1}`"></span>
+                                <span x-show="bookmark.page_index === currentPage"
+                                      class="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-emerald-300">
+                                    Current
+                                </span>
+                            </div>
+                            <p x-show="bookmark.label" x-text="bookmark.label" class="mt-1 text-sm text-gray-300"></p>
+                            <p x-show="!bookmark.label" class="mt-1 text-sm text-gray-500">Saved page marker</p>
+                        </button>
+
+                        <button x-on:click.stop="deleteBookmark(bookmark.id)"
+                                data-delete-bookmark
+                                class="rounded-lg px-3 py-2 text-sm font-medium text-gray-400 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+                                :disabled="isIncognito || isBookmarkBusy">
+                            Delete
+                        </button>
+                    </div>
+                </template>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/templates/reader/partials/_styles.html
+++ b/app/templates/reader/partials/_styles.html
@@ -31,6 +31,15 @@
 
     .reader-toolbar.hidden { transform: translateY(-100%); }
 
+    .bookmark-detour-banner {
+        position: sticky;
+        top: 4.25rem;
+        z-index: 45;
+        backdrop-filter: blur(10px);
+        background: rgba(10, 14, 24, 0.9);
+        border-bottom: 1px solid rgba(251, 191, 36, 0.35);
+    }
+
     .reader-content {
         flex: 1; display: flex; align-items: center; justify-content: center;
         overflow: hidden; position: relative;

--- a/app/templates/reader/partials/_styles.html
+++ b/app/templates/reader/partials/_styles.html
@@ -35,9 +35,9 @@
         position: sticky;
         top: 4.25rem;
         z-index: 45;
-        backdrop-filter: blur(10px);
-        background: rgba(10, 14, 24, 0.9);
-        border-bottom: 1px solid rgba(251, 191, 36, 0.35);
+        backdrop-filter: blur(14px);
+        background: linear-gradient(180deg, rgba(8, 12, 20, 0.96), rgba(11, 17, 28, 0.92));
+        border-bottom: 1px solid rgba(148, 163, 184, 0.18);
     }
 
     .reader-content {

--- a/app/templates/reader/partials/_toolbar.html
+++ b/app/templates/reader/partials/_toolbar.html
@@ -41,6 +41,13 @@
             </svg>
         </button>
 
+        <button x-on:click="openBookmarks()" data-bookmarks-toggle class="p-2 text-gray-300 hover:text-white rounded hover:bg-white/10"
+                :class="{'text-blue-400': showBookmarks || currentBookmark}" title="Bookmarks (b)">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-4-7 4V5z" />
+            </svg>
+        </button>
+
         <button x-on:click="toggleFullscreen()" class="p-2 text-gray-300 hover:text-white rounded hover:bg-white/10" title="Toggle Fullscreen (f)">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />

--- a/docs/releases/0.1.23.md
+++ b/docs/releases/0.1.23.md
@@ -4,16 +4,20 @@ Status: Draft
 
 ## Added
 
-- Placeholder for new features landed during the `0.1.23` cycle.
+- Reader bookmarks as a separate per-user, per-comic save system, including save, jump-to, rename-on-resave, and delete flows from the in-reader bookmarks modal.
+- Bookmark detour mode in the reader so users can jump back to a saved page for reference without immediately overwriting their true resume position.
 
 ## Changed
 
-- Placeholder for behavior changes, refactors, or notable UX adjustments landed during the `0.1.23` cycle.
+- Bookmark jumps now open a temporary detour state with explicit `Return to page X` and `Resume here` actions instead of behaving like ordinary progress-changing navigation.
+- Reader detour messaging was tuned to remain readable over bright comic page margins with a darker banner surface and stronger action contrast.
 
 ## Fixed
 
-- Placeholder for bug fixes landed during the `0.1.23` cycle.
+- Fixed bookmark revisit flows that could otherwise force users to remember their original page manually or close and reopen the comic just to preserve real reading progress.
+- Fixed detour banner readability issues where low-opacity banner/button styling could become faint against white top gutters in comic pages.
 
 ## Validation
 
-- Placeholder for validation notes and executed test coverage relevant to the `0.1.23` release.
+- Elevated API verification passed: `tests/api/test_bookmarks.py`, `tests/api/test_progress.py`, and `tests/api/test_reader.py`.
+- Elevated browser verification passed: `tests/browser/test_reader_smoke.py -k bookmark`.

--- a/static/js/reader.js
+++ b/static/js/reader.js
@@ -150,6 +150,7 @@
             bookmarks: [],
             bookmarksLoaded: false,
             isBookmarkBusy: false,
+            bookmarkDetourOriginPage: null,
             scrubberValue: 0,
             isScrubbing: false,
             isHoveringScrubber: false,
@@ -326,6 +327,12 @@
                 enumerable: true,
                 get() {
                     return this.bookmarks.find((bookmark) => bookmark.page_index === this.currentPage) || null;
+                }
+            },
+            isBookmarkDetourActive: {
+                enumerable: true,
+                get() {
+                    return Number.isInteger(this.bookmarkDetourOriginPage);
                 }
             }
         };
@@ -839,6 +846,41 @@
                 this.bookmarkLabelValue = this.currentBookmark?.label || '';
             },
 
+            beginBookmarkDetour(targetPage) {
+                if (!this.isBookmarkDetourActive) {
+                    this.bookmarkDetourOriginPage = this.currentPage;
+                }
+
+                this.navigateToPage(targetPage, { persist: false });
+                this.closeBookmarks();
+                window.parker.showToast(`Bookmark detour started from page ${this.bookmarkDetourOriginPage + 1}`);
+            },
+
+            clearBookmarkDetour() {
+                this.bookmarkDetourOriginPage = null;
+            },
+
+            returnFromBookmarkDetour() {
+                if (!this.isBookmarkDetourActive) {
+                    return;
+                }
+
+                const originPage = this.bookmarkDetourOriginPage;
+                this.clearBookmarkDetour();
+                this.navigateToPage(originPage, { persist: false });
+                window.parker.showToast(`Returned to page ${originPage + 1}`);
+            },
+
+            resumeProgressFromHere() {
+                if (!this.isBookmarkDetourActive) {
+                    return;
+                }
+
+                this.clearBookmarkDetour();
+                this.updateProgress(true);
+                window.parker.showToast(`Resume point moved to page ${this.currentPage + 1}`);
+            },
+
             async saveBookmark() {
                 if (this.isIncognito) {
                     window.parker.showToast('Incognito Mode: Bookmark changes are disabled.');
@@ -930,12 +972,16 @@
             },
 
             jumpToBookmark(pageIndex) {
-                this.navigateToPage(pageIndex, { persist: false });
-                this.closeBookmarks();
+                if (pageIndex === this.currentPage) {
+                    this.closeBookmarks();
+                    return;
+                }
+
+                this.beginBookmarkDetour(pageIndex);
             },
 
-            async updateProgress() {
-                if (this.isIncognito) {
+            async updateProgress(force = false) {
+                if (this.isIncognito || (this.isBookmarkDetourActive && !force)) {
                     return;
                 }
 

--- a/static/js/reader.js
+++ b/static/js/reader.js
@@ -144,7 +144,12 @@
             doublePageOffset: true,
             showSpineShadow: false,
             showGoto: false,
+            showBookmarks: false,
             gotoInputValue: 1,
+            bookmarkLabelValue: '',
+            bookmarks: [],
+            bookmarksLoaded: false,
+            isBookmarkBusy: false,
             scrubberValue: 0,
             isScrubbing: false,
             isHoveringScrubber: false,
@@ -238,6 +243,7 @@
                         || this.tapVisible
                         || this.isHoveringZone
                         || this.showSettings
+                        || this.showBookmarks
                         || this.showGoto
                         || this.isScrubbing
                         || this.isHoveringScrubber
@@ -315,6 +321,12 @@
 
                     return [{ index: firstPage }, { index: secondPage }];
                 }
+            },
+            currentBookmark: {
+                enumerable: true,
+                get() {
+                    return this.bookmarks.find((bookmark) => bookmark.page_index === this.currentPage) || null;
+                }
             }
         };
     }
@@ -334,7 +346,7 @@
                 this.contextId = params.get('context_id');
 
                 if (this.isIncognito) {
-                    window.parker.showToast('Incognito Mode: Progress will not be saved.');
+                    window.parker.showToast('Incognito Mode: Progress and bookmark changes will not be saved.');
                 }
 
                 this.loadInitData();
@@ -365,6 +377,7 @@
                         }
                     }
 
+                    await this.loadBookmarks();
                     this.preloadContext();
 
                     if (this.isScrollMode) {
@@ -762,6 +775,165 @@
                 this.filters = cloneDefaultFilters();
             },
 
+            async loadBookmarks() {
+                try {
+                    const response = await fetch(window.parker.route('bookmarks.comic_bookmarks', { comic_id: this.comicId }));
+                    if (!response.ok) {
+                        throw new Error('Failed to load bookmarks');
+                    }
+
+                    this.bookmarks = await response.json();
+                    this.bookmarksLoaded = true;
+                    this.bookmarkLabelValue = this.currentBookmark?.label || '';
+                } catch (error) {
+                    console.error(error);
+                }
+            },
+
+            async openBookmarks() {
+                this.showGoto = false;
+                this.showSettings = false;
+                this.showBookmarks = true;
+
+                if (!this.bookmarksLoaded) {
+                    await this.loadBookmarks();
+                } else {
+                    this.bookmarkLabelValue = this.currentBookmark?.label || '';
+                }
+
+                this.$nextTick(() => {
+                    if (this.$refs.bookmarkLabelInput) {
+                        this.$refs.bookmarkLabelInput.focus();
+                        this.$refs.bookmarkLabelInput.select();
+                    }
+                });
+            },
+
+            closeBookmarks() {
+                this.showBookmarks = false;
+                this.resetControlFocus();
+            },
+
+            sortBookmarks(bookmarks) {
+                return [...bookmarks].sort((left, right) => {
+                    if (left.page_index !== right.page_index) {
+                        return left.page_index - right.page_index;
+                    }
+
+                    return new Date(left.created_at) - new Date(right.created_at);
+                });
+            },
+
+            applyBookmarkUpdate(bookmark) {
+                const existingIndex = this.bookmarks.findIndex((item) => item.id === bookmark.id);
+                const nextBookmarks = [...this.bookmarks];
+
+                if (existingIndex >= 0) {
+                    nextBookmarks.splice(existingIndex, 1, bookmark);
+                } else {
+                    nextBookmarks.push(bookmark);
+                }
+
+                this.bookmarks = this.sortBookmarks(nextBookmarks);
+                this.bookmarksLoaded = true;
+                this.bookmarkLabelValue = this.currentBookmark?.label || '';
+            },
+
+            async saveBookmark() {
+                if (this.isIncognito) {
+                    window.parker.showToast('Incognito Mode: Bookmark changes are disabled.');
+                    return;
+                }
+
+                if (this.meta.page_count <= 0 || this.isBookmarkBusy) {
+                    return;
+                }
+
+                this.isBookmarkBusy = true;
+
+                try {
+                    const response = await fetch(window.parker.route('bookmarks.save_comic_bookmark', { comic_id: this.comicId }), {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            page_index: this.currentPage,
+                            label: this.bookmarkLabelValue
+                        })
+                    });
+
+                    const payload = await response.json();
+                    if (!response.ok) {
+                        throw new Error(payload.detail || 'Failed to save bookmark');
+                    }
+
+                    this.applyBookmarkUpdate(payload.bookmark);
+                    window.parker.showToast(payload.created ? 'Bookmark saved' : 'Bookmark updated');
+                } catch (error) {
+                    console.error(error);
+                    window.parker.showToast(error.message || 'Failed to save bookmark', 'error');
+                } finally {
+                    this.isBookmarkBusy = false;
+                }
+            },
+
+            async deleteBookmark(bookmarkId) {
+                if (this.isIncognito) {
+                    window.parker.showToast('Incognito Mode: Bookmark changes are disabled.');
+                    return;
+                }
+
+                if (this.isBookmarkBusy) {
+                    return;
+                }
+
+                this.isBookmarkBusy = true;
+
+                try {
+                    const response = await fetch(window.parker.route('bookmarks.delete_bookmark', { bookmark_id: bookmarkId }), {
+                        method: 'DELETE'
+                    });
+                    const payload = await response.json();
+
+                    if (!response.ok) {
+                        throw new Error(payload.detail || 'Failed to delete bookmark');
+                    }
+
+                    this.bookmarks = this.bookmarks.filter((bookmark) => bookmark.id !== bookmarkId);
+                    this.bookmarkLabelValue = this.currentBookmark?.label || '';
+                    window.parker.showToast('Bookmark deleted');
+                } catch (error) {
+                    console.error(error);
+                    window.parker.showToast(error.message || 'Failed to delete bookmark', 'error');
+                } finally {
+                    this.isBookmarkBusy = false;
+                }
+            },
+
+            navigateToPage(pageIndex, { persist = true } = {}) {
+                if (this.meta.page_count <= 0) {
+                    return;
+                }
+
+                const boundedPage = Math.max(0, Math.min(pageIndex, this.meta.page_count - 1));
+
+                if (this.isScrollMode) {
+                    this.syncScrollPage(boundedPage, { behavior: 'auto', persist });
+                    return;
+                }
+
+                const changed = boundedPage !== this.currentPage;
+                this.currentPage = boundedPage;
+
+                if (persist && changed) {
+                    this.updateProgress();
+                }
+            },
+
+            jumpToBookmark(pageIndex) {
+                this.navigateToPage(pageIndex, { persist: false });
+                this.closeBookmarks();
+            },
+
             async updateProgress() {
                 if (this.isIncognito) {
                     return;
@@ -796,6 +968,13 @@
                 if (this.showGoto) {
                     if (event.key === 'Escape') {
                         this.closeGoto();
+                    }
+                    return;
+                }
+
+                if (this.showBookmarks) {
+                    if (event.key === 'Escape') {
+                        this.closeBookmarks();
                     }
                     return;
                 }
@@ -836,6 +1015,16 @@
                         event.preventDefault();
                         this.openGoto();
                         break;
+                    case 'b':
+                    case 'B':
+                        event.preventDefault();
+                        if (this.showBookmarks) {
+                            this.closeBookmarks();
+                            break;
+                        }
+
+                        this.openBookmarks();
+                        break;
                     case 'h':
                     case 'H':
                         this.toggleUiLock();
@@ -856,6 +1045,7 @@
             },
 
             openGoto() {
+                this.showBookmarks = false;
                 this.showGoto = true;
                 this.gotoInputValue = this.currentPage + 1;
 
@@ -880,12 +1070,7 @@
                 if (page < 1) page = 1;
                 if (page > this.meta.page_count) page = this.meta.page_count;
 
-                if (this.isScrollMode) {
-                    this.syncScrollPage(page - 1, { behavior: 'auto' });
-                } else {
-                    this.currentPage = page - 1;
-                    this.updateProgress();
-                }
+                this.navigateToPage(page - 1);
                 this.closeGoto();
             },
 
@@ -901,15 +1086,7 @@
                     return;
                 }
 
-                if (this.isScrollMode) {
-                    this.syncScrollPage(targetPage, { behavior: 'auto' });
-                    return;
-                }
-
-                if (targetPage !== this.currentPage) {
-                    this.currentPage = targetPage;
-                    this.updateProgress();
-                }
+                this.navigateToPage(targetPage);
             },
 
             toggleUiLock() {

--- a/tests/api/test_bookmarks.py
+++ b/tests/api/test_bookmarks.py
@@ -1,0 +1,147 @@
+from app.models.bookmark import Bookmark
+from app.models.comic import Comic, Volume
+from app.models.library import Library
+from app.models.series import Series
+from app.models.user import User
+
+
+def _seed_bookmark_data(db, normal_user, *, lib_name: str = "bookmark-lib", series_name: str = "Bookmark Series"):
+    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    series = Series(name=series_name, library=library)
+    volume = Volume(series=series, volume_number=1)
+    comic = Comic(
+        volume=volume,
+        number="1",
+        title=f"{series_name} #1",
+        filename=f"{series_name}-1.cbz",
+        file_path=f"/tmp/{series_name}-{lib_name}.cbz",
+        page_count=10,
+    )
+
+    db.add_all([library, series, volume, comic])
+    db.flush()
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    return {
+        "library": library,
+        "series": series,
+        "volume": volume,
+        "comic": comic,
+    }
+
+
+def test_get_comic_bookmarks_returns_sorted_current_user_items(auth_client, db, normal_user):
+    data = _seed_bookmark_data(db, normal_user, lib_name="bookmark-list", series_name="Bookmark List")
+
+    other_user = User(
+        username="bookmark-other",
+        email="bookmark-other@example.com",
+        hashed_password="fakehash",
+        is_superuser=False,
+        is_active=True,
+    )
+    db.add(other_user)
+    db.flush()
+
+    db.add_all([
+        Bookmark(user_id=normal_user.id, comic_id=data["comic"].id, page_index=7, label="Later"),
+        Bookmark(user_id=normal_user.id, comic_id=data["comic"].id, page_index=2, label="Early"),
+        Bookmark(user_id=other_user.id, comic_id=data["comic"].id, page_index=1, label="Other User"),
+    ])
+    db.commit()
+
+    response = auth_client.get(f"/api/bookmarks/comic/{data['comic'].id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["page_index"] for item in payload] == [2, 7]
+    assert [item["label"] for item in payload] == ["Early", "Later"]
+
+
+def test_save_bookmark_creates_then_updates_same_page(auth_client, db, normal_user):
+    data = _seed_bookmark_data(db, normal_user, lib_name="bookmark-save", series_name="Bookmark Save")
+
+    created = auth_client.post(
+        f"/api/bookmarks/comic/{data['comic'].id}",
+        json={"page_index": 4, "label": "Splash"},
+    )
+
+    assert created.status_code == 200
+    created_payload = created.json()
+    assert created_payload["created"] is True
+    assert created_payload["bookmark"]["page_index"] == 4
+    assert created_payload["bookmark"]["label"] == "Splash"
+
+    updated = auth_client.post(
+        f"/api/bookmarks/comic/{data['comic'].id}",
+        json={"page_index": 4, "label": "Better Splash"},
+    )
+
+    assert updated.status_code == 200
+    updated_payload = updated.json()
+    assert updated_payload["created"] is False
+    assert updated_payload["bookmark"]["label"] == "Better Splash"
+
+    bookmarks = db.query(Bookmark).filter(Bookmark.user_id == normal_user.id).all()
+    assert len(bookmarks) == 1
+    assert bookmarks[0].page_index == 4
+    assert bookmarks[0].label == "Better Splash"
+
+
+def test_save_bookmark_rejects_out_of_range_page(auth_client, db, normal_user):
+    data = _seed_bookmark_data(db, normal_user, lib_name="bookmark-range", series_name="Bookmark Range")
+
+    response = auth_client.post(
+        f"/api/bookmarks/comic/{data['comic'].id}",
+        json={"page_index": 99, "label": "Too Far"},
+    )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Bookmark page is out of range"}
+
+
+def test_save_bookmark_restricted_comic_returns_403(auth_client, db, normal_user):
+    data = _seed_bookmark_data(db, normal_user, lib_name="bookmark-restricted", series_name="Bookmark Restricted")
+
+    data["comic"].age_rating = "Mature 17+"
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    response = auth_client.post(
+        f"/api/bookmarks/comic/{data['comic'].id}",
+        json={"page_index": 1, "label": "Blocked"},
+    )
+
+    assert response.status_code == 403
+    assert "restricted" in response.json()["detail"].lower()
+
+
+def test_update_and_delete_bookmark(auth_client, db, normal_user):
+    data = _seed_bookmark_data(db, normal_user, lib_name="bookmark-mutate", series_name="Bookmark Mutate")
+
+    bookmark = Bookmark(
+        user_id=normal_user.id,
+        comic_id=data["comic"].id,
+        page_index=3,
+        label="Original",
+    )
+    db.add(bookmark)
+    db.commit()
+    db.refresh(bookmark)
+
+    patch_response = auth_client.patch(
+        f"/api/bookmarks/{bookmark.id}",
+        json={"label": "Updated"},
+    )
+
+    assert patch_response.status_code == 200
+    assert patch_response.json()["label"] == "Updated"
+
+    delete_response = auth_client.delete(f"/api/bookmarks/{bookmark.id}")
+
+    assert delete_response.status_code == 200
+    assert delete_response.json() == {"bookmark_id": bookmark.id, "message": "Bookmark deleted"}
+    assert db.query(Bookmark).filter(Bookmark.id == bookmark.id).first() is None

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -17,6 +17,7 @@ from app.api.deps import get_current_user, get_db
 from app.core.security import get_password_hash
 from app.database import Base
 from app.main import app
+from app.models.bookmark import Bookmark
 from app.models.comic import Comic, Volume
 from app.models.credits import ComicCredit, Person
 from app.models.interactions import UserVolumeFollow
@@ -172,6 +173,7 @@ def reset_browser_state(browser_db_factory, browser_seed_data):
         session.query(PullListItem).delete()
         session.query(PullList).delete()
         session.query(SavedSearch).delete()
+        session.query(Bookmark).delete()
         session.query(ReadingProgress).delete()
         session.add_all(
             [

--- a/tests/browser/test_reader_smoke.py
+++ b/tests/browser/test_reader_smoke.py
@@ -147,12 +147,16 @@ def test_reader_bookmarks_save_jump_and_delete(page, browser_server):
     page.locator(".reader-controls button").nth(2).click()
     page.wait_for_timeout(300)
     assert page.locator(".reader-controls .text-white.font-bold").first.text_content() == "2"
+    page.locator(".reader-controls button").nth(2).click()
+    page.wait_for_timeout(300)
+    assert page.locator(".reader-controls .text-white.font-bold").first.text_content() == "3"
 
     page.locator("[data-bookmarks-toggle]").click()
     page.wait_for_selector("[data-bookmarks-modal]")
     page.locator("[data-bookmark-item]").first.locator("button").first.click()
     page.wait_for_timeout(300)
     assert page.locator(".reader-controls .text-white.font-bold").first.text_content() == "1"
+    assert page.locator("[data-bookmark-detour]").is_visible()
 
     session = browser_server["db_factory"]()
     try:
@@ -169,6 +173,10 @@ def test_reader_bookmarks_save_jump_and_delete(page, browser_server):
     assert bookmark.page_index == 0
     assert bookmark.label == "Intro beat"
 
+    page.locator(".reader-controls button").nth(2).click()
+    page.wait_for_timeout(300)
+    assert page.locator(".reader-controls .text-white.font-bold").first.text_content() == "2"
+
     session = browser_server["db_factory"]()
     try:
         progress = session.scalar(
@@ -181,8 +189,13 @@ def test_reader_bookmarks_save_jump_and_delete(page, browser_server):
         session.close()
 
     assert progress is not None
-    assert progress.current_page == 1
-    assert progress.completed is False
+    assert progress.current_page == 2
+    assert progress.completed is True
+
+    page.locator("[data-bookmark-detour-return]").click()
+    page.wait_for_timeout(300)
+    assert page.locator(".reader-controls .text-white.font-bold").first.text_content() == "3"
+    assert page.locator("[data-bookmark-detour]").is_hidden()
 
     page.locator("[data-bookmarks-toggle]").click()
     page.wait_for_selector("[data-bookmarks-modal]")

--- a/tests/browser/test_reader_smoke.py
+++ b/tests/browser/test_reader_smoke.py
@@ -1,6 +1,7 @@
 import pytest
 from sqlalchemy import select
 
+from app.models.bookmark import Bookmark
 from app.models.reading_progress import ReadingProgress
 
 TALL_SCROLL_PAGE_BYTES = b"""
@@ -121,6 +122,73 @@ def test_reader_paged_scrubber_moves_to_selected_page_and_updates_progress(page,
     assert progress is not None
     assert progress.current_page == 2
     assert progress.completed is True
+
+
+@pytest.mark.browser
+def test_reader_bookmarks_save_jump_and_delete(page, browser_server):
+    seed = browser_server["seed"]
+    page.goto(f"{browser_server['base_url']}/reader/{seed['active_comic_id']}", wait_until="networkidle")
+
+    page.wait_for_selector(".reader-container")
+    page.locator(".nav-zone.center").click()
+    page.locator("[data-bookmarks-toggle]").click()
+    page.wait_for_selector("[data-bookmarks-modal]")
+
+    label_input = page.locator("[data-bookmarks-modal] input[type='text']")
+    label_input.fill("Intro beat")
+    page.locator("[data-save-bookmark]").click()
+    page.wait_for_selector("[data-bookmark-item]")
+
+    bookmark_item = page.locator("[data-bookmark-item]").first
+    assert bookmark_item.locator("text=Page 1").is_visible()
+    assert bookmark_item.locator("text=Intro beat").is_visible()
+
+    page.locator("[data-close-bookmarks]").click()
+    page.locator(".reader-controls button").nth(2).click()
+    page.wait_for_timeout(300)
+    assert page.locator(".reader-controls .text-white.font-bold").first.text_content() == "2"
+
+    page.locator("[data-bookmarks-toggle]").click()
+    page.wait_for_selector("[data-bookmarks-modal]")
+    page.locator("[data-bookmark-item]").first.locator("button").first.click()
+    page.wait_for_timeout(300)
+    assert page.locator(".reader-controls .text-white.font-bold").first.text_content() == "1"
+
+    session = browser_server["db_factory"]()
+    try:
+        bookmark = session.scalar(
+            select(Bookmark).where(
+                Bookmark.user_id == seed["user_id"],
+                Bookmark.comic_id == seed["active_comic_id"],
+            )
+        )
+    finally:
+        session.close()
+
+    assert bookmark is not None
+    assert bookmark.page_index == 0
+    assert bookmark.label == "Intro beat"
+
+    session = browser_server["db_factory"]()
+    try:
+        progress = session.scalar(
+            select(ReadingProgress).where(
+                ReadingProgress.user_id == seed["user_id"],
+                ReadingProgress.comic_id == seed["active_comic_id"],
+            )
+        )
+    finally:
+        session.close()
+
+    assert progress is not None
+    assert progress.current_page == 1
+    assert progress.completed is False
+
+    page.locator("[data-bookmarks-toggle]").click()
+    page.wait_for_selector("[data-bookmarks-modal]")
+    page.locator("[data-delete-bookmark]").click()
+    page.wait_for_timeout(300)
+    assert page.locator("[data-bookmark-item]").count() == 0
 
 
 @pytest.mark.browser


### PR DESCRIPTION

Adds a first-pass bookmark system to the reader without changing Parker’s existing Reading Progress model.

This introduces per-user, per-comic bookmarks that let readers save intentional page markers, jump back to them later, and manage them from inside the reader. Bookmark navigation is now handled as a temporary detour so revisiting an older saved page does not silently overwrite the user’s true resume position.

**What Changed**

- Added a dedicated bookmark data model, service layer, API routes, and migration
- Added in-reader bookmark UI for:
  - saving the current page
  - jumping to a saved bookmark
  - deleting a bookmark
  - updating a bookmark label by resaving the same page
- Kept bookmarks fully separate from `ReadingProgress`
- Added bookmark detour mode:
  - jumping to a bookmark does not update resume progress
  - detour banner shows `Return to page X` and `Resume here`
  - resume progress only changes when the user explicitly chooses `Resume here`
- Tuned detour banner readability over bright comic margins

**Why**

Parker already had automatic reading progress, but that solves a different problem than intentional bookmarks. This change adds a lightweight saved-page system for readers who want to revisit favorite panels, reference earlier scenes, or keep manual anchors without disturbing normal `Continue Reading` behavior.

**Testing**

- Elevated API verification passed:
  - `tests/api/test_bookmarks.py`
  - `tests/api/test_progress.py`
  - `tests/api/test_reader.py`
- Elevated browser verification passed:
  - `tests/browser/test_reader_smoke.py -k bookmark`

**Notes**

This is intentionally a small first pass focused on the reader experience. It does not yet add bookmark management surfaces outside the reader or integrate bookmarks into stats/history flows.


