### PR TITLE
Add a dedicated story arc reader context

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
   - Hybrid authentication (JWT + secure cookies)
 
 - **Reader**
-  - Context‑aware navigation (series, volume, lists)
+  - Context‑aware navigation (series, volume, lists, story arcs)
   - Manga mode (RTL), double‑page spreads, `Long View`
   - Per-book reader overrides for view mode, double-page, and reading direction
   - Incognito reading sessions that avoid persisting per-book overrides

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,12 @@ This file captures follow-up work that should not get lost between releases.
 
 ## Technical Debt
 
+- Explore container-level Continue behavior for reader contexts.
+  Context: Reader navigation currently preserves launch-time context for reading lists, collections, stacks, series, volumes, and story arcs, but persisted progress is comic-level. Home rails resume the comic and page only, while container "Start reading" actions begin at the first item instead of resuming the user's last position within that container.
+  Follow-up goal: Decide whether container pages should offer a context-aware Continue action that finds the best in-progress or next unread item within that specific container and launches the reader with that container context.
+  Candidate direction: Treat this as a generic reader-session/container-resume feature rather than a story-arc-specific workaround. Reading lists, collections, stacks, and possibly scoped story arcs should share the same design if the feature is worth building.
+  Guardrail: Avoid changing global home-rail resume behavior unless there is a broader product decision to persist last reader launch context; the current comic/page-only resume is simple and predictable.
+
 - Keep an eye on pull list detail page scale before it becomes a usability problem.
   Context: `app/templates/pull_lists/detail.html` currently renders a full list in one view, which is fine for normal pull-list sizes and likely more important to watch than the pull-list index page.
   Follow-up goal: If real users start building unusually large pull lists, consider pagination, filtering, or virtualization for list contents before the detail view becomes heavy to use.

--- a/app/api/reader.py
+++ b/app/api/reader.py
@@ -12,6 +12,7 @@ from app.core.comic_helpers import get_format_sort_index, get_format_weight, REV
 from app.api.deps import SessionDep, CurrentUser
 from app.models.comic import Comic, Volume
 from app.models.series import Series
+from app.models.library import Library
 
 from app.services.images import ImageService
 from app.models.reading_progress import ReadingProgress
@@ -34,12 +35,24 @@ async def get_comic_reader_init(comic_id: int,
                                 current_user: CurrentUser,
                                 # Context Parameters
                                 context_type: Annotated[
-                                    Optional[Literal["volume", "reading_list", "pull_list", "collection", "series"]],
+                                    Optional[Literal["volume", "reading_list", "pull_list", "collection", "series", "story_arc"]],
                                     "Specifies the type of context; defaults to 'volume'"
                                 ] = "volume",
                                 context_id: Annotated[
                                     Optional[int],
                                     "Unique identifier for the given context"
+                                ] = None,
+                                story_arc: Annotated[
+                                    Optional[str],
+                                    "Story arc name for story_arc context navigation"
+                                ] = None,
+                                context_scope: Annotated[
+                                    Optional[Literal["series", "volume"]],
+                                    "Restricts story arc navigation to the launch scope"
+                                ] = None,
+                                context_scope_id: Annotated[
+                                    Optional[int],
+                                    "Unique identifier for the story arc launch scope"
                                 ] = None):
     """
     Get initialization data for the reader.
@@ -194,8 +207,56 @@ async def get_comic_reader_init(comic_id: int,
 
         ids = [i[0] for i in items]
 
+    elif context_type == "story_arc" and story_arc and story_arc.strip():
+        # 5. Story Arc Strategy
+        # Story arcs are metadata-driven and can skip filler issues, so navigation
+        # must use exact story_arc membership instead of issue-number ranges.
+
+        arc_name = story_arc.strip()
+        context_label = arc_name
+
+        format_weight = get_format_sort_index()
+        number_direction = sort_number.asc()
+        if comic.volume.series.name.lower() in REVERSE_NUMBERING_SERIES:
+            number_direction = sort_number.desc()
+
+        query = (
+            db.query(Comic.id)
+            .join(Volume)
+            .join(Series)
+            .join(Library)
+            .filter(
+                Comic.story_arc == arc_name,
+                Library.parse_story_arcs == True,
+            )
+        )
+
+        if context_scope == "volume" and context_scope_id == comic.volume_id:
+            query = query.filter(Comic.volume_id == context_scope_id)
+        else:
+            series_scope_id = (
+                context_scope_id
+                if context_scope == "series" and context_scope_id == comic.volume.series_id
+                else comic.volume.series_id
+            )
+            query = query.filter(Volume.series_id == series_scope_id)
+
+        if safe_filter is not None:
+            query = query.filter(safe_filter)
+
+        items = query.order_by(
+            Volume.volume_number,
+            format_weight,
+            sort_year.asc(),
+            sort_month.asc(),
+            sort_day.asc(),
+            number_direction,
+        ).all()
+
+        ids = [i[0] for i in items]
+
     else:
-        # 5. Default / Volume Strategy
+        # 6. Default / Volume Strategy
         # OPTIMIZATION: Fetch lightweight Tuples instead of full Comic objects.
         # This prevents instantiating 900 objects for large series.
 

--- a/app/templates/comics/series_detail.html
+++ b/app/templates/comics/series_detail.html
@@ -537,6 +537,8 @@ function seriesDetail() {
         readFilter: 'all', // 'all', 'read', 'unread'
         sortOrder: 'asc',  // 'asc', 'desc'
         isReverseNumbering: false,
+        storyArcScope: 'series',
+        storyArcScopeId: {{ series_id }},
 
         paginationMode: '{{ get_system_setting("ui.pagination_mode", "infinite") }}',
 

--- a/app/templates/comics/volume_detail.html
+++ b/app/templates/comics/volume_detail.html
@@ -438,6 +438,8 @@ function volumeDetail() {
         readFilter: 'all', // 'all', 'read', 'unread'
         sortOrder: 'asc',  // 'asc', 'desc'
         isReverseNumbering: false,
+        storyArcScope: 'volume',
+        storyArcScopeId: {{ volume_id }},
 
         paginationMode: '{{ get_system_setting("ui.pagination_mode", "infinite") }}',
 

--- a/app/templates/partials/arc_card.html
+++ b/app/templates/partials/arc_card.html
@@ -1,4 +1,4 @@
-<div class="group relative cursor-pointer" x-on:click="filterByArc(arc.name)">
+<div class="group relative cursor-pointer" x-on:click="window.location.href = window.parker.storyArcReaderUrl(arc, storyArcScope, storyArcScopeId)">
 
     <div class="aspect-[2/3] bg-gray-700 rounded-lg overflow-hidden relative shadow-md transition-transform duration-200 group-hover:scale-[1.02]">
 
@@ -6,7 +6,7 @@
              class="w-full h-full object-cover transition-opacity duration-300 group-hover:opacity-40">
 
         <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
-             <a :href="window.parker.readerRoute(arc.first_issue_id)"
+             <a :href="window.parker.storyArcReaderUrl(arc, storyArcScope, storyArcScopeId)"
                 x-on:click.stop
                 class="bg-blue-600 hover:bg-blue-500 text-white rounded-full p-3 shadow-xl transform hover:scale-110 transition-transform"
                 title="Start Reading Arc">

--- a/docs/releases/0.1.23.md
+++ b/docs/releases/0.1.23.md
@@ -7,6 +7,7 @@ Status: Draft
 - Reader bookmarks as a separate per-user, per-comic save system, including save, jump-to, rename-on-resave, and delete flows from the in-reader bookmarks modal.
 - Bookmark detour mode in the reader so users can jump back to a saved page for reference without immediately overwriting their true resume position.
 - Comic detail pages now surface saved bookmarks in the left action rail so readers can jump straight back into notable pages outside the reader itself.
+- Story arcs now launch the reader with an explicit `story_arc` context so in-reader previous/next book navigation follows exact arc metadata membership.
 
 ## Changed
 
@@ -22,6 +23,7 @@ Status: Draft
 - Fixed bookmark revisit flows that could otherwise force users to remember their original page manually or close and reopen the comic just to preserve real reading progress.
 - Fixed detour banner readability issues where low-opacity banner/button styling could become faint against white top gutters in comic pages.
 - Fixed reader exit flows from dashboard and other generic launch surfaces that previously always dumped users onto the comic detail page instead of back where they started.
+- Fixed story arc reader navigation so filler issues inside an apparent numeric run are skipped unless their `story_arc` metadata matches the launched arc.
 - Fixed stack detail pages so the `Details` tab now renders the full aggregated metadata already returned by the API, including pencillers, characters, teams, and locations instead of only showing writers.
 - Fixed comic detail tag sections so character, team, location, and genre chips now render in alphabetical order to match the rest of the app's detail pages.
 
@@ -35,3 +37,5 @@ Status: Draft
 - Elevated browser verification passed: `tests/browser/test_continue_reading_flows.py`.
 - Verified the stack detail template now mirrors the reading list metadata sections for writers, pencillers, characters, teams, and locations; no automated test run was performed for this fix in this pass.
 - Elevated API verification passed: `tests/api/test_comics.py -k "get_comic_detail_returns_metadata_and_in_progress_status or get_comic_detail_sorts_tag_metadata_alphabetically"`.
+- Elevated API verification passed: `tests/api/test_reader.py`, `tests/api/test_series.py`, and `tests/api/test_volumes.py`.
+- JavaScript syntax verification passed: `node --check static/js/reader.js`.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -637,6 +637,21 @@ document.addEventListener('error', function(e) {
         }
     };
 
+    const storyArcReaderUrl = (arc, contextScope, contextScopeId) => {
+        if (!arc || !arc.first_issue_id) {
+            return '#';
+        }
+
+        const params = new URLSearchParams({
+            context_type: 'story_arc',
+            story_arc: arc.name || '',
+            context_scope: contextScope,
+            context_scope_id: contextScopeId
+        });
+
+        return window.parker.readerRoute(arc.first_issue_id, params.toString());
+    };
+
 
     // Export utilities
     window.parker = { ...(window.parker || {}),
@@ -648,7 +663,8 @@ document.addEventListener('error', function(e) {
         paginationMixin,
         storage,
         prefs,
-        searchHandoff
+        searchHandoff,
+        storyArcReaderUrl
     };
 
 })();

--- a/static/js/reader.js
+++ b/static/js/reader.js
@@ -167,6 +167,9 @@
             isIncognito: false,
             contextType: null,
             contextId: null,
+            storyArc: null,
+            contextScope: null,
+            contextScopeId: null,
             pageMeta: {},
             filters: cloneDefaultFilters(),
             scrollTicking: false,
@@ -372,6 +375,9 @@
                 this.isIncognito = params.get('incognito') === 'true';
                 this.contextType = params.get('context_type');
                 this.contextId = params.get('context_id');
+                this.storyArc = params.get('story_arc');
+                this.contextScope = params.get('context_scope');
+                this.contextScopeId = params.get('context_scope_id');
                 this.launchPageIndex = Number.parseInt(params.get('page'), 10);
                 this.launchBookmarkOriginPage = Number.parseInt(params.get('bookmark_origin_page'), 10);
                 this.returnTo = params.get('return_to');
@@ -399,8 +405,7 @@
             async loadInitData() {
                 try {
                     const params = new URLSearchParams();
-                    if (this.contextType) params.append('context_type', this.contextType);
-                    if (this.contextId) params.append('context_id', this.contextId);
+                    this.appendReaderContextParams(params);
 
                     const response = await fetch(window.parker.route('reader.init', { comic_id: this.comicId }, params.toString()));
 
@@ -783,8 +788,7 @@
                 let url = window.parker.route('pages.reader', { comic_id: id });
                 const params = new URLSearchParams();
 
-                if (this.contextType) params.append('context_type', this.contextType);
-                if (this.contextId) params.append('context_id', this.contextId);
+                this.appendReaderContextParams(params);
                 if (this.isIncognito) params.append('incognito', 'true');
                 if (this.returnTo) params.append('return_to', this.returnTo);
 
@@ -822,8 +826,18 @@
                     return;
                 }
 
+                if (this.contextType === 'story_arc' && this.contextScope === 'series' && this.contextScopeId) {
+                    window.location.href = window.parker.route('pages.series_detail', { series_id: this.contextScopeId });
+                    return;
+                }
+
                 if (this.contextType === 'volume' && this.contextId) {
                     window.location.href = window.parker.route('pages.volume_detail', { volume_id: this.contextId });
+                    return;
+                }
+
+                if (this.contextType === 'story_arc' && this.contextScope === 'volume' && this.contextScopeId) {
+                    window.location.href = window.parker.route('pages.volume_detail', { volume_id: this.contextScopeId });
                     return;
                 }
 
@@ -1092,8 +1106,7 @@
                 }
 
                 const params = new URLSearchParams();
-                if (this.contextType) params.append('context_type', this.contextType);
-                if (this.contextId) params.append('context_id', this.contextId);
+                this.appendReaderContextParams(params, { includeProgressContext: true });
 
                 fetch(window.parker.route('progress.comic_progress', { comic_id: this.comicId }, params.toString()), {
                     method: 'POST',
@@ -1251,7 +1264,30 @@
                 if (contextType === 'reading_list') return 'Reading List';
                 if (contextType === 'collection') return 'Collection';
                 if (contextType === 'series') return 'Series';
+                if (contextType === 'story_arc') return 'Story Arc';
                 return 'Volume';
+            },
+
+            appendReaderContextParams(params, { includeProgressContext = false } = {}) {
+                if (!this.contextType) {
+                    return;
+                }
+
+                if (includeProgressContext && this.contextType === 'story_arc') {
+                    return;
+                }
+
+                params.append('context_type', this.contextType);
+
+                if (this.contextId && this.contextType !== 'story_arc') {
+                    params.append('context_id', this.contextId);
+                }
+
+                if (!includeProgressContext && this.contextType === 'story_arc') {
+                    if (this.storyArc) params.append('story_arc', this.storyArc);
+                    if (this.contextScope) params.append('context_scope', this.contextScope);
+                    if (this.contextScopeId) params.append('context_scope_id', this.contextScopeId);
+                }
             },
 
             handleZoneClick(zone) {

--- a/tests/api/test_reader.py
+++ b/tests/api/test_reader.py
@@ -268,6 +268,72 @@ def test_reader_init_reading_list_collection_and_series_contexts(auth_client, db
     assert series_payload["next_comic_id"] == rev1.id
 
 
+def test_reader_init_story_arc_context_skips_non_member_issues(auth_client, db, normal_user):
+    library, series, volume = _create_graph(
+        db,
+        lib_name="reader-story-arc-lib",
+        series_name="Story Arc Series",
+    )
+
+    arc_start = _add_comic(db, volume, number="104", title="Arc Start", story_arc="Gap Arc", page_count=12)
+    arc_middle = _add_comic(db, volume, number="105", title="Arc Middle", story_arc="Gap Arc", page_count=12)
+    _add_comic(db, volume, number="107", title="Filler Story", page_count=12)
+    arc_end = _add_comic(db, volume, number="108", title="Arc End", story_arc="Gap Arc", page_count=12)
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.get(
+        f"/api/reader/{arc_middle.id}/read-init"
+        f"?context_type=story_arc"
+        f"&story_arc=Gap%20Arc"
+        f"&context_scope=series"
+        f"&context_scope_id={series.id}"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["context_type"] == "story_arc"
+    assert payload["context_label"] == "Gap Arc"
+    assert payload["context_total"] == 3
+    assert payload["context_position"] == 2
+    assert payload["prev_comic_id"] == arc_start.id
+    assert payload["next_comic_id"] == arc_end.id
+
+
+def test_reader_init_story_arc_context_respects_volume_scope(auth_client, db, normal_user):
+    library, _, first_volume = _create_graph(
+        db,
+        lib_name="reader-story-arc-scope-lib",
+        series_name="Story Arc Scope",
+    )
+    second_volume = Volume(series=first_volume.series, volume_number=2)
+    db.add(second_volume)
+    db.flush()
+
+    first = _add_comic(db, first_volume, number="1", title="Scoped Arc One", story_arc="Shared Arc", page_count=12)
+    second = _add_comic(db, first_volume, number="2", title="Scoped Arc Two", story_arc="Shared Arc", page_count=12)
+    _add_comic(db, second_volume, number="3", title="Other Volume Arc", story_arc="Shared Arc", page_count=12)
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    response = auth_client.get(
+        f"/api/reader/{first.id}/read-init"
+        f"?context_type=story_arc"
+        f"&story_arc=Shared%20Arc"
+        f"&context_scope=volume"
+        f"&context_scope_id={first_volume.id}"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["context_total"] == 2
+    assert payload["context_position"] == 1
+    assert payload["prev_comic_id"] is None
+    assert payload["next_comic_id"] == second.id
+
+
 def test_reader_page_endpoint_headers_and_errors(client, db):
     _, _, volume = _create_graph(db, lib_name="reader-page-lib", series_name="Reader Pages")
     comic = _add_comic(db, volume, number="1", title="Page Comic")


### PR DESCRIPTION
Adds a dedicated story arc reader context so launching a story arc from series or volume detail keeps reader navigation constrained to comics whose `story_arc` metadata matches the launched arc. This prevents filler issues inside an apparent numeric run from appearing via reader next/previous navigation.

**Changes**
- Added `context_type=story_arc` support to the reader init API.
- Added dedicated `story_arc`, `context_scope`, and `context_scope_id` query params instead of overloading `context_id`.
- Scoped story arc navigation to the launching series or volume.
- Preserved story arc context across reader next/previous book navigation.
- Story arc reader context is preserved for reader navigation, but omitted from progress activity metadata because activity logs currently support only numeric context IDs.
- Moved story arc reader URL construction into shared `window.parker.storyArcReaderUrl(...)`.
- Updated series/volume story arc cards to launch the reader with story arc context.
- Added reader API regression tests for non-contiguous story arcs and scoped arc navigation.
- Updated README and `0.1.23` release notes.

**Validation**
- `node --check static/js/app.js`
- `node --check static/js/reader.js`
- `.\.venv\Scripts\python.exe -m pytest tests/api/test_reader.py tests/api/test_series.py tests/api/test_volumes.py`
- `git diff --check`