### PR TITLE
Surface bookmarks on comic detail pages

### DIFF
--- a/app/api/comics.py
+++ b/app/api/comics.py
@@ -18,6 +18,7 @@ from app.models.credits import Person, ComicCredit
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.collection import Collection, CollectionItem
 from app.models.pull_list import PullList, PullListItem
+from app.models.bookmark import Bookmark
 from app.models.reading_progress import ReadingProgress
 from app.models.interactions import UserComicRating
 
@@ -162,6 +163,17 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
     # If started but not finished, show "Continue"
     if progress and not progress.completed and progress.current_page > 0:
         read_status = "in_progress"
+    resume_page = progress.current_page if progress and not progress.completed and progress.current_page > 0 else None
+
+    bookmarks = (
+        db.query(Bookmark)
+        .filter(
+            Bookmark.user_id == current_user.id,
+            Bookmark.comic_id == comic.id,
+        )
+        .order_by(Bookmark.page_index.asc())
+        .all()
+    )
 
     parker_rating = build_parker_rating_state(db, comic.id, current_user.id)
     parker_readers_count = get_visible_comic_reader_count(db, comic.id)
@@ -233,6 +245,15 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
 
         # Read status
         "read_status": read_status,
+        "resume_page": resume_page,
+        "bookmarks": [
+            {
+                "id": bookmark.id,
+                "page_index": bookmark.page_index,
+                "label": bookmark.label,
+            }
+            for bookmark in bookmarks
+        ],
 
         # ColorScape data
         "color_palette": comic.color_palette,

--- a/app/templates/comics/comic_detail.html
+++ b/app/templates/comics/comic_detail.html
@@ -77,6 +77,45 @@
                     </div>
                 </div>
 
+                <template x-if="comic?.bookmarks?.length">
+                    <div class="overflow-hidden rounded-lg border border-gray-700 bg-gray-800 shadow-lg">
+                        <div class="flex items-start justify-between gap-4 border-b border-gray-700 px-4 py-4">
+                            <div class="min-w-0">
+                                <h3 class="font-bold text-gray-200">Bookmarks</h3>
+                                <p class="mt-1 text-xs text-gray-400">Jump directly to saved pages from here.</p>
+                            </div>
+                            <span class="whitespace-nowrap rounded-full border border-gray-600 bg-gray-900 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-gray-300">
+                                <span x-text="comic.bookmarks.length"></span> saved
+                            </span>
+                        </div>
+
+                        <div class="max-h-72 overflow-y-auto">
+                            <template x-for="bookmark in comic.bookmarks" :key="bookmark.id">
+                                <a :href="bookmarkReaderHref(bookmark)"
+                                   data-detail-bookmark-link
+                                   class="group block border-b border-gray-700/80 px-4 py-3 transition-colors hover:bg-gray-700/40 last:border-b-0">
+                                    <div class="flex items-start justify-between gap-3">
+                                        <div class="min-w-0">
+                                            <p class="truncate text-sm font-semibold text-white" x-text="bookmark.label || `Page ${bookmark.page_index + 1}`"></p>
+                                            <p class="mt-1 text-xs text-gray-400">
+                                                <span class="font-semibold text-blue-300" x-text="`Page ${bookmark.page_index + 1}`"></span>
+                                                <span x-show="bookmark.label">saved jump point</span>
+                                            </p>
+                                        </div>
+                                        <span class="shrink-0 text-xs font-semibold uppercase tracking-wide text-gray-500 transition-colors group-hover:text-blue-300">
+                                            Open
+                                        </span>
+                                    </div>
+                                </a>
+                            </template>
+                        </div>
+
+                        <p x-show="hasResumePage()" class="border-t border-gray-700 px-4 py-3 text-xs text-gray-400">
+                            Bookmark launches preserve your current resume page until you choose otherwise in the reader.
+                        </p>
+                    </div>
+                </template>
+
                 <div class="bg-gray-800 rounded-lg p-4 space-y-4 border border-gray-700">
                     <h3 class="font-bold text-gray-300 border-b border-gray-700 pb-2">File Info</h3>
 
@@ -397,11 +436,31 @@ function comicDetail() {
 
         async markRead() {
             await fetch(window.parker.route('progress.mark_comic_as_read',{ comic_id: this.comicId }), { method: 'POST' });
-            // You could show a toast here
+            if (this.comic) {
+                this.comic = { ...this.comic, read_status: 'new', resume_page: null };
+            }
         },
 
         async markUnread() {
             await fetch(window.parker.route('progress.mark_comic_as_unread', { comic_id: this.comicId }), { method: 'DELETE' });
+            if (this.comic) {
+                this.comic = { ...this.comic, read_status: 'new', resume_page: null };
+            }
+        },
+
+        hasResumePage() {
+            return Number.isInteger(this.comic?.resume_page) && this.comic.resume_page > 0;
+        },
+
+        bookmarkReaderHref(bookmark) {
+            const params = new URLSearchParams();
+            params.set('page', bookmark.page_index);
+
+            if (this.hasResumePage() && this.comic.resume_page !== bookmark.page_index) {
+                params.set('bookmark_origin_page', this.comic.resume_page);
+            }
+
+            return window.parker.route('pages.reader', { comic_id: this.comicId }, params.toString());
         },
 
         applyRatingState(data) {

--- a/docs/releases/0.1.23.md
+++ b/docs/releases/0.1.23.md
@@ -6,11 +6,13 @@ Status: Draft
 
 - Reader bookmarks as a separate per-user, per-comic save system, including save, jump-to, rename-on-resave, and delete flows from the in-reader bookmarks modal.
 - Bookmark detour mode in the reader so users can jump back to a saved page for reference without immediately overwriting their true resume position.
+- Comic detail pages now surface saved bookmarks in the left action rail so readers can jump straight back into notable pages outside the reader itself.
 
 ## Changed
 
 - Reader bookmarks now default to page-number ordering so saved jump points stay aligned with comic flow.
 - Bookmark jumps now open a temporary detour state with explicit `Return to page X` and `Resume here` actions instead of behaving like ordinary progress-changing navigation.
+- Comic detail bookmark links now launch into the same detour-safe reader flow when a saved resume page exists.
 - Reader detour messaging was tuned to remain readable over bright comic page margins with a darker banner surface and stronger action contrast.
 - The reader bookmarks modal now scales better for larger bookmark counts with filterable results, compact rows, and inline label editing directly from the list.
 
@@ -22,4 +24,6 @@ Status: Draft
 ## Validation
 
 - Elevated API verification passed: `tests/api/test_bookmarks.py`, `tests/api/test_progress.py`, and `tests/api/test_reader.py`.
+- Elevated API verification passed: `tests/api/test_comics.py`.
 - Elevated browser verification passed: `tests/browser/test_reader_smoke.py -k bookmark`.
+- Elevated browser verification passed: `tests/browser/test_saved_search_pull_list_and_session_flows.py -k comic_detail_bookmarks_launch_reader_detour`.

--- a/static/js/reader.js
+++ b/static/js/reader.js
@@ -152,6 +152,8 @@
             bookmarksLoaded: false,
             isBookmarkBusy: false,
             bookmarkDetourOriginPage: null,
+            launchPageIndex: null,
+            launchBookmarkOriginPage: null,
             editingBookmarkId: null,
             editingBookmarkLabelValue: '',
             scrubberValue: 0,
@@ -369,6 +371,16 @@
                 this.isIncognito = params.get('incognito') === 'true';
                 this.contextType = params.get('context_type');
                 this.contextId = params.get('context_id');
+                this.launchPageIndex = Number.parseInt(params.get('page'), 10);
+                this.launchBookmarkOriginPage = Number.parseInt(params.get('bookmark_origin_page'), 10);
+
+                if (Number.isNaN(this.launchPageIndex)) {
+                    this.launchPageIndex = null;
+                }
+
+                if (Number.isNaN(this.launchBookmarkOriginPage)) {
+                    this.launchBookmarkOriginPage = null;
+                }
 
                 if (this.isIncognito) {
                     window.parker.showToast('Incognito Mode: Progress and bookmark changes will not be saved.');
@@ -399,6 +411,16 @@
 
                         if (progress.has_progress && !progress.completed) {
                             this.currentPage = progress.current_page;
+                        }
+                    }
+
+                    if (Number.isInteger(this.launchPageIndex) && this.meta.page_count > 0) {
+                        const boundedLaunchPage = Math.max(0, Math.min(this.launchPageIndex, this.meta.page_count - 1));
+                        this.currentPage = boundedLaunchPage;
+
+                        if (Number.isInteger(this.launchBookmarkOriginPage)) {
+                            const boundedOriginPage = Math.max(0, Math.min(this.launchBookmarkOriginPage, this.meta.page_count - 1));
+                            this.bookmarkDetourOriginPage = boundedOriginPage !== boundedLaunchPage ? boundedOriginPage : null;
                         }
                     }
 

--- a/tests/api/test_comics.py
+++ b/tests/api/test_comics.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from app.api.comics import filter_by_user_access, natural_sort_key
 from app.models.collection import Collection, CollectionItem
+from app.models.bookmark import Bookmark
 from app.models.comic import Comic, Volume
 from app.models.credits import ComicCredit, Person
 from app.models.interactions import UserComicRating
@@ -219,6 +220,10 @@ def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, d
             completed=False,
         )
     )
+    db.add_all([
+        Bookmark(user_id=normal_user.id, comic_id=comic.id, page_index=7, label="Later"),
+        Bookmark(user_id=normal_user.id, comic_id=comic.id, page_index=2, label="Earlier"),
+    ])
     db.commit()
 
     response = auth_client.get(f"/api/comics/{comic.id}")
@@ -237,6 +242,11 @@ def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, d
     assert payload["locations"] == ["Detail City"]
     assert payload["genres"] == ["Detail Genre"]
     assert payload["read_status"] == "in_progress"
+    assert payload["resume_page"] == 5
+    assert payload["bookmarks"] == [
+        {"id": payload["bookmarks"][0]["id"], "page_index": 2, "label": "Earlier"},
+        {"id": payload["bookmarks"][1]["id"], "page_index": 7, "label": "Later"},
+    ]
     assert payload["web"] == "https://comicvine.gamespot.com/detail-issue/4000-7/"
     assert payload["web_label"] == "ComicVine"
     assert payload["web_title"] == "View on ComicVine"

--- a/tests/browser/test_saved_search_pull_list_and_session_flows.py
+++ b/tests/browser/test_saved_search_pull_list_and_session_flows.py
@@ -1,7 +1,9 @@
 import pytest
 from sqlalchemy import select
 
+from app.models.bookmark import Bookmark
 from app.models.pull_list import PullList, PullListItem
+from app.models.reading_progress import ReadingProgress
 
 
 def _create_pull_list(db_factory, user_id, name, description=None):
@@ -177,6 +179,55 @@ def test_comic_detail_add_to_existing_pull_list_then_edit_and_remove_item(page, 
     cleared_list = _get_pull_list_snapshot(browser_server["db_factory"], updated_name)
     assert cleared_list is not None
     assert cleared_list["comic_ids"] == []
+
+
+@pytest.mark.browser
+def test_comic_detail_bookmarks_launch_reader_detour(page, browser_server):
+    seed = browser_server["seed"]
+    session = browser_server["db_factory"]()
+    try:
+        session.add(
+            Bookmark(
+                user_id=seed["user_id"],
+                comic_id=seed["in_progress_comic_id"],
+                page_index=0,
+                label="Opening beat",
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    page.goto(f"{browser_server['base_url']}/comics/{seed['in_progress_comic_id']}", wait_until="networkidle")
+
+    page.get_by_role("heading", name=f"{seed['series_name']} #{seed['in_progress_comic_number']}").wait_for()
+    page.get_by_role("heading", name="Bookmarks").wait_for()
+    page.locator("[data-detail-bookmark-link]").first.click()
+
+    page.wait_for_url(f"**/reader/{seed['in_progress_comic_id']}**")
+    page.wait_for_selector("[data-bookmark-detour]")
+    assert page.locator(".reader-controls .text-white.font-bold").first.text_content() == "1"
+    assert page.locator("[data-bookmark-detour-return]").text_content().strip() == "Return to page 2"
+
+    page.keyboard.press("ArrowRight")
+    page.wait_for_timeout(300)
+    page.keyboard.press("ArrowRight")
+    page.wait_for_timeout(300)
+    assert page.locator(".reader-controls .text-white.font-bold").first.text_content() == "3"
+
+    session = browser_server["db_factory"]()
+    try:
+        progress = session.scalar(
+            select(ReadingProgress).where(
+                ReadingProgress.user_id == seed["user_id"],
+                ReadingProgress.comic_id == seed["in_progress_comic_id"],
+            )
+        )
+    finally:
+        session.close()
+
+    assert progress is not None
+    assert progress.current_page == 1
 
 
 @pytest.mark.browser


### PR DESCRIPTION


Adds bookmark visibility to the comic detail page so saved pages can be reopened outside the reader.

If a comic has bookmarks, the detail page now shows them in the left action rail beneath the read-state controls. Clicking one opens the reader directly to that page. When the user already has in-progress reading progress on the comic, these launches preserve the same detour-safe behavior used inside the reader so bookmark revisits do not overwrite the true resume point.

## Included

- Adds bookmark data to the comic detail payload
- Surfaces bookmarks on the comic detail page when present
- Places bookmark links in the left action column below `Mark Read` / `Mark Unread`
- Keeps bookmark ordering aligned to page number
- Launches bookmark links into the reader at the saved page
- Reuses detour-safe resume handling when a saved progress position exists
- Updates `docs/releases/0.1.23.md`

## Why

Once bookmarks existed only inside the reader, they were useful during an active reading session but less visible when returning to a comic later from its detail page.

This change gives bookmarks a natural secondary surface without expanding them into broader app-level navigation. It makes saved reference points easier to use while keeping reading progress as the canonical resume location.

## Validation

- API verification passed:
  - `tests/api/test_comics.py -q`
- Browser verification passed:
  - `tests/browser/test_reader_smoke.py -k bookmark -q`
  - `tests/browser/test_saved_search_pull_list_and_session_flows.py -k comic_detail_bookmarks_launch_reader_detour -q`