### PR TITLE
Enhance stack awareness on comic detail

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,9 +10,9 @@ This file captures follow-up work that should not get lost between releases.
   Candidate direction: Treat this as a generic reader-session/container-resume feature rather than a story-arc-specific workaround. Reading lists, collections, stacks, and possibly scoped story arcs should share the same design if the feature is worth building.
   Guardrail: Avoid changing global home-rail resume behavior unless there is a broader product decision to persist last reader launch context; the current comic/page-only resume is simple and predictable.
 
-- Keep an eye on pull list detail page scale before it becomes a usability problem.
-  Context: `app/templates/pull_lists/detail.html` currently renders a full list in one view, which is fine for normal pull-list sizes and likely more important to watch than the pull-list index page.
-  Follow-up goal: If real users start building unusually large pull lists, consider pagination, filtering, or virtualization for list contents before the detail view becomes heavy to use.
+- Keep an eye on stack list detail page scale before it becomes a usability problem.
+  Context: `app/templates/pull_lists/detail.html` currently renders a full list in one view, which is fine for normal stack sizes and likely more important to watch than the stack index page.
+  Follow-up goal: If real users start building unusually large stacks, consider pagination, filtering, or virtualization for list contents before the detail view becomes heavy to use.
   Guardrail: Treat this as a usage-driven optimization, not a default roadmap item, unless real list sizes or UX complaints justify it.
 
 - Keep an eye on smart filter scale before the search load menu gets crowded.

--- a/alembic/versions/e1d5f6a7b8c9_add_pull_list_membership_indexes.py
+++ b/alembic/versions/e1d5f6a7b8c9_add_pull_list_membership_indexes.py
@@ -1,0 +1,33 @@
+"""add pull list membership indexes
+
+Revision ID: e1d5f6a7b8c9
+Revises: bd41f00d0b85
+Create Date: 2026-07-19 14:45:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e1d5f6a7b8c9"
+down_revision: Union[str, None] = "bd41f00d0b85"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("pull_lists", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_pull_lists_user_id"), ["user_id"], unique=False)
+
+    with op.batch_alter_table("pull_list_items", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_pull_list_items_comic_id"), ["comic_id"], unique=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("pull_list_items", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_pull_list_items_comic_id"))
+
+    with op.batch_alter_table("pull_lists", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_pull_lists_user_id"))

--- a/app/api/comics.py
+++ b/app/api/comics.py
@@ -165,8 +165,10 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
         ReadingProgress.user_id == current_user.id
     ).first()
 
+    if progress and progress.completed:
+        read_status = "completed"
     # If started but not finished, show "Continue"
-    if progress and not progress.completed and progress.current_page > 0:
+    elif progress and not progress.completed and progress.current_page > 0:
         read_status = "in_progress"
     resume_page = progress.current_page if progress and not progress.completed and progress.current_page > 0 else None
 

--- a/app/api/comics.py
+++ b/app/api/comics.py
@@ -179,6 +179,15 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
         .order_by(Bookmark.page_index.asc())
         .all()
     )
+    stack_membership_count = (
+        db.query(PullListItem)
+        .join(PullList, PullList.id == PullListItem.pull_list_id)
+        .filter(
+            PullList.user_id == current_user.id,
+            PullListItem.comic_id == comic.id,
+        )
+        .count()
+    )
 
     parker_rating = build_parker_rating_state(db, comic.id, current_user.id)
     parker_readers_count = get_visible_comic_reader_count(db, comic.id)
@@ -251,6 +260,7 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
         # Read status
         "read_status": read_status,
         "resume_page": resume_page,
+        "stack_membership_count": stack_membership_count,
         "bookmarks": [
             {
                 "id": bookmark.id,

--- a/app/models/pull_list.py
+++ b/app/models/pull_list.py
@@ -8,7 +8,7 @@ class PullList(Base):
     __tablename__ = "pull_lists"
 
     id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
     name = Column(String, nullable=False)
     description = Column(Text, nullable=True)
 
@@ -32,7 +32,7 @@ class PullListItem(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     pull_list_id = Column(Integer, ForeignKey("pull_lists.id"), nullable=False)
-    comic_id = Column(Integer, ForeignKey("comics.id"), nullable=False)
+    comic_id = Column(Integer, ForeignKey("comics.id"), nullable=False, index=True)
 
     # Critical for custom ordering
     sort_order = Column(Integer, nullable=False, default=0)

--- a/app/templates/comics/comic_detail.html
+++ b/app/templates/comics/comic_detail.html
@@ -444,7 +444,7 @@ function comicDetail() {
         async markRead() {
             await fetch(window.parker.route('progress.mark_comic_as_read',{ comic_id: this.comicId }), { method: 'POST' });
             if (this.comic) {
-                this.comic = { ...this.comic, read_status: 'new', resume_page: null };
+                this.comic = { ...this.comic, read_status: 'completed', resume_page: null };
             }
         },
 

--- a/app/templates/comics/comic_detail.html
+++ b/app/templates/comics/comic_detail.html
@@ -11,7 +11,7 @@
 
 <div class="relative z-10">
 
-    <div class="max-w-6xl mx-auto" x-data="comicDetail()">
+    <div class="max-w-6xl mx-auto" x-data="comicDetail()" x-on:pull-list-item-added.window="handlePullListItemAdded($event.detail)">
 
         <div class="flex items-center space-x-2 text-gray-400 mb-6 text-sm" x-show="!error" x-cloak>
             <a :href="window.parker.route('pages.library_detail', { library_id: comic?.library_id })" class="hover:text-white" x-text="comic?.library_name"></a>
@@ -57,14 +57,21 @@
 
                     {% include "partials/read_comic_button.html" %}
 
-                    <button
-                        x-on:click="$dispatch('open-add-to-pull-list', { id: comicId, type: 'comic' })"
-                        class="w-full bg-gray-700 hover:bg-gray-600 text-gray-200 font-bold py-2 px-4 rounded-lg transition-colors border border-gray-600 flex items-center justify-center gap-2">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                            <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd" />
-                        </svg>
-                        Add to Stack
-                    </button>
+                    <div>
+                        <button
+                            x-on:click="$dispatch('open-add-to-pull-list', { id: comicId, type: 'comic' })"
+                            class="w-full bg-gray-700 hover:bg-gray-600 text-gray-200 font-bold py-2 px-4 rounded-lg transition-colors border border-gray-600 flex items-center justify-center gap-2 flex-wrap">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd" />
+                            </svg>
+                            <span>Add to Stack</span>
+                            <span x-show="comic?.stack_membership_count > 0"
+                                  x-cloak
+                                  data-stack-membership
+                                  class="text-sm font-medium text-gray-400"
+                                  x-text="`(in ${comic.stack_membership_count} stack${comic.stack_membership_count === 1 ? '' : 's'})`"></span>
+                        </button>
+                    </div>
 
 
                     <div class="grid grid-cols-2 gap-3">
@@ -461,6 +468,21 @@ function comicDetail() {
             }
 
             return window.parker.readerRoute(this.comicId, params.toString());
+        },
+
+        handlePullListItemAdded(detail) {
+            if (!this.comic || detail?.comicId !== this.comicId) {
+                return;
+            }
+
+            const currentCount = Number.isInteger(this.comic.stack_membership_count)
+                ? this.comic.stack_membership_count
+                : 0;
+
+            this.comic = {
+                ...this.comic,
+                stack_membership_count: currentCount + 1,
+            };
         },
 
         applyRatingState(data) {

--- a/app/templates/partials/add_pull_list_modal.html
+++ b/app/templates/partials/add_pull_list_modal.html
@@ -161,6 +161,9 @@ function addPullListModal() {
 
                 if (res.ok) {
                     window.parker.showToast("Added to stack!", 'success');
+                    window.dispatchEvent(new CustomEvent('pull-list-item-added', {
+                        detail: { comicId: this.targetId, pullListId: listId }
+                    }));
                     this.close();
                 } else {
                     const err = await res.json();

--- a/app/templates/partials/read_comic_button.html
+++ b/app/templates/partials/read_comic_button.html
@@ -5,7 +5,7 @@
         :class="comic?.read_status === 'in_progress' ? 'bg-blue-600 hover:bg-blue-500' : 'bg-green-600 hover:bg-green-500'"
     >
         <span class="text-xl" x-text="comic?.read_status === 'in_progress' ? '▶' : '📖'"></span>
-        <span x-text="comic?.read_status === 'in_progress' ? 'Continue' : 'Read Now'"></span>
+        <span x-text="comic?.read_status === 'in_progress' ? 'Continue' : (comic?.read_status === 'completed' ? 'Read Again' : 'Read')"></span>
     </a>
 
     <button x-on:click="open = !open" x-on:click.away="open = false"

--- a/docs/releases/0.1.23.md
+++ b/docs/releases/0.1.23.md
@@ -15,6 +15,7 @@ Status: Draft
 - Reader bookmarks now default to page-number ordering so saved jump points stay aligned with comic flow.
 - Bookmark jumps now open a temporary detour state with explicit `Return to page X` and `Resume here` actions instead of behaving like ordinary progress-changing navigation.
 - Comic detail bookmark links now launch into the same detour-safe reader flow when a saved resume page exists.
+- Comic detail pages now inline stack membership awareness into the `Add to Stack` action when the current issue already belongs to one or more stacks.
 - Reader close behavior now prefers the original launch surface when opened from generic app pages instead of always falling back to comic detail.
 - Reader detour messaging was tuned to remain readable over bright comic page margins with a darker banner surface and stronger action contrast.
 - The reader bookmarks modal now scales better for larger bookmark counts with filterable results, compact rows, and inline label editing directly from the list.
@@ -27,6 +28,7 @@ Status: Draft
 - Fixed bookmark revisit flows that could otherwise force users to remember their original page manually or close and reopen the comic just to preserve real reading progress.
 - Fixed detour banner readability issues where low-opacity banner/button styling could become faint against white top gutters in comic pages.
 - Fixed reader exit flows from dashboard and other generic launch surfaces that previously always dumped users onto the comic detail page instead of back where they started.
+- Fixed comic detail stack actions so users can now see existing stack membership before triggering an avoidable duplicate-add error.
 - Fixed story arc reader navigation so filler issues inside an apparent numeric run are skipped unless their `story_arc` metadata matches the launched arc.
 - Fixed stack detail pages so the `Details` tab now renders the full aggregated metadata already returned by the API, including pencillers, characters, teams, and locations instead of only showing writers.
 - Fixed comic detail tag sections so character, team, location, and genre chips now render in alphabetical order to match the rest of the app's detail pages.
@@ -42,6 +44,8 @@ Status: Draft
 - Elevated browser verification passed: `tests/browser/test_continue_reading_flows.py`.
 - Verified the stack detail template now mirrors the reading list metadata sections for writers, pencillers, characters, teams, and locations; no automated test run was performed for this fix in this pass.
 - Elevated API verification passed: `tests/api/test_comics.py -k "get_comic_detail_returns_metadata_and_in_progress_status or get_comic_detail_sorts_tag_metadata_alphabetically"`.
+- Elevated API verification passed: `tests/api/test_pull_lists.py`.
 - Elevated API verification passed: `tests/api/test_reader.py`, `tests/api/test_series.py`, and `tests/api/test_volumes.py`.
 - JavaScript syntax verification passed: `node --check static/js/reader.js`.
 - Elevated API verification passed: `tests/api/test_pages.py tests/api/test_settings.py`.
+- Elevated browser verification passed: `tests/browser/test_saved_search_pull_list_and_session_flows.py -k "comic_detail_add_to_existing_pull_list_then_edit_and_remove_item or comic_detail_shows_existing_stack_membership"`.

--- a/docs/releases/0.1.23.md
+++ b/docs/releases/0.1.23.md
@@ -16,6 +16,7 @@ Status: Draft
 - Bookmark jumps now open a temporary detour state with explicit `Return to page X` and `Resume here` actions instead of behaving like ordinary progress-changing navigation.
 - Comic detail bookmark links now launch into the same detour-safe reader flow when a saved resume page exists.
 - Comic detail pages now inline stack membership awareness into the `Add to Stack` action when the current issue already belongs to one or more stacks.
+- Comic detail read actions now reuse the same `Read`, `Continue`, and `Read Again` wording already used on series and volume browsing surfaces.
 - Reader close behavior now prefers the original launch surface when opened from generic app pages instead of always falling back to comic detail.
 - Reader detour messaging was tuned to remain readable over bright comic page margins with a darker banner surface and stronger action contrast.
 - The reader bookmarks modal now scales better for larger bookmark counts with filterable results, compact rows, and inline label editing directly from the list.
@@ -29,6 +30,7 @@ Status: Draft
 - Fixed detour banner readability issues where low-opacity banner/button styling could become faint against white top gutters in comic pages.
 - Fixed reader exit flows from dashboard and other generic launch surfaces that previously always dumped users onto the comic detail page instead of back where they started.
 - Fixed comic detail stack actions so users can now see existing stack membership before triggering an avoidable duplicate-add error.
+- Fixed comic detail completed-read actions so fully read issues no longer misleadingly show a generic `Read` label instead of `Read Again`.
 - Fixed story arc reader navigation so filler issues inside an apparent numeric run are skipped unless their `story_arc` metadata matches the launched arc.
 - Fixed stack detail pages so the `Details` tab now renders the full aggregated metadata already returned by the API, including pencillers, characters, teams, and locations instead of only showing writers.
 - Fixed comic detail tag sections so character, team, location, and genre chips now render in alphabetical order to match the rest of the app's detail pages.
@@ -45,7 +47,9 @@ Status: Draft
 - Verified the stack detail template now mirrors the reading list metadata sections for writers, pencillers, characters, teams, and locations; no automated test run was performed for this fix in this pass.
 - Elevated API verification passed: `tests/api/test_comics.py -k "get_comic_detail_returns_metadata_and_in_progress_status or get_comic_detail_sorts_tag_metadata_alphabetically"`.
 - Elevated API verification passed: `tests/api/test_pull_lists.py`.
+- Elevated API verification passed: `tests/api/test_comics.py -k "get_comic_detail_returns_metadata_and_in_progress_status or get_comic_detail_returns_completed_read_status"`.
 - Elevated API verification passed: `tests/api/test_reader.py`, `tests/api/test_series.py`, and `tests/api/test_volumes.py`.
 - JavaScript syntax verification passed: `node --check static/js/reader.js`.
 - Elevated API verification passed: `tests/api/test_pages.py tests/api/test_settings.py`.
 - Elevated browser verification passed: `tests/browser/test_saved_search_pull_list_and_session_flows.py -k "comic_detail_add_to_existing_pull_list_then_edit_and_remove_item or comic_detail_shows_existing_stack_membership"`.
+- Elevated browser verification passed: `tests/browser/test_saved_search_pull_list_and_session_flows.py -k comic_detail_completed_issue_shows_read_again`.

--- a/tests/api/test_comics.py
+++ b/tests/api/test_comics.py
@@ -257,6 +257,40 @@ def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, d
     assert payload["parker_readers_count"] is None
 
 
+def test_get_comic_detail_returns_completed_read_status(auth_client, db, normal_user):
+    library, _, volume = _create_graph(db, lib_name="comic-detail-completed", series_name="Completed Detail Saga")
+
+    comic = Comic(
+        volume_id=volume.id,
+        number="4",
+        title="Completed Issue",
+        page_count=18,
+        filename="completed-4.cbz",
+        file_path="/tmp/completed-4.cbz",
+    )
+    db.add(comic)
+    normal_user.accessible_libraries.append(library)
+    db.flush()
+
+    db.add(
+        ReadingProgress(
+            user_id=normal_user.id,
+            comic_id=comic.id,
+            current_page=17,
+            total_pages=18,
+            completed=True,
+        )
+    )
+    db.commit()
+
+    response = auth_client.get(f"/api/comics/{comic.id}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["read_status"] == "completed"
+    assert payload["resume_page"] is None
+
+
 def test_get_comic_detail_sorts_tag_metadata_alphabetically(auth_client, db, normal_user):
     library, _, volume = _create_graph(db, lib_name="comic-detail-tags", series_name="Sorted Detail Saga")
 

--- a/tests/browser/test_saved_search_pull_list_and_session_flows.py
+++ b/tests/browser/test_saved_search_pull_list_and_session_flows.py
@@ -37,6 +37,15 @@ def _get_pull_list_snapshot(db_factory, name):
         session.close()
 
 
+def _add_comic_to_pull_list(db_factory, pull_list_id, comic_id):
+    session = db_factory()
+    try:
+        session.add(PullListItem(pull_list_id=pull_list_id, comic_id=comic_id, sort_order=0))
+        session.commit()
+    finally:
+        session.close()
+
+
 @pytest.mark.browser
 def test_login_next_redirect_and_logout_clears_session(page, browser_server):
     page.goto(f"{browser_server['base_url']}/login?next=/search", wait_until="networkidle")
@@ -132,12 +141,16 @@ def test_comic_detail_add_to_existing_pull_list_then_edit_and_remove_item(page, 
     page.goto(f"{browser_server['base_url']}/comics/{seed['active_comic_id']}", wait_until="networkidle")
 
     page.get_by_role("heading", name=f"{seed['series_name']} #{seed['active_comic_number']}").wait_for()
+    assert page.locator("[data-stack-membership]").count() == 1
+    assert page.locator("[data-stack-membership]").is_hidden()
     page.get_by_role("button", name="Add to Stack").click()
 
     page.get_by_role("heading", name="Add to Stack").wait_for()
     page.get_by_role("button", name=list_name).click()
 
     page.wait_for_selector("text=Added to stack!")
+    page.locator("[data-stack-membership]").wait_for()
+    assert page.locator("[data-stack-membership]").text_content().strip() == "(in 1 stack)"
 
     created_list = _get_pull_list_snapshot(browser_server["db_factory"], list_name)
     assert created_list is not None
@@ -179,6 +192,18 @@ def test_comic_detail_add_to_existing_pull_list_then_edit_and_remove_item(page, 
     cleared_list = _get_pull_list_snapshot(browser_server["db_factory"], updated_name)
     assert cleared_list is not None
     assert cleared_list["comic_ids"] == []
+
+
+@pytest.mark.browser
+def test_comic_detail_shows_existing_stack_membership(page, browser_server):
+    seed = browser_server["seed"]
+    pull_list_id = _create_pull_list(browser_server["db_factory"], seed["user_id"], "Already Stacked")
+    _add_comic_to_pull_list(browser_server["db_factory"], pull_list_id, seed["active_comic_id"])
+
+    page.goto(f"{browser_server['base_url']}/comics/{seed['active_comic_id']}", wait_until="networkidle")
+
+    page.get_by_role("heading", name=f"{seed['series_name']} #{seed['active_comic_number']}").wait_for()
+    assert page.locator("[data-stack-membership]").text_content().strip() == "(in 1 stack)"
 
 
 @pytest.mark.browser

--- a/tests/browser/test_saved_search_pull_list_and_session_flows.py
+++ b/tests/browser/test_saved_search_pull_list_and_session_flows.py
@@ -207,6 +207,16 @@ def test_comic_detail_shows_existing_stack_membership(page, browser_server):
 
 
 @pytest.mark.browser
+def test_comic_detail_completed_issue_shows_read_again(page, browser_server):
+    seed = browser_server["seed"]
+
+    page.goto(f"{browser_server['base_url']}/comics/{seed['completed_comic_id']}", wait_until="networkidle")
+
+    page.get_by_role("heading", name=f"{seed['series_name']} #{seed['completed_comic_number']}").wait_for()
+    page.get_by_role("link", name="Read Again").wait_for()
+
+
+@pytest.mark.browser
 def test_comic_detail_bookmarks_launch_reader_detour(page, browser_server):
     seed = browser_server["seed"]
     session = browser_server["db_factory"]()


### PR DESCRIPTION
Improve comic detail page stack awareness
- surface existing stack membership inline within the Add to Stack action
- update comic detail state immediately after adding a comic to a stack
- add pull list indexes to support stack membership lookups efficiently
- cover the new behavior with focused browser tests

Align comic detail page read actions with completed status
- expose completed read status from the comic detail API
- show Read Again for completed issues on comic detail pages
- keep Mark Read in sync with the updated completed-state label
- add focused API and browser coverage
- update 0.1.23 release notes