### PR TITLE
 Adds an optional navigation shortcut for single-volume series

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
   - Rich metadata (credits, tags, page counts, colors)
   - Reading Lists, Collections, Story Arcs, Stacks, Smart Lists
   - Volume-level `Following` for future issue tracking by run
+  - Optional single-volume series shortcut to open the volume detail page directly
 
 - **User System**
   - Multi‑library access with row‑level security

--- a/alembic/versions/bd41f00d0b85_add_index_to_volume_series_id.py
+++ b/alembic/versions/bd41f00d0b85_add_index_to_volume_series_id.py
@@ -1,0 +1,27 @@
+"""add_index_to_volume_series_id
+
+Revision ID: bd41f00d0b85
+Revises: 5466f87f7df4
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "bd41f00d0b85"
+down_revision: Union[str, None] = "5466f87f7df4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("volumes", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_volumes_series_id"), ["series_id"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("volumes", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_volumes_series_id"))

--- a/app/models/comic.py
+++ b/app/models/comic.py
@@ -11,7 +11,7 @@ class Volume(Base):
     __tablename__ = "volumes"
 
     id = Column(Integer, primary_key=True, index=True)
-    series_id = Column(Integer, ForeignKey("series.id"))
+    series_id = Column(Integer, ForeignKey("series.id"), index=True)
     volume_number = Column(Integer, default=1)
     summary_override = Column(Text, nullable=True)
 

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from app.core.comic_helpers import get_smart_cover
 from app.api.deps import SessionDep, ComicDep, VolumeDep, SeriesDep, LibraryDep, CurrentUser
 from app.config import settings
+from app.core.settings_loader import get_cached_setting
 from app.core.templates import templates
 from app.models.comic import Comic, Volume
 from app.core.login_effects import get_active_effect
@@ -123,8 +124,27 @@ async def library_view(request: Request, library: LibraryDep, user: CurrentUser)
     })
 
 @router.get("/series/{series_id}", response_class=HTMLResponse, name="series_detail")
-async def series_detail(request: Request, series: SeriesDep, db: SessionDep, user: CurrentUser):
+async def series_detail(
+        request: Request,
+        series: SeriesDep,
+        db: SessionDep,
+        user: CurrentUser,
+        show_series: bool = Query(False)
+):
     """Series detail page"""
+    if not show_series and get_cached_setting("ui.auto_redirect_single_volume_series", False):
+        volume_ids = (
+            db.query(Volume.id)
+            .filter(Volume.series_id == series.id)
+            .order_by(Volume.volume_number)
+            .limit(2)
+            .all()
+        )
+        if len(volume_ids) == 1:
+            return RedirectResponse(
+                url=request.url_for("volume_detail", volume_id=volume_ids[0].id),
+                status_code=307,
+            )
 
     # Find the "Smart Cover" to use for colors/background
     base_query = db.query(Comic).join(Volume).filter(Volume.series_id == series.id)

--- a/app/services/settings_service.py
+++ b/app/services/settings_service.py
@@ -128,6 +128,14 @@ class SettingsService:
             ]
         },
         {
+            "key": "ui.auto_redirect_single_volume_series",
+            "value": "false",
+            "category": "appearance",
+            "data_type": "bool",
+            "label": "Open Single-Volume Series as Volume",
+            "description": "When enabled, opening a series with exactly one volume sends readers directly to that volume page."
+        },
+        {
             "key": "ui.on_deck.staleness_weeks", "value": "4",
             "category": "appearance", "data_type": "int",
             "label": "On Deck Staleness (Weeks)",

--- a/app/templates/comics/volume_detail.html
+++ b/app/templates/comics/volume_detail.html
@@ -16,7 +16,7 @@
         <div class="flex flex-wrap items-center gap-2 text-gray-400 mb-6 text-sm" x-show="!error" x-cloak>
             <a :href="window.parker.route('pages.library_detail', { library_id: volume?.library_id })" class="hover:text-white" x-text="volume?.library_name"></a>
             <span>/</span>
-            <a :href="window.parker.route('pages.series_detail', { series_id: volume?.series_id    })" class="hover:text-blue-400" x-text="volume?.series_name || 'Series'"></a>
+            <a :href="window.parker.route('pages.series_detail', { series_id: volume?.series_id }) + '?show_series=1'" class="hover:text-blue-400" x-text="volume?.series_name || 'Series'"></a>
             <span>/</span>
             <span class="text-white" x-text="`Vol ${volume?.volume_number}`"></span>
         </div>

--- a/docs/releases/0.1.23.md
+++ b/docs/releases/0.1.23.md
@@ -8,6 +8,7 @@ Status: Draft
 - Bookmark detour mode in the reader so users can jump back to a saved page for reference without immediately overwriting their true resume position.
 - Comic detail pages now surface saved bookmarks in the left action rail so readers can jump straight back into notable pages outside the reader itself.
 - Story arcs now launch the reader with an explicit `story_arc` context so in-reader previous/next book navigation follows exact arc metadata membership.
+- Added an appearance setting, `ui.auto_redirect_single_volume_series`, that can open single-volume series directly on their volume detail page.
 
 ## Changed
 
@@ -17,6 +18,9 @@ Status: Draft
 - Reader close behavior now prefers the original launch surface when opened from generic app pages instead of always falling back to comic detail.
 - Reader detour messaging was tuned to remain readable over bright comic page margins with a darker banner surface and stronger action contrast.
 - The reader bookmarks modal now scales better for larger bookmark counts with filterable results, compact rows, and inline label editing directly from the list.
+- Series page navigation can now collapse one-volume series into the volume page when the new setting is enabled, while multi-volume series continue to land on the series page.
+- Volume detail breadcrumbs now use `?show_series=1` when linking back to the parent series so users can still reach the series shell even when single-volume redirects are enabled.
+- Single-volume redirect checks now use the cached settings helper and an indexed `volumes.series_id` lookup to keep series page navigation cheap.
 
 ## Fixed
 
@@ -26,6 +30,7 @@ Status: Draft
 - Fixed story arc reader navigation so filler issues inside an apparent numeric run are skipped unless their `story_arc` metadata matches the launched arc.
 - Fixed stack detail pages so the `Details` tab now renders the full aggregated metadata already returned by the API, including pencillers, characters, teams, and locations instead of only showing writers.
 - Fixed comic detail tag sections so character, team, location, and genre chips now render in alphabetical order to match the rest of the app's detail pages.
+- Fixed the potential breadcrumb redirect loop introduced by single-volume series collapsing by adding an explicit series-page escape hatch.
 
 ## Validation
 
@@ -39,3 +44,4 @@ Status: Draft
 - Elevated API verification passed: `tests/api/test_comics.py -k "get_comic_detail_returns_metadata_and_in_progress_status or get_comic_detail_sorts_tag_metadata_alphabetically"`.
 - Elevated API verification passed: `tests/api/test_reader.py`, `tests/api/test_series.py`, and `tests/api/test_volumes.py`.
 - JavaScript syntax verification passed: `node --check static/js/reader.js`.
+- Elevated API verification passed: `tests/api/test_pages.py tests/api/test_settings.py`.

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -1,4 +1,34 @@
 from app.core.templates import templates
+from app.models.comic import Comic, Volume
+from app.models.library import Library
+from app.models.series import Series
+
+
+def _seed_series_page_data(db, volume_count=1):
+    library = Library(name=f"Page Test Library {volume_count}", path=f"/tmp/page-test-library-{volume_count}")
+    series = Series(name=f"Page Test Series {volume_count}", library=library)
+    db.add(series)
+
+    volumes = []
+    for index in range(1, volume_count + 1):
+        volume = Volume(series=series, volume_number=index)
+        volumes.append(volume)
+        db.add(
+            Comic(
+                volume=volume,
+                number="1",
+                filename=f"page-test-{volume_count}-{index}.cbz",
+                file_path=f"/tmp/page-test-{volume_count}-{index}.cbz",
+                page_count=10,
+            )
+        )
+
+    db.commit()
+    db.refresh(series)
+    for volume in volumes:
+        db.refresh(volume)
+
+    return series, volumes
 
 
 def test_home_page_shows_storage_warning_for_admin_when_startup_looks_suspicious(admin_client, monkeypatch):
@@ -141,6 +171,45 @@ def test_reader_page_uses_modular_reader_shell(auth_client):
     assert "window.createReader({ comicId: 123 })" in body
     assert "/static/js/reader.js" in body
     assert 'x-on:click="toggleViewMode()"' in body
+
+
+def test_series_page_redirects_to_single_volume_when_setting_enabled(admin_client, db, monkeypatch):
+    series, volumes = _seed_series_page_data(db)
+    monkeypatch.setattr("app.routers.pages.get_cached_setting", lambda key, default=None: True)
+
+    response = admin_client.get(f"/series/{series.id}", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"].endswith(f"/volumes/{volumes[0].id}")
+
+
+def test_series_page_show_series_query_skips_single_volume_redirect(admin_client, db, monkeypatch):
+    series, _ = _seed_series_page_data(db)
+    monkeypatch.setattr("app.routers.pages.get_cached_setting", lambda key, default=None: True)
+
+    response = admin_client.get(f"/series/{series.id}?show_series=1", follow_redirects=False)
+
+    assert response.status_code == 200
+    assert "seriesDetail()" in response.text
+
+
+def test_series_page_keeps_multi_volume_series_when_setting_enabled(admin_client, db, monkeypatch):
+    series, _ = _seed_series_page_data(db, volume_count=2)
+    monkeypatch.setattr("app.routers.pages.get_cached_setting", lambda key, default=None: True)
+
+    response = admin_client.get(f"/series/{series.id}", follow_redirects=False)
+
+    assert response.status_code == 200
+    assert "seriesDetail()" in response.text
+
+
+def test_volume_page_series_breadcrumb_uses_series_escape_hatch(admin_client, db):
+    _, volumes = _seed_series_page_data(db)
+
+    response = admin_client.get(f"/volumes/{volumes[0].id}")
+
+    assert response.status_code == 200
+    assert "?show_series=1" in response.text
 
 
 def test_user_settings_page_renders_for_authenticated_user(auth_client):

--- a/tests/api/test_settings.py
+++ b/tests/api/test_settings.py
@@ -108,6 +108,20 @@ def test_initialize_defaults_seeds_short_server_display_name(db):
     assert service.get("general.app_name") == "Parker"
 
 
+def test_initialize_defaults_seeds_single_volume_redirect_setting(db):
+    service = SettingsService(db)
+
+    service.initialize_defaults()
+
+    setting = db.query(SystemSetting).filter(
+        SystemSetting.key == "ui.auto_redirect_single_volume_series"
+    ).first()
+    assert setting is not None
+    assert service.get("ui.auto_redirect_single_volume_series") is False
+    assert setting.category == "appearance"
+    assert setting.data_type == "bool"
+
+
 def test_initialize_defaults_preserves_existing_custom_server_display_name(db):
     db.add(
         SystemSetting(


### PR DESCRIPTION

Adds an optional navigation shortcut for single-volume series. When enabled via the new `ui.auto_redirect_single_volume_series` appearance setting, opening a series with exactly one volume redirects directly to that volume detail page. Multi-volume series continue to open on the series detail page.

**Details**

- Added the `ui.auto_redirect_single_volume_series` boolean setting, defaulting to `false`.
- Updated `/series/{series_id}` page routing to redirect single-volume series only when the setting is enabled.
- Added `?show_series=1` as an escape hatch so the series shell remains reachable.
- Updated volume detail breadcrumbs to use the escape hatch when linking back to the parent series.
- Added an index on `volumes.series_id` plus an Alembic migration so the redirect check stays cheap.
- Switched the route setting check to `get_cached_setting(...)` to avoid a per-request settings DB lookup.
- Updated README and 0.1.23 draft release notes.
- Added focused tests for the setting default, redirect behavior, multi-volume behavior, escape hatch, and breadcrumb link.

**Validation**

- `tests/api/test_pages.py tests/api/test_settings.py` passed: `29 passed`
- New Alembic migration syntax check passed with `py_compile` via the project venv.