### PR TITLE
Make reader close return to the launch surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
   - Incognito reading sessions that avoid persisting per-book overrides
   - Zero‑latency engine with preloading and swipe navigation
   - Separate per-comic bookmarks with detour-safe resume handling
+  - Smart close behavior that returns readers to the page they launched from
   - Image inspection tools
 
 - **Discovery**

--- a/app/templates/collections/collection_detail.html
+++ b/app/templates/collections/collection_detail.html
@@ -217,7 +217,7 @@ function collectionDetail() {
             if (this.collection?.comics?.length > 0) {
                 let qs = `context_type=collection&context_id=${this.collection.id}`;
                 if (incognito) qs += '&incognito=true';
-                window.location.href = window.parker.route('pages.reader', { comic_id: this.collection.comics[0].id }, qs);
+                window.location.href = window.parker.readerRoute(this.collection.comics[0].id, qs, { includeReturnTo: false });
             }
         }
     }

--- a/app/templates/comics/comic_detail.html
+++ b/app/templates/comics/comic_detail.html
@@ -460,7 +460,7 @@ function comicDetail() {
                 params.set('bookmark_origin_page', this.comic.resume_page);
             }
 
-            return window.parker.route('pages.reader', { comic_id: this.comicId }, params.toString());
+            return window.parker.readerRoute(this.comicId, params.toString());
         },
 
         applyRatingState(data) {

--- a/app/templates/partials/arc_card.html
+++ b/app/templates/partials/arc_card.html
@@ -6,7 +6,7 @@
              class="w-full h-full object-cover transition-opacity duration-300 group-hover:opacity-40">
 
         <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-             <a :href="window.parker.route('pages.reader', {comic_id: arc.first_issue_id})"
+             <a :href="window.parker.readerRoute(arc.first_issue_id)"
                 x-on:click.stop
                 class="bg-blue-600 hover:bg-blue-500 text-white rounded-full p-3 shadow-xl transform hover:scale-110 transition-transform"
                 title="Start Reading Arc">

--- a/app/templates/partials/comic_card.html
+++ b/app/templates/partials/comic_card.html
@@ -6,6 +6,9 @@
             else if(typeof collection !== 'undefined') { return `context_type=collection&context_id=${this.collection.id}`; }
             else { return ''; }
         },
+        get includeReaderReturnTo() {
+            return !(typeof readingList !== 'undefined' || typeof collection !== 'undefined');
+        },
         get isSelected() { return $store.batch && $store.batch.has(comic.id, 'comic'); },
         updateStatus(e) {
             // Check if my ID was included in the batch
@@ -19,7 +22,7 @@
 
      }" @comics-updated.window="updateStatus($event)">
 
-    <a :href="window.parker.route('pages.reader', { comic_id: comic.id }, readerQueryParams)" class="block group relative cursor-pointer">
+    <a :href="window.parker.readerRoute(comic.id, readerQueryParams, { includeReturnTo: includeReaderReturnTo })" class="block group relative cursor-pointer">
 
         <div class="aspect-[2/3] bg-gray-700 rounded-lg overflow-hidden relative shadow-md transition-all duration-200 group-hover:scale-[1.02]"
              :class="isSelected ? 'ring-4 ring-blue-500/80 scale-[0.98]' : ''">

--- a/app/templates/partials/comic_row.html
+++ b/app/templates/partials/comic_row.html
@@ -3,9 +3,12 @@
             if(readingList) { return `context_type=reading_list&context_id=${this.readingListId}`; }
             else if(collection) { return `context_type=collection&context_id=${this.collection.id}`; }
             else { return ''; }
+        },
+        get includeReaderReturnTo() {
+            return !(readingList || collection);
         }
     }">
-<a :href="window.parker.route('pages.reader', { comic_id: comic.id }, readerQueryParams)" class="flex-shrink-0 relative block w-16 h-24 rounded overflow-hidden shadow-sm group-hover:shadow-md transition-all">
+<a :href="window.parker.readerRoute(comic.id, readerQueryParams, { includeReturnTo: includeReaderReturnTo })" class="flex-shrink-0 relative block w-16 h-24 rounded overflow-hidden shadow-sm group-hover:shadow-md transition-all">
     <img
         :src="window.parker.url(comic.thumbnail_path)"
         :alt="comic.title"
@@ -36,7 +39,7 @@
     </div>
 </div>
 
-<a :href="window.parker.route('pages.reader', { comic_id: comic.id }, readerQueryParams)" class="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded text-sm font-bold opacity-0 group-hover:opacity-100 transition-opacity shadow-lg flex-shrink-0">
+<a :href="window.parker.readerRoute(comic.id, readerQueryParams, { includeReturnTo: includeReaderReturnTo })" class="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded text-sm font-bold opacity-0 group-hover:opacity-100 transition-opacity shadow-lg flex-shrink-0">
     Read
 </a>
 </div>

--- a/app/templates/partials/config_context.html
+++ b/app/templates/partials/config_context.html
@@ -84,5 +84,25 @@
 
     window.parker = {...(window.parker || {}), route: get_route };
 
+    get_current_relative_url = function() {
+        return `${window.location.pathname}${window.location.search}`;
+    };
+
+    window.parker = {...(window.parker || {}), currentRelativeUrl: get_current_relative_url };
+
+    build_reader_route = function(comicId, rawQuery = '', options = {}) {
+        const query = new URLSearchParams(rawQuery ? rawQuery.toString().replace(/^[?&]/, '') : '');
+        const includeReturnTo = options.includeReturnTo !== false;
+        const returnTo = typeof options.returnTo === 'string' ? options.returnTo : get_current_relative_url();
+
+        if (includeReturnTo && returnTo && !query.has('return_to')) {
+            query.set('return_to', returnTo);
+        }
+
+        return get_route('pages.reader', { comic_id: comicId }, query.toString());
+    };
+
+    window.parker = {...(window.parker || {}), readerRoute: build_reader_route };
+
 </script>
 {% endmacro %}

--- a/app/templates/partials/on_deck_card.html
+++ b/app/templates/partials/on_deck_card.html
@@ -1,5 +1,5 @@
 <div class="w-48 flex-shrink-0 group relative">
-    <a :href="window.parker.route('pages.reader', { comic_id: item.comic_id })">
+    <a :href="window.parker.readerRoute(item.comic_id)">
         <div class="aspect-[2/3] bg-gray-800 rounded-lg overflow-hidden shadow-lg border border-gray-700 relative">
             <img :src="window.parker.url(item.thumbnail)" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300">
 

--- a/app/templates/partials/progress_card.html
+++ b/app/templates/partials/progress_card.html
@@ -1,6 +1,6 @@
 <div class="bg-gray-800 rounded-lg p-4 hover:bg-gray-750 transition-colors border border-gray-700 flex flex-col sm:flex-row gap-4 group">
 
-    <a :href="window.parker.route('pages.reader', { comic_id: item.comic_id })" class="flex-shrink-0 relative block w-24 h-36 rounded overflow-hidden shadow-sm group-hover:shadow-md transition-all mx-auto sm:mx-0">
+    <a :href="window.parker.readerRoute(item.comic_id)" class="flex-shrink-0 relative block w-24 h-36 rounded overflow-hidden shadow-sm group-hover:shadow-md transition-all mx-auto sm:mx-0">
         <img :src="window.parker.url(item.thumbnail_path)" :alt="item.title" class="w-full h-full object-cover" loading="lazy">
     </a>
 
@@ -23,7 +23,7 @@
     </div>
 
     <div class="flex sm:flex-col gap-2 justify-center sm:border-l sm:border-gray-700 sm:pl-4">
-        <a :href="window.parker.route('pages.reader', { comic_id: item.comic_id })" class="btn-primary text-sm text-center py-2 px-4 flex-1 sm:flex-none">
+        <a :href="window.parker.readerRoute(item.comic_id)" class="btn-primary text-sm text-center py-2 px-4 flex-1 sm:flex-none">
             Continue
         </a>
 

--- a/app/templates/partials/read_comic_button.html
+++ b/app/templates/partials/read_comic_button.html
@@ -1,6 +1,6 @@
 <div class="relative flex items-center w-full" x-data="{ open: false }">
 
-    <a :href="window.parker.route('pages.reader', { comic_id: comicId })"
+    <a :href="window.parker.readerRoute(comicId)"
        class="flex-1 bg-blue-600 hover:bg-blue-500 text-white font-bold py-3 px-4 rounded-l-lg transition-colors flex items-center justify-center gap-2 shadow-lg shadow-blue-900/20 border-r border-black"
         :class="comic?.read_status === 'in_progress' ? 'bg-blue-600 hover:bg-blue-500' : 'bg-green-600 hover:bg-green-500'"
     >
@@ -28,7 +28,7 @@
          style="display: none;">
 
         <div class="py-1">
-            <a :href="window.parker.route('pages.reader', { comic_id: comicId }, 'incognito=true')"
+            <a :href="window.parker.readerRoute(comicId, 'incognito=true')"
                class="group flex items-center px-4 py-3 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors">
                 <span class="mr-3 text-lg opacity-70 group-hover:opacity-100">👓</span>
                 <div>

--- a/app/templates/partials/read_series_button.html
+++ b/app/templates/partials/read_series_button.html
@@ -1,5 +1,5 @@
 <a
-    :href="window.parker.route('pages.reader', { comic_id: series?.resume_to.comic_id }, `context_type=series&context_id=${seriesId}`)"
+    :href="window.parker.readerRoute(series?.resume_to.comic_id, `context_type=series&context_id=${seriesId}`, { includeReturnTo: false })"
     class="flex items-center gap-2 px-6 py-2 rounded-full font-bold transition-colors shadow-lg"
     :class="series?.resume_to.status !== 'new' ? 'bg-blue-600 hover:bg-blue-500 text-white' : 'bg-green-600 hover:bg-green-500 text-white'"
 >

--- a/app/templates/partials/read_volume_button.html
+++ b/app/templates/partials/read_volume_button.html
@@ -1,5 +1,5 @@
 <a
-    :href="window.parker.route('pages.reader', { comic_id: volume?.resume_to?.comic_id }, `context_type=volume&context_id=${volumeId}`)"
+    :href="window.parker.readerRoute(volume?.resume_to?.comic_id, `context_type=volume&context_id=${volumeId}`, { includeReturnTo: false })"
     class="flex items-center gap-2 px-6 py-2 rounded-full font-bold transition-colors shadow-lg"
     :class="volume?.resume_to?.status !== 'new' ? 'bg-blue-600 hover:bg-blue-500 text-white' : 'bg-green-600 hover:bg-green-500 text-white'"
 >

--- a/app/templates/pull_lists/detail.html
+++ b/app/templates/pull_lists/detail.html
@@ -32,7 +32,7 @@
 
             <div class="flex gap-3">
                 <template x-if="list?.items?.length > 0">
-                    <a :href="window.parker.route('pages.reader', { comic_id: list.items[0].id }, `context_type=pull_list&context_id=${listId}`)"
+                    <a :href="window.parker.readerRoute(list.items[0].id, `context_type=pull_list&context_id=${listId}`, { includeReturnTo: false })"
                        class="bg-green-600 hover:bg-green-500 text-white px-6 py-3 rounded-full font-bold transition-colors flex items-center gap-2 shadow-lg hover:shadow-green-900/20">
                         <span class="text-xl">▶</span> Start Reading
                     </a>
@@ -98,7 +98,7 @@
                 </div>
 
                 <div class="flex items-center gap-3">
-                    <a :href="window.parker.route('pages.reader', { comic_id: item.id }, `context_type=pull_list&context_id=${listId}`)" class="text-gray-400 hover:text-green-400" title="Read">
+                    <a :href="window.parker.readerRoute(item.id, `context_type=pull_list&context_id=${listId}`, { includeReturnTo: false })" class="text-gray-400 hover:text-green-400" title="Read">
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />

--- a/app/templates/reading_lists/reading_list_detail.html
+++ b/app/templates/reading_lists/reading_list_detail.html
@@ -215,7 +215,7 @@ function readingListDetail() {
             if (this.readingList?.comics?.length > 0) {
                 let qs = `context_type=reading_list&context_id=${this.readingList.id}`;
                 if (incognito) qs += '&incognito=true';
-                window.location.href = window.parker.route('pages.reader', { comic_id: this.readingList.comics[0].id }, qs);
+                window.location.href = window.parker.readerRoute(this.readingList.comics[0].id, qs, { includeReturnTo: false });
             }
         }
     }

--- a/app/templates/user/dashboard.html
+++ b/app/templates/user/dashboard.html
@@ -491,7 +491,7 @@
 
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <template x-for="item in data?.continue_reading" :key="item.comic_id">
-                        <a :href="window.parker.route('pages.reader', { comic_id: item.comic_id})" class="flex bg-gray-800 rounded-lg overflow-hidden border border-gray-700 hover:border-blue-500 transition-colors group h-32 relative">
+                        <a :href="window.parker.readerRoute(item.comic_id)" class="flex bg-gray-800 rounded-lg overflow-hidden border border-gray-700 hover:border-blue-500 transition-colors group h-32 relative">
                             <img :src="item.thumbnail" class="w-24 h-full object-cover">
 
                             <div class="p-4 flex flex-col justify-center min-w-0 flex-1">

--- a/docs/releases/0.1.23.md
+++ b/docs/releases/0.1.23.md
@@ -13,6 +13,7 @@ Status: Draft
 - Reader bookmarks now default to page-number ordering so saved jump points stay aligned with comic flow.
 - Bookmark jumps now open a temporary detour state with explicit `Return to page X` and `Resume here` actions instead of behaving like ordinary progress-changing navigation.
 - Comic detail bookmark links now launch into the same detour-safe reader flow when a saved resume page exists.
+- Reader close behavior now prefers the original launch surface when opened from generic app pages instead of always falling back to comic detail.
 - Reader detour messaging was tuned to remain readable over bright comic page margins with a darker banner surface and stronger action contrast.
 - The reader bookmarks modal now scales better for larger bookmark counts with filterable results, compact rows, and inline label editing directly from the list.
 
@@ -20,6 +21,7 @@ Status: Draft
 
 - Fixed bookmark revisit flows that could otherwise force users to remember their original page manually or close and reopen the comic just to preserve real reading progress.
 - Fixed detour banner readability issues where low-opacity banner/button styling could become faint against white top gutters in comic pages.
+- Fixed reader exit flows from dashboard and other generic launch surfaces that previously always dumped users onto the comic detail page instead of back where they started.
 
 ## Validation
 
@@ -27,3 +29,5 @@ Status: Draft
 - Elevated API verification passed: `tests/api/test_comics.py`.
 - Elevated browser verification passed: `tests/browser/test_reader_smoke.py -k bookmark`.
 - Elevated browser verification passed: `tests/browser/test_saved_search_pull_list_and_session_flows.py -k comic_detail_bookmarks_launch_reader_detour`.
+- Elevated browser verification passed: `tests/browser/test_reader_contract_smoke.py`.
+- Elevated browser verification passed: `tests/browser/test_continue_reading_flows.py`.

--- a/static/js/reader.js
+++ b/static/js/reader.js
@@ -154,6 +154,7 @@
             bookmarkDetourOriginPage: null,
             launchPageIndex: null,
             launchBookmarkOriginPage: null,
+            returnTo: null,
             editingBookmarkId: null,
             editingBookmarkLabelValue: '',
             scrubberValue: 0,
@@ -373,6 +374,7 @@
                 this.contextId = params.get('context_id');
                 this.launchPageIndex = Number.parseInt(params.get('page'), 10);
                 this.launchBookmarkOriginPage = Number.parseInt(params.get('bookmark_origin_page'), 10);
+                this.returnTo = params.get('return_to');
 
                 if (Number.isNaN(this.launchPageIndex)) {
                     this.launchPageIndex = null;
@@ -380,6 +382,10 @@
 
                 if (Number.isNaN(this.launchBookmarkOriginPage)) {
                     this.launchBookmarkOriginPage = null;
+                }
+
+                if (!this.isSafeReturnTo(this.returnTo)) {
+                    this.returnTo = null;
                 }
 
                 if (this.isIncognito) {
@@ -780,6 +786,7 @@
                 if (this.contextType) params.append('context_type', this.contextType);
                 if (this.contextId) params.append('context_id', this.contextId);
                 if (this.isIncognito) params.append('incognito', 'true');
+                if (this.returnTo) params.append('return_to', this.returnTo);
 
                 const queryString = params.toString();
                 if (queryString) {
@@ -790,6 +797,11 @@
             },
 
             exitReader() {
+                if (this.isSafeReturnTo(this.returnTo)) {
+                    window.location.href = this.returnTo;
+                    return;
+                }
+
                 if (this.contextType === 'reading_list' && this.contextId) {
                     window.location.href = window.parker.route('pages.reading_list_detail', { reading_list_id: this.contextId });
                     return;
@@ -816,6 +828,10 @@
                 }
 
                 window.location.href = window.parker.route('pages.comic_detail', { comic_id: this.comicId });
+            },
+
+            isSafeReturnTo(value) {
+                return typeof value === 'string' && value.startsWith('/') && !value.startsWith('//');
             },
 
             resetFilters() {

--- a/tests/browser/test_continue_reading_flows.py
+++ b/tests/browser/test_continue_reading_flows.py
@@ -36,6 +36,24 @@ def test_continue_reading_tabs_show_expected_items(page, browser_server):
 
 
 @pytest.mark.browser
+def test_continue_reading_launch_returns_to_list_on_reader_close(page, browser_server):
+    seed = browser_server["seed"]
+    page.goto(f"{browser_server['base_url']}/continue-reading", wait_until="networkidle")
+
+    page.get_by_role("heading", name="Continue Reading").wait_for()
+    card = page.locator("div.border.border-gray-700").filter(has_text=seed["in_progress_comic_title"]).first
+    card.get_by_role("link", name="Continue").click()
+
+    page.wait_for_url(f"**/reader/{seed['in_progress_comic_id']}**")
+    page.locator(".reader-container").wait_for()
+    page.keyboard.press("Escape")
+
+    page.wait_for_url("**/continue-reading")
+    page.get_by_role("heading", name="Continue Reading").wait_for()
+    page.wait_for_selector(f"text={seed['in_progress_comic_title']}")
+
+
+@pytest.mark.browser
 def test_continue_reading_mark_read_moves_issue_to_completed(page, browser_server):
     seed = browser_server["seed"]
     page.goto(f"{browser_server['base_url']}/continue-reading", wait_until="networkidle")


### PR DESCRIPTION

Improves reader exit behavior so `Close` returns users to the page they launched the issue from instead of always sending them to comic detail.

This keeps existing context-aware reader behavior intact for structured launches like reading lists, collections, stacks, series, and volumes, while adding smarter return handling for generic surfaces such as dashboard rails, continue-reading views, and shared comic cards.

## Included

- Adds a shared `window.parker.readerRoute(...)` helper for building reader URLs
- Adds support for a safe `return_to` reader query param
- Updates reader close behavior to:
  - prefer `return_to` when present and valid
  - otherwise use existing `context_type/context_id`
  - otherwise fall back to comic detail
- Preserves existing context-aware reader behavior for:
  - reading lists
  - collections
  - stacks
  - series
  - volumes
- Updates generic reader launch surfaces to pass `return_to`
- Avoids adding `return_to` on structured launches where `context_type/context_id` already define the correct return behavior

## Why

The old behavior was functional but generic: no matter where the user launched a comic from, `Close` usually returned them to comic detail.

That felt off on dashboard, continue-reading, and other discovery surfaces where the user expected to land back where they started. This change makes reader exit behavior feel more natural without removing the existing context model that also powers issue-to-issue navigation inside lists, collections, series, and volumes.

## Validation

- Elevated browser verification passed:
  - `tests/browser/test_continue_reading_flows.py -q`
  - `tests/browser/test_reader_contract_smoke.py -q`
  - `tests/browser/test_reader_smoke.py -k bookmark -q`
  - `tests/browser/test_saved_search_pull_list_and_session_flows.py -k comic_detail_bookmarks_launch_reader_detour -q`


