### PR TITLE
Adds a new Library Timeline feature for character and team metadata t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
 - **Discovery**
   - Netflix‑style home page with content rails
   - `Continue Reading`, `Jump Back In`, `Trending`, and `New from Following`
+  - Library Timeline for character and team histories generated from embedded metadata
   - Recommendations by creator or metadata
   - Random gems, recently updated series
 

--- a/app/api/timelines.py
+++ b/app/api/timelines.py
@@ -113,7 +113,6 @@ def _serialize_comic(comic: Comic, annotations: dict[int, dict]) -> dict:
         "imprint": comic.imprint,
         "format": comic.format,
         "story_arc": comic.story_arc,
-        "series_group": comic.series_group,
         "thumbnail_path": get_thumbnail_url(comic.id, comic.updated_at),
         "reading_lists": comic_annotations.get("reading_lists", []),
         "collections": comic_annotations.get("collections", []),

--- a/app/api/timelines.py
+++ b/app/api/timelines.py
@@ -1,0 +1,350 @@
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import Float, case, cast, func, or_
+from sqlalchemy.orm import joinedload
+
+from app.api.deps import CurrentUser, SessionDep
+from app.core.comic_helpers import get_series_age_restriction, get_thumbnail_url
+from app.models.collection import Collection, CollectionItem
+from app.models.comic import Comic, Volume
+from app.models.library import Library
+from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.series import Series
+from app.models.tags import Character, Team
+
+router = APIRouter()
+
+TimelineSubjectType = Literal["character", "team"]
+
+SUBJECT_MODELS = {
+    "character": (Character, Comic.characters),
+    "team": (Team, Comic.teams),
+}
+
+
+def _allowed_library_ids(user: CurrentUser) -> list[int] | None:
+    if user.is_superuser:
+        return None
+    return [library.id for library in user.accessible_libraries]
+
+
+def _apply_scope(query, user: CurrentUser, allowed_ids: list[int] | None):
+    if allowed_ids is not None:
+        query = query.filter(Series.library_id.in_(allowed_ids))
+
+    age_filter = get_series_age_restriction(user)
+    if age_filter is not None:
+        query = query.filter(age_filter)
+
+    return query
+
+
+def _subject_query(db: SessionDep, subject_type: TimelineSubjectType, name: str, user: CurrentUser):
+    model, relationship = SUBJECT_MODELS[subject_type]
+    allowed_ids = _allowed_library_ids(user)
+
+    query = (
+        db.query(model)
+        .join(model.comics)
+        .join(Volume, Comic.volume_id == Volume.id)
+        .join(Series, Volume.series_id == Series.id)
+        .filter(model.name == name)
+    )
+
+    return _apply_scope(query, user, allowed_ids).distinct()
+
+
+def _valid_year(comic: Comic) -> int | None:
+    return comic.year if comic.year and comic.year > 0 else None
+
+
+def _valid_month(comic: Comic) -> int | None:
+    return comic.month if comic.month and comic.month > 0 else None
+
+
+def _valid_day(comic: Comic) -> int | None:
+    return comic.day if comic.day and comic.day > 0 else None
+
+
+def _date_label(comic: Comic) -> str | None:
+    year = _valid_year(comic)
+    if year is None:
+        return None
+
+    month = _valid_month(comic)
+    day = _valid_day(comic)
+    if month is None:
+        return str(year)
+    if day is None:
+        return f"{year}-{month:02d}"
+    return f"{year}-{month:02d}-{day:02d}"
+
+
+def _comic_sort_key(comic: Comic):
+    year = _valid_year(comic) or 9999
+    month = _valid_month(comic) or 99
+    day = _valid_day(comic) or 99
+    try:
+        issue_number = float(comic.number)
+    except (TypeError, ValueError):
+        issue_number = 999999.0
+
+    series_name = comic.volume.series.name if comic.volume and comic.volume.series else ""
+    return (year, month, day, series_name.lower(), issue_number, comic.number or "", comic.id)
+
+
+def _serialize_comic(comic: Comic, annotations: dict[int, dict]) -> dict:
+    series = comic.volume.series
+    comic_annotations = annotations.get(comic.id, {})
+
+    return {
+        "id": comic.id,
+        "series_id": series.id,
+        "series": series.name,
+        "volume": comic.volume.volume_number,
+        "number": comic.number,
+        "title": comic.title,
+        "year": _valid_year(comic),
+        "month": _valid_month(comic),
+        "day": _valid_day(comic),
+        "date_label": _date_label(comic),
+        "publisher": comic.publisher,
+        "imprint": comic.imprint,
+        "format": comic.format,
+        "story_arc": comic.story_arc,
+        "series_group": comic.series_group,
+        "thumbnail_path": get_thumbnail_url(comic.id, comic.updated_at),
+        "reading_lists": comic_annotations.get("reading_lists", []),
+        "collections": comic_annotations.get("collections", []),
+    }
+
+
+def _load_annotations(db: SessionDep, comics: list[Comic]) -> dict[int, dict]:
+    comic_ids = [comic.id for comic in comics]
+    annotations = {
+        comic_id: {"reading_lists": [], "collections": []}
+        for comic_id in comic_ids
+    }
+    if not comic_ids:
+        return annotations
+
+    reading_rows = (
+        db.query(
+            ReadingListItem.comic_id,
+            ReadingList.id,
+            ReadingList.name,
+            ReadingListItem.position,
+        )
+        .join(ReadingList, ReadingListItem.reading_list_id == ReadingList.id)
+        .join(Comic, ReadingListItem.comic_id == Comic.id)
+        .join(Volume, Comic.volume_id == Volume.id)
+        .join(Series, Volume.series_id == Series.id)
+        .join(Library, Series.library_id == Library.id)
+        .filter(ReadingListItem.comic_id.in_(comic_ids), Library.parse_reading_lists == True)
+        .order_by(ReadingList.name.asc(), ReadingListItem.position.asc())
+        .all()
+    )
+
+    collection_rows = (
+        db.query(CollectionItem.comic_id, Collection.id, Collection.name)
+        .join(Collection, CollectionItem.collection_id == Collection.id)
+        .join(Comic, CollectionItem.comic_id == Comic.id)
+        .join(Volume, Comic.volume_id == Volume.id)
+        .join(Series, Volume.series_id == Series.id)
+        .join(Library, Series.library_id == Library.id)
+        .filter(CollectionItem.comic_id.in_(comic_ids), Library.parse_collections == True)
+        .order_by(Collection.name.asc())
+        .all()
+    )
+
+    for comic_id, list_id, list_name, position in reading_rows:
+        annotations[comic_id]["reading_lists"].append(
+            {"id": list_id, "name": list_name, "position": position}
+        )
+
+    for comic_id, collection_id, collection_name in collection_rows:
+        annotations[comic_id]["collections"].append(
+            {"id": collection_id, "name": collection_name}
+        )
+
+    return annotations
+
+
+def _first_by(items: list[Comic], key_fn) -> list[dict]:
+    first_items = {}
+    for comic in items:
+        key = key_fn(comic)
+        if not key:
+            continue
+        if key not in first_items:
+            first_items[key] = comic
+
+    return [
+        {"name": name, "comic": comic}
+        for name, comic in sorted(first_items.items(), key=lambda item: item[0].lower())
+    ]
+
+
+@router.get("/suggestions", name="suggestions")
+async def timeline_suggestions(
+    db: SessionDep,
+    current_user: CurrentUser,
+    q: str = Query(..., min_length=1),
+    limit: int = Query(10, ge=1, le=25),
+):
+    q_str = f"%{q}%"
+    allowed_ids = _allowed_library_ids(current_user)
+    suggestions = []
+
+    for subject_type, (model, _relationship) in SUBJECT_MODELS.items():
+        query = (
+            db.query(model.name)
+            .join(model.comics)
+            .join(Volume, Comic.volume_id == Volume.id)
+            .join(Series, Volume.series_id == Series.id)
+            .filter(model.name.ilike(q_str))
+        )
+        rows = (
+            _apply_scope(query, current_user, allowed_ids)
+            .distinct()
+            .order_by(model.name.asc())
+            .limit(limit)
+            .all()
+        )
+        suggestions.extend(
+            {"type": subject_type, "name": row[0]}
+            for row in rows
+            if row[0]
+        )
+
+    return sorted(suggestions, key=lambda item: (item["name"].lower(), item["type"]))[:limit]
+
+
+@router.get("/", name="detail")
+async def get_timeline(
+    db: SessionDep,
+    current_user: CurrentUser,
+    subject_type: TimelineSubjectType = Query(..., alias="type"),
+    name: str = Query(..., min_length=1),
+    per_year_limit: int = Query(8, ge=1, le=25),
+):
+    subject = _subject_query(db, subject_type, name, current_user).first()
+    if not subject:
+        raise HTTPException(status_code=404, detail="Timeline subject not found")
+
+    model, relationship = SUBJECT_MODELS[subject_type]
+    allowed_ids = _allowed_library_ids(current_user)
+
+    sort_year = case((or_(Comic.year == None, Comic.year <= 0), 9999), else_=Comic.year)
+    sort_month = case((or_(Comic.month == None, Comic.month <= 0), 99), else_=Comic.month)
+    sort_day = case((or_(Comic.day == None, Comic.day <= 0), 99), else_=Comic.day)
+
+    query = (
+        db.query(Comic)
+        .join(Volume, Comic.volume_id == Volume.id)
+        .join(Series, Volume.series_id == Series.id)
+        .filter(relationship.any(model.name == subject.name))
+        .options(joinedload(Comic.volume).joinedload(Volume.series))
+    )
+    comics = (
+        _apply_scope(query, current_user, allowed_ids)
+        .order_by(
+            sort_year.asc(),
+            sort_month.asc(),
+            sort_day.asc(),
+            Series.name.asc(),
+            cast(Comic.number, Float).asc(),
+            Comic.number.asc(),
+        )
+        .all()
+    )
+
+    comics = sorted(comics, key=_comic_sort_key)
+    dated_comics = [comic for comic in comics if _valid_year(comic) is not None]
+    undated_comics = [comic for comic in comics if _valid_year(comic) is None]
+    annotations = _load_annotations(db, comics)
+
+    years = []
+    for year in sorted({comic.year for comic in dated_comics}):
+        year_comics = [comic for comic in dated_comics if comic.year == year]
+        visible = year_comics[:per_year_limit]
+        years.append(
+            {
+                "year": year,
+                "issue_count": len(year_comics),
+                "hidden_count": max(len(year_comics) - len(visible), 0),
+                "entries": [_serialize_comic(comic, annotations) for comic in visible],
+            }
+        )
+
+    first_issue = dated_comics[0] if dated_comics else (comics[0] if comics else None)
+    latest_issue = dated_comics[-1] if dated_comics else (comics[-1] if comics else None)
+
+    first_story_arcs = _first_by(
+        dated_comics,
+        lambda comic: comic.story_arc.strip() if comic.story_arc and comic.story_arc.strip() else None,
+    )
+    first_series = _first_by(
+        dated_comics or comics,
+        lambda comic: comic.volume.series.name if comic.volume and comic.volume.series else None,
+    )
+
+    reading_list_firsts = {}
+    collection_firsts = {}
+    for comic in dated_comics:
+        for reading_list in annotations.get(comic.id, {}).get("reading_lists", []):
+            reading_list_firsts.setdefault(reading_list["name"], {"id": reading_list["id"], "comic": comic})
+        for collection in annotations.get(comic.id, {}).get("collections", []):
+            collection_firsts.setdefault(collection["name"], {"id": collection["id"], "comic": comic})
+
+    year_values = [_valid_year(comic) for comic in dated_comics]
+    year_values = [year for year in year_values if year is not None]
+
+    return {
+        "subject": {
+            "type": subject_type,
+            "name": subject.name,
+        },
+        "summary": {
+            "total_issues": len(comics),
+            "dated_issues": len(dated_comics),
+            "undated_issues": len(undated_comics),
+            "series_count": len({comic.volume.series_id for comic in comics}),
+            "story_arc_count": len(
+                {
+                    comic.story_arc.strip()
+                    for comic in comics
+                    if comic.story_arc and comic.story_arc.strip()
+                }
+            ),
+            "reading_list_count": len(reading_list_firsts),
+            "collection_count": len(collection_firsts),
+            "start_year": min(year_values) if year_values else None,
+            "end_year": max(year_values) if year_values else None,
+            "per_year_limit": per_year_limit,
+        },
+        "milestones": {
+            "first_issue": _serialize_comic(first_issue, annotations) if first_issue else None,
+            "latest_issue": _serialize_comic(latest_issue, annotations) if latest_issue else None,
+            "first_series": [
+                {"name": item["name"], "comic": _serialize_comic(item["comic"], annotations)}
+                for item in first_series[:12]
+            ],
+            "first_story_arcs": [
+                {"name": item["name"], "comic": _serialize_comic(item["comic"], annotations)}
+                for item in first_story_arcs[:12]
+            ],
+            "first_reading_lists": [
+                {"id": item["id"], "name": name, "comic": _serialize_comic(item["comic"], annotations)}
+                for name, item in sorted(reading_list_firsts.items(), key=lambda item: item[0].lower())[:12]
+            ],
+            "first_collections": [
+                {"id": item["id"], "name": name, "comic": _serialize_comic(item["comic"], annotations)}
+                for name, item in sorted(collection_firsts.items(), key=lambda item: item[0].lower())[:12]
+            ],
+        },
+        "years": years,
+        "undated_entries": [_serialize_comic(comic, annotations) for comic in undated_comics[:25]],
+        "undated_hidden_count": max(len(undated_comics) - 25, 0),
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -42,6 +42,7 @@ from app.api import migration
 from app.api import batch
 from app.api import home
 from app.api import insights
+from app.api import timelines
 
 # Frontend Routes (HTML)
 from app.routers import pages, admin
@@ -241,6 +242,7 @@ app.include_router(progress.router, prefix="/api/progress", tags=["progress"])
 app.include_router(batch.router, prefix="/api/batch", tags=["batch"])
 app.include_router(search.router, prefix="/api/search", tags=["search"])
 app.include_router(insights.router, prefix="/api/insights", tags=["insights"])
+app.include_router(timelines.router, prefix="/api/timelines", tags=["timelines"])
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(users.router, prefix="/api/users", tags=["users"])
 app.include_router(settings_api.router, prefix="/api/settings", tags=["settings"])

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -63,6 +63,12 @@ async def insights(request: Request, user: CurrentUser):
     return templates.TemplateResponse(request=request, name="insights.html")
 
 
+@router.get("/timelines", response_class=HTMLResponse, name="timelines")
+async def timelines(request: Request, user: CurrentUser):
+    """Library timeline page"""
+    return templates.TemplateResponse(request=request, name="timelines.html")
+
+
 @router.get("/insights/creator-chemistry", response_class=HTMLResponse, name="insights_creator_chemistry")
 async def insights_creator_chemistry(request: Request, user: CurrentUser):
     """Creator collaboration insights page"""

--- a/app/templates/insights.html
+++ b/app/templates/insights.html
@@ -15,6 +15,18 @@
     </section>
 
     <section class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <a href="{{ url('/timelines') }}" class="group rounded-lg border border-gray-700 bg-gray-800/80 hover:border-blue-500/60 hover:bg-gray-800 px-6 py-6 shadow-xl transition-all">
+            <h2 class="text-2xl font-black text-white">Library Timeline</h2>
+            <p class="mt-3 text-sm leading-6 text-gray-400">
+                Build a chronological view for a character or team from tags embedded in your comic files.
+            </p>
+
+            <div class="mt-6 inline-flex items-center gap-2 text-sm font-bold text-blue-300 group-hover:text-blue-200">
+                Open Library Timeline
+                <span aria-hidden="true">&rarr;</span>
+            </div>
+        </a>
+
         <a href="{{ url('/insights/creator-chemistry') }}" class="group rounded-3xl border border-gray-700 bg-gray-800/80 hover:border-blue-500/60 hover:bg-gray-800 px-6 py-6 shadow-xl transition-all">
             <h2 class="text-2xl font-black text-white">Creator Chemistry</h2>
             <p class="mt-3 text-sm leading-6 text-gray-400">

--- a/app/templates/partials/context_pill.html
+++ b/app/templates/partials/context_pill.html
@@ -1,0 +1,19 @@
+{% macro context_pill(kind, text_expr, key_expr=None) %}
+    {% if kind == 'story_arc' %}
+        {% set classes = "border-amber-500/30 bg-amber-950/30 text-amber-200" %}
+    {% elif kind == 'reading_list' %}
+        {% set classes = "border-green-500/30 bg-green-950/30 text-green-200" %}
+    {% elif kind == 'collection' %}
+        {% set classes = "border-blue-500/30 bg-blue-950/30 text-blue-200" %}
+    {% elif kind == 'series_group' %}
+        {% set classes = "border-purple-500/30 bg-purple-950/30 text-purple-200" %}
+    {% else %}
+        {% set classes = "border-gray-600 bg-gray-800 text-gray-200" %}
+    {% endif %}
+
+    <span
+        {% if key_expr %}:key="{{ key_expr }}"{% endif %}
+        class="rounded-full border {{ classes }} px-2 py-1 text-xs font-semibold"
+        x-text="{{ text_expr }}"
+    ></span>
+{% endmacro %}

--- a/app/templates/partials/context_pill.html
+++ b/app/templates/partials/context_pill.html
@@ -5,8 +5,6 @@
         {% set classes = "border-green-500/30 bg-green-950/30 text-green-200" %}
     {% elif kind == 'collection' %}
         {% set classes = "border-blue-500/30 bg-blue-950/30 text-blue-200" %}
-    {% elif kind == 'series_group' %}
-        {% set classes = "border-purple-500/30 bg-purple-950/30 text-purple-200" %}
     {% else %}
         {% set classes = "border-gray-600 bg-gray-800 text-gray-200" %}
     {% endif %}

--- a/app/templates/partials/search_widget.html
+++ b/app/templates/partials/search_widget.html
@@ -84,7 +84,7 @@
                 <div class="px-4 py-2 bg-gray-900/50 text-xs font-bold text-gray-400 uppercase tracking-wider sticky top-0 backdrop-blur-sm">Tags</div>
 
                 <template x-for="item in results.characters" :key="'char'+item.id">
-                    <a :href="window.parker.route('pages.search', {}, `field=character&value=${encodeURIComponent(item.name)}&operator=contains`)" class="block px-4 py-2 hover:bg-gray-700 transition-colors flex items-center gap-3 group">
+                    <a :href="window.parker.route('pages.timelines', {}, `type=character&name=${encodeURIComponent(item.name)}`)" class="block px-4 py-2 hover:bg-gray-700 transition-colors flex items-center gap-3 group">
                         <span class="text-xl group-hover:scale-110 transition-transform">🦸‍♂️</span>
                         <div class="min-w-0">
                             <div class="font-bold text-white truncate" x-text="item.name"></div>
@@ -94,7 +94,7 @@
                 </template>
 
                 <template x-for="item in results.teams" :key="'team'+item.id">
-                    <a :href="window.parker.route('pages.search', {}, `field=team&value=${encodeURIComponent(item.name)}&operator=contains`)" class="block px-4 py-2 hover:bg-gray-700 transition-colors flex items-center gap-3 group">
+                    <a :href="window.parker.route('pages.timelines', {}, `type=team&name=${encodeURIComponent(item.name)}`)" class="block px-4 py-2 hover:bg-gray-700 transition-colors flex items-center gap-3 group">
                         <span class="text-xl group-hover:scale-110 transition-transform">🛡️</span>
                         <div class="min-w-0">
                             <div class="font-bold text-white truncate" x-text="item.name"></div>

--- a/app/templates/partials/tag_chip.html
+++ b/app/templates/partials/tag_chip.html
@@ -23,7 +23,11 @@
 {% endif %}
 
 <a
+    {% if type in ['character', 'team'] %}
+    :href="window.parker.route('pages.timelines', {}, `type={{ type }}&name=${encodeURIComponent({{ item }})}`)"
+    {% else %}
     :href="window.parker.route('pages.search', {}, `field={{ type }}&value=${encodeURIComponent({{ item }})}&operator=contains`)"
+    {% endif %}
     class="{{ classes }} px-3 py-1.5 text-sm transition-colors cursor-pointer select-none flex-shrink-0"
     x-text="{{ item }}"
 ></a>

--- a/app/templates/timelines.html
+++ b/app/templates/timelines.html
@@ -205,13 +205,10 @@
                                             <template x-if="entry.story_arc">
                                                 {{ context_pill('story_arc', 'entry.story_arc') }}
                                             </template>
-                                            <template x-if="showSeriesGroup(entry)">
-                                                {{ context_pill('series_group', 'entry.series_group') }}
-                                            </template>
                                             <template x-for="readingList in entry.reading_lists" :key="`rl-${entry.id}-${readingList.id}`">
                                                 {{ context_pill('reading_list', '`${readingList.name} #${formatPosition(readingList.position)}`') }}
                                             </template>
-                                            <template x-for="collection in visibleCollections(entry)" :key="`col-${entry.id}-${collection.id}`">
+                                            <template x-for="collection in entry.collections" :key="`col-${entry.id}-${collection.id}`">
                                                 {{ context_pill('collection', 'collection.name') }}
                                             </template>
                                             </div>
@@ -290,13 +287,10 @@
                                                             <template x-if="entry.story_arc">
                                                                 {{ context_pill('story_arc', 'entry.story_arc') }}
                                                             </template>
-                                                            <template x-if="showSeriesGroup(entry)">
-                                                                {{ context_pill('series_group', 'entry.series_group') }}
-                                                            </template>
                                                             <template x-for="readingList in entry.reading_lists" :key="`decade-rl-${entry.id}-${readingList.id}`">
                                                                 {{ context_pill('reading_list', '`${readingList.name} #${formatPosition(readingList.position)}`') }}
                                                             </template>
-                                                            <template x-for="collection in visibleCollections(entry)" :key="`decade-col-${entry.id}-${collection.id}`">
+                                                            <template x-for="collection in entry.collections" :key="`decade-col-${entry.id}-${collection.id}`">
                                                                 {{ context_pill('collection', 'collection.name') }}
                                                             </template>
                                                         </div>
@@ -527,22 +521,6 @@ function libraryTimeline() {
         formatPosition(position) {
             const value = Number(position);
             return Number.isInteger(value) ? value.toString() : value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
-        },
-
-        normalizedContextName(value) {
-            return String(value || '').trim().toLowerCase();
-        },
-
-        visibleCollections(entry) {
-            return entry?.collections || [];
-        },
-
-        showSeriesGroup(entry) {
-            const seriesGroup = this.normalizedContextName(entry?.series_group);
-            if (!seriesGroup) return false;
-            return !(entry?.collections || []).some(
-                (collection) => this.normalizedContextName(collection.name) === seriesGroup
-            );
         },
 
         hasMilestones() {

--- a/app/templates/timelines.html
+++ b/app/templates/timelines.html
@@ -1,0 +1,573 @@
+{% extends "base.html" %}
+
+{% block title %}Library Timeline - Parker{% endblock %}
+
+{% block content %}
+{% from "partials/context_pill.html" import context_pill %}
+
+<div class="max-w-7xl mx-auto" x-data="libraryTimeline()" x-init="init()">
+    <div class="mb-8">
+        <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+            <div class="max-w-3xl">
+                <p class="text-xs font-bold uppercase tracking-[0.28em] text-blue-300">Library Timeline</p>
+                <h1 class="mt-3 text-4xl font-black tracking-tight text-white md:text-5xl">
+                    <span x-text="timeline?.subject?.name || 'Character and Team History'"></span>
+                </h1>
+                <p class="mt-3 max-w-2xl text-sm leading-6 text-gray-400">
+                    Generated from metadata embedded in your comic files.
+                </p>
+            </div>
+
+            <template x-if="timeline">
+                <a
+                    :href="matchingIssuesUrl()"
+                    class="inline-flex w-fit items-center justify-center rounded-lg border border-blue-500/60 bg-blue-600 px-4 py-2 text-sm font-bold text-white shadow-lg transition-colors hover:bg-blue-500"
+                >
+                    View Matching Issues
+                </a>
+            </template>
+        </div>
+    </div>
+
+    <section class="mb-8 rounded-lg border border-gray-700 bg-gray-800/80 p-4 shadow-xl">
+        <div class="grid gap-3 lg:grid-cols-[auto_minmax(0,1fr)] lg:items-start">
+            <div class="inline-flex w-fit rounded-lg border border-gray-700 bg-gray-900 p-1">
+                <button
+                    type="button"
+                    class="rounded-md px-3 py-2 text-sm font-bold transition-colors"
+                    :class="subjectType === 'character' ? 'bg-blue-600 text-white' : 'text-gray-300 hover:bg-gray-800 hover:text-white'"
+                    @click="setSubjectType('character')"
+                >
+                    Character
+                </button>
+                <button
+                    type="button"
+                    class="rounded-md px-3 py-2 text-sm font-bold transition-colors"
+                    :class="subjectType === 'team' ? 'bg-green-600 text-white' : 'text-gray-300 hover:bg-gray-800 hover:text-white'"
+                    @click="setSubjectType('team')"
+                >
+                    Team
+                </button>
+            </div>
+
+            <div class="relative">
+                <input
+                    type="search"
+                    x-model="query"
+                    @input.debounce.250ms="fetchSuggestions()"
+                    @keydown.enter.prevent="loadFromQuery()"
+                    @keydown.escape.prevent="suggestions = []"
+                    placeholder="Search characters or teams"
+                    class="w-full rounded-lg border border-gray-700 bg-gray-900 px-4 py-2.5 text-gray-100 outline-none transition-shadow focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30"
+                    autocomplete="off"
+                >
+
+                <div
+                    x-show="suggestions.length > 0"
+                    x-cloak
+                    class="absolute left-0 right-0 top-full z-40 mt-2 max-h-80 overflow-y-auto rounded-lg border border-gray-700 bg-gray-900 shadow-2xl"
+                >
+                    <template x-for="item in filteredSuggestions()" :key="`${item.type}:${item.name}`">
+                        <button
+                            type="button"
+                            class="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-gray-800"
+                            @click="selectSuggestion(item)"
+                        >
+                            <span class="min-w-0 truncate font-semibold text-white" x-text="item.name"></span>
+                            <span
+                                class="rounded-full border px-2 py-0.5 text-[11px] font-bold uppercase tracking-wide"
+                                :class="item.type === 'character' ? 'border-blue-500/40 text-blue-300' : 'border-green-500/40 text-green-300'"
+                                x-text="item.type"
+                            ></span>
+                        </button>
+                    </template>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <template x-if="loading">
+        <div class="flex justify-center py-16">
+            <div class="h-12 w-12 animate-spin rounded-full border-b-2 border-blue-500"></div>
+        </div>
+    </template>
+
+    <template x-if="error && !loading">
+        <section class="rounded-lg border border-gray-700 bg-gray-800 p-8 text-center shadow-xl">
+            <h2 class="text-2xl font-black text-white">Timeline Not Found</h2>
+            <p class="mt-2 text-gray-400" x-text="error"></p>
+        </section>
+    </template>
+
+    <template x-if="!timeline && !loading && !error">
+        <section class="rounded-lg border border-gray-700 bg-gray-800 p-8 shadow-xl">
+            <h2 class="text-2xl font-black text-white">Choose a Character or Team</h2>
+            <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-400">
+                Timelines are built from tagged issues in your library, with reading lists, collections, and story arcs added as context when those metadata fields are present.
+            </p>
+        </section>
+    </template>
+
+    <template x-if="timeline && !loading">
+        <div class="space-y-8">
+            <section class="grid grid-cols-2 gap-3 md:grid-cols-4 lg:grid-cols-6">
+                <div class="rounded-lg border border-gray-700 bg-gray-800 p-4">
+                    <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Issues</div>
+                    <div class="mt-1 text-2xl font-black text-white" x-text="timeline.summary.total_issues"></div>
+                </div>
+                <div class="rounded-lg border border-gray-700 bg-gray-800 p-4">
+                    <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Years</div>
+                    <div class="mt-1 text-2xl font-black text-white" x-text="yearRange()"></div>
+                </div>
+                <div class="rounded-lg border border-gray-700 bg-gray-800 p-4">
+                    <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Series</div>
+                    <div class="mt-1 text-2xl font-black text-white" x-text="timeline.summary.series_count"></div>
+                </div>
+                <div class="rounded-lg border border-gray-700 bg-gray-800 p-4">
+                    <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Story Arcs</div>
+                    <div class="mt-1 text-2xl font-black text-white" x-text="timeline.summary.story_arc_count"></div>
+                </div>
+                <div class="rounded-lg border border-gray-700 bg-gray-800 p-4">
+                    <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Reading Lists</div>
+                    <div class="mt-1 text-2xl font-black text-white" x-text="timeline.summary.reading_list_count"></div>
+                </div>
+                <div class="rounded-lg border border-gray-700 bg-gray-800 p-4">
+                    <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Undated</div>
+                    <div class="mt-1 text-2xl font-black text-white" x-text="timeline.summary.undated_issues"></div>
+                </div>
+            </section>
+
+            <section class="rounded-lg border border-gray-700 bg-gray-800 p-5 shadow-xl" x-show="hasMilestones()">
+                <div class="mb-4 flex items-center justify-between gap-4">
+                    <h2 class="text-xl font-black text-white">Milestones</h2>
+                    <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Derived Metadata</span>
+                </div>
+
+                <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                    <template x-if="timeline.milestones.first_issue">
+                        <a :href="comicUrl(timeline.milestones.first_issue)" class="rounded-lg border border-blue-500/30 bg-blue-950/20 p-4 transition-colors hover:border-blue-400/70">
+                            <div class="text-xs font-bold uppercase tracking-wide text-blue-300">First in Library</div>
+                            <div class="mt-2 font-bold text-white" x-text="issueLabel(timeline.milestones.first_issue)"></div>
+                            <div class="mt-1 text-sm text-gray-400" x-text="timeline.milestones.first_issue.date_label || 'Undated'"></div>
+                        </a>
+                    </template>
+
+                    <template x-if="timeline.milestones.latest_issue">
+                        <a :href="comicUrl(timeline.milestones.latest_issue)" class="rounded-lg border border-cyan-500/30 bg-cyan-950/20 p-4 transition-colors hover:border-cyan-400/70">
+                            <div class="text-xs font-bold uppercase tracking-wide text-cyan-300">Latest in Library</div>
+                            <div class="mt-2 font-bold text-white" x-text="issueLabel(timeline.milestones.latest_issue)"></div>
+                            <div class="mt-1 text-sm text-gray-400" x-text="timeline.milestones.latest_issue.date_label || 'Undated'"></div>
+                        </a>
+                    </template>
+
+                    <template x-for="item in spotlightMilestones()" :key="`${item.kind}:${item.name}`">
+                        <a :href="milestoneUrl(item)" class="rounded-lg border border-gray-700 bg-gray-900/70 p-4 transition-colors hover:border-blue-500/60">
+                            <div class="text-xs font-bold uppercase tracking-wide text-gray-500" x-text="item.kind"></div>
+                            <div class="mt-2 truncate font-bold text-white" x-text="item.name"></div>
+                            <div class="mt-1 text-sm text-gray-400" x-text="issueLabel(item.comic)"></div>
+                        </a>
+                    </template>
+                </div>
+            </section>
+
+            <section class="rounded-lg border border-gray-700 bg-gray-800/70 p-4 text-sm text-gray-400" x-show="timelineMode() === 'decades'">
+                This timeline spans <span class="font-semibold text-gray-200" x-text="timeline.years.length"></span> distinct years, so Parker is grouping it by decade.
+            </section>
+
+            <template x-if="timelineMode() === 'years'">
+                <section class="space-y-6">
+                    <template x-for="year in timeline.years" :key="year.year">
+                        <div class="grid gap-4 md:grid-cols-[7rem_minmax(0,1fr)]">
+                            <div class="md:text-right">
+                                <div class="sticky top-24 text-3xl font-black text-white" x-text="year.year"></div>
+                                <div class="mt-1 text-sm text-gray-500">
+                                    <span x-text="year.issue_count"></span>
+                                    <span x-text="year.issue_count === 1 ? 'issue' : 'issues'"></span>
+                                </div>
+                            </div>
+
+                            <div class="space-y-3 border-l border-gray-700 pl-4">
+                                <template x-for="entry in year.entries" :key="entry.id">
+                                    <a :href="comicUrl(entry)" data-timeline-entry-card class="group grid gap-3 rounded-lg border border-gray-700 bg-gray-800 p-3 transition-colors hover:border-blue-500/60 hover:bg-gray-800/90 sm:grid-cols-[4.5rem_minmax(0,1fr)]">
+                                        <img
+                                            :src="window.parker.url(entry.thumbnail_path)"
+                                            :alt="issueLabel(entry)"
+                                            class="aspect-[2/3] w-16 rounded-md object-cover"
+                                            loading="lazy"
+                                        >
+                                        <div class="min-w-0">
+                                            <div class="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                                                <h3 class="truncate font-black text-white group-hover:text-blue-200" x-text="issueLabel(entry)"></h3>
+                                                <span class="text-sm font-semibold text-gray-400" x-text="entry.date_label || year.year"></span>
+                                            </div>
+                                            <p class="mt-1 truncate text-sm text-gray-400" x-show="entry.title" x-text="entry.title"></p>
+                                            <div class="mt-3 flex flex-wrap gap-2">
+                                            <template x-if="entry.story_arc">
+                                                {{ context_pill('story_arc', 'entry.story_arc') }}
+                                            </template>
+                                            <template x-if="showSeriesGroup(entry)">
+                                                {{ context_pill('series_group', 'entry.series_group') }}
+                                            </template>
+                                            <template x-for="readingList in entry.reading_lists" :key="`rl-${entry.id}-${readingList.id}`">
+                                                {{ context_pill('reading_list', '`${readingList.name} #${formatPosition(readingList.position)}`') }}
+                                            </template>
+                                            <template x-for="collection in visibleCollections(entry)" :key="`col-${entry.id}-${collection.id}`">
+                                                {{ context_pill('collection', 'collection.name') }}
+                                            </template>
+                                            </div>
+                                        </div>
+                                    </a>
+                                </template>
+
+                                <div x-show="year.hidden_count > 0" class="rounded-lg border border-gray-700 bg-gray-900 px-4 py-3 text-sm text-gray-400">
+                                    <span x-text="year.hidden_count"></span>
+                                    more matching
+                                    <span x-text="year.hidden_count === 1 ? 'issue' : 'issues'"></span>
+                                    in <span x-text="year.year"></span>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                </section>
+            </template>
+
+            <template x-if="timelineMode() === 'decades'">
+                <section class="space-y-4">
+                    <template x-for="decade in decadeGroups()" :key="decade.key">
+                        <div class="rounded-lg border border-gray-700 bg-gray-800 shadow-xl">
+                        <button
+                            type="button"
+                            class="flex w-full flex-col gap-3 p-5 text-left transition-colors hover:bg-gray-700/40 sm:flex-row sm:items-center sm:justify-between"
+                            @click="toggleDecade(decade.key)"
+                        >
+                            <div>
+                                <div class="text-3xl font-black text-white" x-text="decade.label"></div>
+                                <div class="mt-1 text-sm text-gray-400">
+                                    <span x-text="decade.issue_count"></span>
+                                    <span x-text="decade.issue_count === 1 ? 'issue' : 'issues'"></span>
+                                    across
+                                    <span x-text="decade.year_count"></span>
+                                    <span x-text="decade.year_count === 1 ? 'year' : 'years'"></span>
+                                </div>
+                            </div>
+
+                            <div class="flex items-center gap-3">
+                                <span class="rounded-full border border-gray-600 bg-gray-900 px-3 py-1 text-xs font-bold uppercase tracking-wide text-gray-300">
+                                    <span x-text="decade.first_year"></span>-<span x-text="decade.last_year"></span>
+                                </span>
+                                <span class="text-sm font-bold text-blue-300" x-text="isDecadeExpanded(decade.key) ? 'Collapse' : 'Expand'"></span>
+                            </div>
+                        </button>
+
+                        <div x-show="isDecadeExpanded(decade.key)" x-collapse class="border-t border-gray-700 p-4">
+                            <div class="space-y-6">
+                                <template x-for="year in decade.years" :key="`${decade.key}-${year.year}`">
+                                    <div class="grid gap-4 md:grid-cols-[7rem_minmax(0,1fr)]">
+                                        <div class="md:text-right">
+                                            <div class="text-2xl font-black text-white" x-text="year.year"></div>
+                                            <div class="mt-1 text-sm text-gray-500">
+                                                <span x-text="year.issue_count"></span>
+                                                <span x-text="year.issue_count === 1 ? 'issue' : 'issues'"></span>
+                                            </div>
+                                        </div>
+
+                                        <div class="space-y-3 border-l border-gray-700 pl-4">
+                                            <template x-for="entry in year.entries" :key="entry.id">
+                                                <a :href="comicUrl(entry)" data-timeline-entry-card class="group grid gap-3 rounded-lg border border-gray-700 bg-gray-900/70 p-3 transition-colors hover:border-blue-500/60 sm:grid-cols-[4.5rem_minmax(0,1fr)]">
+                                                    <img
+                                                        :src="window.parker.url(entry.thumbnail_path)"
+                                                        :alt="issueLabel(entry)"
+                                                        class="aspect-[2/3] w-16 rounded-md object-cover"
+                                                        loading="lazy"
+                                                    >
+                                                    <div class="min-w-0">
+                                                        <div class="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                                                            <h3 class="truncate font-black text-white group-hover:text-blue-200" x-text="issueLabel(entry)"></h3>
+                                                            <span class="text-sm font-semibold text-gray-400" x-text="entry.date_label || year.year"></span>
+                                                        </div>
+                                                        <p class="mt-1 truncate text-sm text-gray-400" x-show="entry.title" x-text="entry.title"></p>
+                                                        <div class="mt-3 flex flex-wrap gap-2">
+                                                            <template x-if="entry.story_arc">
+                                                                {{ context_pill('story_arc', 'entry.story_arc') }}
+                                                            </template>
+                                                            <template x-if="showSeriesGroup(entry)">
+                                                                {{ context_pill('series_group', 'entry.series_group') }}
+                                                            </template>
+                                                            <template x-for="readingList in entry.reading_lists" :key="`decade-rl-${entry.id}-${readingList.id}`">
+                                                                {{ context_pill('reading_list', '`${readingList.name} #${formatPosition(readingList.position)}`') }}
+                                                            </template>
+                                                            <template x-for="collection in visibleCollections(entry)" :key="`decade-col-${entry.id}-${collection.id}`">
+                                                                {{ context_pill('collection', 'collection.name') }}
+                                                            </template>
+                                                        </div>
+                                                    </div>
+                                                </a>
+                                            </template>
+
+                                            <div x-show="year.hidden_count > 0" class="rounded-lg border border-gray-700 bg-gray-900 px-4 py-3 text-sm text-gray-400">
+                                                <span x-text="year.hidden_count"></span>
+                                                more matching
+                                                <span x-text="year.hidden_count === 1 ? 'issue' : 'issues'"></span>
+                                                in <span x-text="year.year"></span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+                        </div>
+                        </div>
+                    </template>
+                </section>
+            </template>
+
+            <section class="rounded-lg border border-gray-700 bg-gray-800 p-5 shadow-xl" x-show="timeline.undated_entries.length > 0">
+                <h2 class="text-xl font-black text-white">Undated Issues</h2>
+                <div class="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                    <template x-for="entry in timeline.undated_entries" :key="entry.id">
+                        <a :href="comicUrl(entry)" class="rounded-lg border border-gray-700 bg-gray-900 p-3 transition-colors hover:border-blue-500/60">
+                            <div class="font-bold text-white" x-text="issueLabel(entry)"></div>
+                            <div class="mt-1 truncate text-sm text-gray-400" x-text="entry.title || 'No title metadata'"></div>
+                        </a>
+                    </template>
+                </div>
+            </section>
+        </div>
+    </template>
+</div>
+
+<script>
+function libraryTimeline() {
+    return {
+        subjectType: 'character',
+        query: '',
+        suggestions: [],
+        timeline: null,
+        loading: false,
+        error: null,
+        expandedDecades: {},
+        yearModeThreshold: 12,
+
+        init() {
+            const params = new URLSearchParams(window.location.search);
+            const type = params.get('type');
+            const name = params.get('name');
+            if (type === 'character' || type === 'team') {
+                this.subjectType = type;
+            }
+            if (name) {
+                this.query = name;
+                this.loadTimeline(type || this.subjectType, name, false);
+            }
+        },
+
+        setSubjectType(type) {
+            if (this.subjectType === type) return;
+            this.subjectType = type;
+            this.query = '';
+            this.suggestions = [];
+            this.error = null;
+        },
+
+        filteredSuggestions() {
+            return this.suggestions.filter((item) => item.type === this.subjectType);
+        },
+
+        async fetchSuggestions() {
+            if (this.query.trim().length < 2) {
+                this.suggestions = [];
+                return;
+            }
+
+            const url = window.parker.route(
+                'timelines.suggestions',
+                {},
+                `q=${encodeURIComponent(this.query.trim())}&limit=12`
+            );
+            const res = await fetch(url);
+            this.suggestions = res.ok ? await res.json() : [];
+        },
+
+        selectSuggestion(item) {
+            this.subjectType = item.type;
+            this.query = item.name;
+            this.suggestions = [];
+            this.loadTimeline(item.type, item.name, true);
+        },
+
+        loadFromQuery() {
+            const value = this.query.trim();
+            if (!value) return;
+            this.suggestions = [];
+            this.loadTimeline(this.subjectType, value, true);
+        },
+
+        async loadTimeline(type, name, pushState = true) {
+            this.loading = true;
+            this.error = null;
+            this.timeline = null;
+            this.expandedDecades = {};
+            this.subjectType = type === 'team' ? 'team' : 'character';
+            this.query = name;
+
+            try {
+                const url = window.parker.route(
+                    'timelines.detail',
+                    {},
+                    `type=${encodeURIComponent(this.subjectType)}&name=${encodeURIComponent(name)}`
+                );
+                const res = await fetch(url);
+                if (!res.ok) {
+                    this.error = 'No visible tagged issues were found for that subject.';
+                    return;
+                }
+
+                this.timeline = await res.json();
+                document.title = `${this.timeline.subject.name} Timeline - Parker`;
+
+                if (pushState) {
+                    const pageUrl = window.parker.route(
+                        'pages.timelines',
+                        {},
+                        `type=${encodeURIComponent(this.subjectType)}&name=${encodeURIComponent(name)}`
+                    );
+                    window.history.pushState({}, '', pageUrl);
+                }
+            } catch (e) {
+                console.error(e);
+                this.error = 'Unable to load this timeline.';
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        yearRange() {
+            const start = this.timeline?.summary?.start_year;
+            const end = this.timeline?.summary?.end_year;
+            if (!start && !end) return '--';
+            if (start === end) return `${start}`;
+            return `${start}-${end}`;
+        },
+
+        timelineMode() {
+            const yearCount = this.timeline?.years?.length || 0;
+            return yearCount > this.yearModeThreshold ? 'decades' : 'years';
+        },
+
+        decadeGroups() {
+            const grouped = {};
+            for (const year of this.timeline?.years || []) {
+                const decadeStart = Math.floor(Number(year.year) / 10) * 10;
+                const key = `${decadeStart}s`;
+                if (!grouped[key]) {
+                    grouped[key] = {
+                        key,
+                        label: key,
+                        first_year: year.year,
+                        last_year: year.year,
+                        year_count: 0,
+                        issue_count: 0,
+                        years: [],
+                    };
+                }
+
+                grouped[key].years.push(year);
+                grouped[key].year_count += 1;
+                grouped[key].issue_count += year.issue_count;
+                grouped[key].first_year = Math.min(grouped[key].first_year, year.year);
+                grouped[key].last_year = Math.max(grouped[key].last_year, year.year);
+            }
+
+            return Object.values(grouped).sort((a, b) => a.first_year - b.first_year);
+        },
+
+        isDecadeExpanded(key) {
+            return !!this.expandedDecades[key];
+        },
+
+        toggleDecade(key) {
+            this.expandedDecades = {
+                ...this.expandedDecades,
+                [key]: !this.expandedDecades[key],
+            };
+        },
+
+        matchingIssuesUrl() {
+            if (!this.timeline) return window.parker.route('pages.search');
+            return window.parker.searchHandoff.buildUrl({
+                match: 'all',
+                sortBy: 'year',
+                sortOrder: 'asc',
+                filters: [{
+                    field: this.timeline.subject.type,
+                    operator: 'contains',
+                    value: [this.timeline.subject.name]
+                }]
+            });
+        },
+
+        comicUrl(entry) {
+            return window.parker.route('pages.comic_detail', { comic_id: entry.id });
+        },
+
+        milestoneUrl(item) {
+            if (item.kind === 'Reading List' && item.id) {
+                return window.parker.route('pages.reading_list_detail', { reading_list_id: item.id });
+            }
+            if (item.kind === 'Collection' && item.id) {
+                return window.parker.route('pages.collection_detail', { collection_id: item.id });
+            }
+            return this.comicUrl(item.comic);
+        },
+
+        issueLabel(entry) {
+            const number = entry.number ? ` #${entry.number}` : '';
+            return `${entry.series}${number}`;
+        },
+
+        formatPosition(position) {
+            const value = Number(position);
+            return Number.isInteger(value) ? value.toString() : value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
+        },
+
+        normalizedContextName(value) {
+            return String(value || '').trim().toLowerCase();
+        },
+
+        visibleCollections(entry) {
+            return entry?.collections || [];
+        },
+
+        showSeriesGroup(entry) {
+            const seriesGroup = this.normalizedContextName(entry?.series_group);
+            if (!seriesGroup) return false;
+            return !(entry?.collections || []).some(
+                (collection) => this.normalizedContextName(collection.name) === seriesGroup
+            );
+        },
+
+        hasMilestones() {
+            return !!(
+                this.timeline?.milestones?.first_issue ||
+                this.timeline?.milestones?.latest_issue ||
+                this.spotlightMilestones().length
+            );
+        },
+
+        spotlightMilestones() {
+            if (!this.timeline) return [];
+            const rows = [];
+            for (const item of this.timeline.milestones.first_story_arcs || []) {
+                rows.push({ kind: 'Story Arc', name: item.name, comic: item.comic });
+            }
+            for (const item of this.timeline.milestones.first_reading_lists || []) {
+                rows.push({ kind: 'Reading List', id: item.id, name: item.name, comic: item.comic });
+            }
+            for (const item of this.timeline.milestones.first_collections || []) {
+                rows.push({ kind: 'Collection', id: item.id, name: item.name, comic: item.comic });
+            }
+            return rows.slice(0, 6);
+        },
+    };
+}
+</script>
+{% endblock %}

--- a/docs/releases/0.1.23.md
+++ b/docs/releases/0.1.23.md
@@ -9,6 +9,8 @@ Status: Draft
 - Comic detail pages now surface saved bookmarks in the left action rail so readers can jump straight back into notable pages outside the reader itself.
 - Story arcs now launch the reader with an explicit `story_arc` context so in-reader previous/next book navigation follows exact arc metadata membership.
 - Added an appearance setting, `ui.auto_redirect_single_volume_series`, that can open single-volume series directly on their volume detail page.
+- Added Library Timeline pages for character and team tags, generated from embedded comic metadata with story arc, reading list, collection, and series-group context.
+- Added timeline autocomplete and deep-linkable timeline routes so character and team tag chips can open chronology views directly from comic detail and quick search.
 
 ## Changed
 
@@ -23,6 +25,10 @@ Status: Draft
 - Series page navigation can now collapse one-volume series into the volume page when the new setting is enabled, while multi-volume series continue to land on the series page.
 - Volume detail breadcrumbs now use `?show_series=1` when linking back to the parent series so users can still reach the series shell even when single-volume redirects are enabled.
 - Single-volume redirect checks now use the cached settings helper and an indexed `volumes.series_id` lookup to keep series page navigation cheap.
+- Character and team chips now open Library Timeline by default, with a prominent Advanced Search handoff preserved for exhaustive issue results.
+- Timeline subject type switching now clears pending autocomplete text so character and team searches do not leak into each other.
+- Timeline issue rows now cap visible entries per year and switch longer histories into expandable decade groups when a subject spans more than 12 distinct dated years.
+- Timeline context badges now use shared story arc, reading list, collection, and series-group pill styling for consistent metadata color semantics.
 
 ## Fixed
 
@@ -35,6 +41,7 @@ Status: Draft
 - Fixed stack detail pages so the `Details` tab now renders the full aggregated metadata already returned by the API, including pencillers, characters, teams, and locations instead of only showing writers.
 - Fixed comic detail tag sections so character, team, location, and genre chips now render in alphabetical order to match the rest of the app's detail pages.
 - Fixed the potential breadcrumb redirect loop introduced by single-volume series collapsing by adding an explicit series-page escape hatch.
+- Fixed timeline context badges so generated collections no longer duplicate matching raw `series_group` badges on the same issue row.
 
 ## Validation
 
@@ -53,3 +60,8 @@ Status: Draft
 - Elevated API verification passed: `tests/api/test_pages.py tests/api/test_settings.py`.
 - Elevated browser verification passed: `tests/browser/test_saved_search_pull_list_and_session_flows.py -k "comic_detail_add_to_existing_pull_list_then_edit_and_remove_item or comic_detail_shows_existing_stack_membership"`.
 - Elevated browser verification passed: `tests/browser/test_saved_search_pull_list_and_session_flows.py -k comic_detail_completed_issue_shows_read_again`.
+- Elevated API verification passed: `tests/api/test_timelines.py`.
+- Elevated browser verification passed: `tests/browser/test_navigation_smoke.py -k timeline`.
+- Elevated API and route verification passed: `tests/api/test_search_api.py tests/core/test_route_map.py`.
+- Python syntax verification passed: `py_compile app/api/timelines.py`.
+- Whitespace verification passed: `git diff --check` with only expected CRLF warnings.

--- a/docs/releases/0.1.23.md
+++ b/docs/releases/0.1.23.md
@@ -9,7 +9,7 @@ Status: Draft
 - Comic detail pages now surface saved bookmarks in the left action rail so readers can jump straight back into notable pages outside the reader itself.
 - Story arcs now launch the reader with an explicit `story_arc` context so in-reader previous/next book navigation follows exact arc metadata membership.
 - Added an appearance setting, `ui.auto_redirect_single_volume_series`, that can open single-volume series directly on their volume detail page.
-- Added Library Timeline pages for character and team tags, generated from embedded comic metadata with story arc, reading list, collection, and series-group context.
+- Added Library Timeline pages for character and team tags, generated from embedded comic metadata with story arc, reading list, and collection context.
 - Added timeline autocomplete and deep-linkable timeline routes so character and team tag chips can open chronology views directly from comic detail and quick search.
 
 ## Changed
@@ -28,7 +28,7 @@ Status: Draft
 - Character and team chips now open Library Timeline by default, with a prominent Advanced Search handoff preserved for exhaustive issue results.
 - Timeline subject type switching now clears pending autocomplete text so character and team searches do not leak into each other.
 - Timeline issue rows now cap visible entries per year and switch longer histories into expandable decade groups when a subject spans more than 12 distinct dated years.
-- Timeline context badges now use shared story arc, reading list, collection, and series-group pill styling for consistent metadata color semantics.
+- Timeline context badges now use shared story arc, reading list, and collection pill styling for consistent metadata color semantics.
 
 ## Fixed
 
@@ -41,7 +41,7 @@ Status: Draft
 - Fixed stack detail pages so the `Details` tab now renders the full aggregated metadata already returned by the API, including pencillers, characters, teams, and locations instead of only showing writers.
 - Fixed comic detail tag sections so character, team, location, and genre chips now render in alphabetical order to match the rest of the app's detail pages.
 - Fixed the potential breadcrumb redirect loop introduced by single-volume series collapsing by adding an explicit series-page escape hatch.
-- Fixed timeline context badges so generated collections no longer duplicate matching raw `series_group` badges on the same issue row.
+- Fixed timeline context badges so metadata-backed collections do not duplicate a second raw metadata badge on the same issue row.
 
 ## Validation
 

--- a/tests/api/test_timelines.py
+++ b/tests/api/test_timelines.py
@@ -1,0 +1,227 @@
+from app.models.collection import Collection, CollectionItem
+from app.models.comic import Comic, Volume
+from app.models.library import Library
+from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.series import Series
+from app.models.tags import Character, Team
+
+
+def _comic(
+    volume,
+    *,
+    number: str,
+    title: str,
+    year: int | None = None,
+    month: int | None = None,
+    day: int | None = None,
+    story_arc: str | None = None,
+    series_group: str | None = None,
+    age_rating: str | None = None,
+) -> Comic:
+    slug = title.lower().replace(" ", "-").replace("#", "")
+    return Comic(
+        volume=volume,
+        number=number,
+        title=title,
+        year=year,
+        month=month,
+        day=day,
+        story_arc=story_arc,
+        series_group=series_group,
+        age_rating=age_rating,
+        filename=f"{slug}.cbz",
+        file_path=f"/tmp/{slug}.cbz",
+        page_count=22,
+    )
+
+
+def _seed_timeline_fixture(db, normal_user):
+    library = Library(name="Timeline Library", path="/tmp/timeline-library")
+    hidden_library = Library(name="Hidden Timeline Library", path="/tmp/hidden-timeline-library")
+    db.add_all([library, hidden_library])
+    db.flush()
+
+    action = Series(name="Action Timeline", library=library)
+    adventures = Series(name="Adventures Timeline", library=library)
+    hidden_series = Series(name="Hidden Timeline", library=hidden_library)
+    db.add_all([action, adventures, hidden_series])
+    db.flush()
+
+    action_volume = Volume(series=action, volume_number=1)
+    adventures_volume = Volume(series=adventures, volume_number=1)
+    hidden_volume = Volume(series=hidden_series, volume_number=1)
+    db.add_all([action_volume, adventures_volume, hidden_volume])
+    db.flush()
+
+    issue_one = _comic(
+        action_volume,
+        number="1",
+        title="Timeline Dawn",
+        year=1938,
+        month=6,
+        day=1,
+        series_group="Golden Age",
+        age_rating="Teen",
+    )
+    issue_two = _comic(
+        adventures_volume,
+        number="436",
+        title="Timeline Millennium",
+        year=1988,
+        month=1,
+        story_arc="Millennium",
+        age_rating="Teen",
+    )
+    issue_three = _comic(
+        action_volume,
+        number="999",
+        title="Timeline Undated",
+        age_rating="Teen",
+    )
+    hidden_issue = _comic(
+        hidden_volume,
+        number="1",
+        title="Timeline Hidden",
+        year=1999,
+        age_rating="Teen",
+    )
+    db.add_all([issue_one, issue_two, issue_three, hidden_issue])
+    db.flush()
+
+    hero = Character(name="Timeline Hero")
+    team = Team(name="Timeline Team")
+    db.add_all([hero, team])
+    db.flush()
+
+    for comic in [issue_one, issue_two, issue_three, hidden_issue]:
+        comic.characters.append(hero)
+    issue_two.teams.append(team)
+
+    event = ReadingList(name="Timeline Event", description="ordered event")
+    collection = Collection(name="Timeline Collection", description="group")
+    db.add_all([event, collection])
+    db.flush()
+
+    db.add_all(
+        [
+            ReadingListItem(reading_list_id=event.id, comic_id=issue_two.id, position=12),
+            CollectionItem(collection_id=collection.id, comic_id=issue_one.id),
+        ]
+    )
+
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    return {
+        "library": library,
+        "hero": hero,
+        "team": team,
+        "issue_one": issue_one,
+        "issue_two": issue_two,
+        "issue_three": issue_three,
+        "hidden_issue": hidden_issue,
+    }
+
+
+def test_character_timeline_orders_issues_and_adds_metadata_context(auth_client, db, normal_user):
+    data = _seed_timeline_fixture(db, normal_user)
+
+    response = auth_client.get("/api/timelines?type=character&name=Timeline%20Hero")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["subject"] == {"type": "character", "name": "Timeline Hero"}
+    assert payload["summary"]["total_issues"] == 3
+    assert payload["summary"]["dated_issues"] == 2
+    assert payload["summary"]["undated_issues"] == 1
+    assert payload["summary"]["series_count"] == 2
+    assert payload["summary"]["story_arc_count"] == 1
+    assert payload["summary"]["reading_list_count"] == 1
+    assert payload["summary"]["collection_count"] == 1
+    assert payload["summary"]["start_year"] == 1938
+    assert payload["summary"]["end_year"] == 1988
+
+    assert [group["year"] for group in payload["years"]] == [1938, 1988]
+    assert payload["years"][0]["entries"][0]["id"] == data["issue_one"].id
+    assert payload["years"][0]["entries"][0]["collections"][0]["name"] == "Timeline Collection"
+    assert payload["years"][1]["entries"][0]["id"] == data["issue_two"].id
+    assert payload["years"][1]["entries"][0]["story_arc"] == "Millennium"
+    assert payload["years"][1]["entries"][0]["reading_lists"][0]["name"] == "Timeline Event"
+    assert payload["years"][1]["entries"][0]["reading_lists"][0]["position"] == 12
+    assert payload["undated_entries"][0]["id"] == data["issue_three"].id
+
+    assert payload["milestones"]["first_issue"]["id"] == data["issue_one"].id
+    assert payload["milestones"]["latest_issue"]["id"] == data["issue_two"].id
+    assert payload["milestones"]["first_story_arcs"][0]["name"] == "Millennium"
+    assert payload["milestones"]["first_reading_lists"][0]["name"] == "Timeline Event"
+    assert payload["milestones"]["first_reading_lists"][0]["id"]
+    assert payload["milestones"]["first_collections"][0]["name"] == "Timeline Collection"
+    assert payload["milestones"]["first_collections"][0]["id"]
+
+
+def test_team_timeline_supports_team_subjects(auth_client, db, normal_user):
+    data = _seed_timeline_fixture(db, normal_user)
+
+    response = auth_client.get("/api/timelines?type=team&name=Timeline%20Team")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["subject"] == {"type": "team", "name": "Timeline Team"}
+    assert payload["summary"]["total_issues"] == 1
+    assert payload["years"][0]["entries"][0]["id"] == data["issue_two"].id
+
+
+def test_timeline_suggestions_are_scoped_to_visible_character_and_team_tags(auth_client, db, normal_user):
+    _seed_timeline_fixture(db, normal_user)
+
+    response = auth_client.get("/api/timelines/suggestions?q=Timeline")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert {"type": "character", "name": "Timeline Hero"} in payload
+    assert {"type": "team", "name": "Timeline Team"} in payload
+
+
+def test_timeline_respects_library_access_and_age_restrictions(auth_client, db, normal_user):
+    data = _seed_timeline_fixture(db, normal_user)
+
+    restricted_series = Series(name="Restricted Timeline", library=data["library"])
+    restricted_volume = Volume(series=restricted_series, volume_number=1)
+    restricted_issue = _comic(
+        restricted_volume,
+        number="1",
+        title="Timeline Restricted",
+        year=2000,
+        age_rating="Mature 17+",
+    )
+    restricted_issue.characters.append(data["hero"])
+    db.add_all([restricted_series, restricted_volume, restricted_issue])
+
+    normal_user.max_age_rating = "Teen"
+    normal_user.allow_unknown_age_ratings = False
+    db.commit()
+
+    response = auth_client.get("/api/timelines?type=character&name=Timeline%20Hero")
+
+    assert response.status_code == 200
+    payload = response.json()
+    ids = {
+        entry["id"]
+        for group in payload["years"]
+        for entry in group["entries"]
+    }
+    ids.update(entry["id"] for entry in payload["undated_entries"])
+
+    assert data["hidden_issue"].id not in ids
+    assert restricted_issue.id not in ids
+
+
+def test_timeline_rejects_non_mvp_subject_types(auth_client, db, normal_user):
+    _seed_timeline_fixture(db, normal_user)
+
+    response = auth_client.get("/api/timelines?type=location&name=Timeline%20City")
+
+    assert response.status_code == 422

--- a/tests/api/test_timelines.py
+++ b/tests/api/test_timelines.py
@@ -144,6 +144,7 @@ def test_character_timeline_orders_issues_and_adds_metadata_context(auth_client,
 
     assert [group["year"] for group in payload["years"]] == [1938, 1988]
     assert payload["years"][0]["entries"][0]["id"] == data["issue_one"].id
+    assert "series_group" not in payload["years"][0]["entries"][0]
     assert payload["years"][0]["entries"][0]["collections"][0]["name"] == "Timeline Collection"
     assert payload["years"][1]["entries"][0]["id"] == data["issue_two"].id
     assert payload["years"][1]["entries"][0]["story_arc"] == "Millennium"

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -83,6 +83,8 @@ def browser_seed_data(browser_db_factory):
         volume=volume,
         number="3",
         title="Smoke Horizon",
+        year=2024,
+        month=5,
         filename="smoke-horizon.cbz",
         file_path="/tmp/smoke-horizon.cbz",
         page_count=4,

--- a/tests/browser/test_navigation_smoke.py
+++ b/tests/browser/test_navigation_smoke.py
@@ -186,7 +186,7 @@ def test_timeline_subject_type_toggle_clears_search_input(page, browser_server):
 
 
 @pytest.mark.browser
-def test_timeline_entry_deduplicates_matching_series_group_and_collection_badges(page, browser_server):
+def test_timeline_entry_shows_series_group_metadata_as_one_collection_badge(page, browser_server):
     seed = browser_server["seed"]
     _add_duplicate_collection_context(browser_server)
 

--- a/tests/browser/test_navigation_smoke.py
+++ b/tests/browser/test_navigation_smoke.py
@@ -1,5 +1,49 @@
 import pytest
 
+from app.models.collection import Collection, CollectionItem
+from app.models.comic import Comic
+from app.models.tags import Character
+
+
+def _insert_decade_timeline_fixture(browser_server):
+    session = browser_server["db_factory"]()
+    try:
+        character = Character(name="Decade Smoke")
+        session.add(character)
+        session.flush()
+
+        volume_id = browser_server["seed"]["volume_id"]
+        for offset, year in enumerate(range(2000, 2013), start=1):
+            comic = Comic(
+                volume_id=volume_id,
+                number=str(100 + offset),
+                title=f"Decade Smoke {year}",
+                year=year,
+                filename=f"decade-smoke-{year}.cbz",
+                file_path=f"/tmp/decade-smoke-{year}.cbz",
+                page_count=3,
+            )
+            comic.characters.append(character)
+            session.add(comic)
+
+        session.commit()
+    finally:
+        session.close()
+
+
+def _add_duplicate_collection_context(browser_server):
+    session = browser_server["db_factory"]()
+    try:
+        comic = session.get(Comic, browser_server["seed"]["in_progress_comic_id"])
+        comic.series_group = "Smoke Group"
+        collection = Collection(name="Smoke Group", description="Generated from SeriesGroup")
+        session.add(collection)
+        session.flush()
+        session.add(CollectionItem(collection_id=collection.id, comic_id=comic.id))
+        session.commit()
+    finally:
+        session.close()
+
 
 @pytest.mark.browser
 def test_continue_reading_page_shows_in_progress_items_and_opens_reader(page, browser_server):
@@ -87,3 +131,96 @@ def test_quick_search_navigates_to_reading_list(page, browser_server):
 
     page.wait_for_url(f"**/reading-lists/{seed['reading_list_id']}")
     page.get_by_role("heading", name=seed["reading_list_name"]).wait_for()
+
+
+@pytest.mark.browser
+def test_library_timeline_deep_link_shows_character_history_and_search_handoff(page, browser_server):
+    seed = browser_server["seed"]
+    page.goto(
+        f"{browser_server['base_url']}/timelines?type=character&name=Captain%20Smoke",
+        wait_until="networkidle",
+    )
+
+    page.get_by_role("heading", name="Captain Smoke").wait_for()
+    page.get_by_text("Generated from metadata embedded in your comic files.").wait_for()
+    page.locator("h3").filter(has_text=f"{seed['series_name']} #{seed['in_progress_comic_number']}").wait_for()
+
+    page.get_by_role("link", name="View Matching Issues").click()
+
+    page.wait_for_url("**/search*")
+    page.get_by_role("heading", name="Advanced Search").wait_for()
+
+
+@pytest.mark.browser
+def test_character_tag_chip_opens_timeline_before_search_handoff(page, browser_server):
+    seed = browser_server["seed"]
+    page.goto(
+        f"{browser_server['base_url']}/comics/{seed['in_progress_comic_id']}",
+        wait_until="networkidle",
+    )
+
+    page.get_by_role("heading", name=f"{seed['series_name']} #{seed['in_progress_comic_number']}").wait_for()
+    page.get_by_role("link", name="Captain Smoke").click()
+
+    page.wait_for_url("**/timelines?type=character&name=Captain%20Smoke")
+    page.get_by_role("heading", name="Captain Smoke").wait_for()
+    page.locator("h3").filter(has_text=f"{seed['series_name']} #{seed['in_progress_comic_number']}").wait_for()
+
+    page.get_by_role("link", name="View Matching Issues").click()
+
+    page.wait_for_url("**/search*")
+    page.get_by_role("heading", name="Advanced Search").wait_for()
+
+
+@pytest.mark.browser
+def test_timeline_subject_type_toggle_clears_search_input(page, browser_server):
+    page.goto(f"{browser_server['base_url']}/timelines", wait_until="networkidle")
+
+    search_input = page.get_by_placeholder("Search characters or teams")
+    search_input.fill("Captain")
+
+    page.get_by_role("button", name="Team").click()
+
+    assert search_input.input_value() == ""
+    page.get_by_role("heading", name="Character and Team History").wait_for()
+
+
+@pytest.mark.browser
+def test_timeline_entry_deduplicates_matching_series_group_and_collection_badges(page, browser_server):
+    seed = browser_server["seed"]
+    _add_duplicate_collection_context(browser_server)
+
+    page.goto(
+        f"{browser_server['base_url']}/timelines?type=character&name=Captain%20Smoke",
+        wait_until="networkidle",
+    )
+
+    page.get_by_role("heading", name="Captain Smoke").wait_for()
+    row = page.locator("[data-timeline-entry-card]").filter(
+        has_text=f"{seed['series_name']} #{seed['in_progress_comic_number']}"
+    ).first
+    row.wait_for()
+
+    assert row.get_by_text("Smoke Group").count() == 1
+
+
+@pytest.mark.browser
+def test_library_timeline_groups_long_histories_by_decade(page, browser_server):
+    _insert_decade_timeline_fixture(browser_server)
+
+    page.goto(
+        f"{browser_server['base_url']}/timelines?type=character&name=Decade%20Smoke",
+        wait_until="networkidle",
+    )
+
+    page.get_by_role("heading", name="Decade Smoke").wait_for()
+    page.get_by_text("grouping it by decade").wait_for()
+    page.get_by_text("2000s").wait_for()
+    page.get_by_text("2010s").wait_for()
+
+    issue_heading = page.locator("h3").filter(has_text="Smoke Series #101")
+    assert issue_heading.count() == 0 or not issue_heading.first.is_visible()
+
+    page.get_by_role("button").filter(has_text="2000s").click()
+
+    issue_heading.first.wait_for()


### PR DESCRIPTION
Adds a new **Library Timeline** feature for character and team metadata tags. Users can open a timeline from character/team tag chips, quick search, or the new Insights entry, then review a chronological history generated entirely from embedded comic metadata.

## What Changed

- Added `/timelines` page with autocomplete and deep-link support for character/team timelines.
- Added `/api/timelines` endpoints for timeline data and subject suggestions.
- Character and team chips now open Library Timeline by default.
- Added a prominent **View Matching Issues** handoff back to Advanced Search.
- Timeline rows include story arc, reading list, collection, and series-group context.
- Reading list and collection milestone pills link to their container pages.
- Per-year issue listings are capped, with long histories grouped into expandable decades.
- Added shared context pill styling:
  - yellow = story arc
  - green = reading list
  - blue = collection
- Fixed duplicate context pills when a collection mirrors the raw `series_group` value.
- Switching between Character and Team clears pending autocomplete text.
- Updated README and `docs/releases/0.1.23.md`.

## Validation

- `tests/api/test_timelines.py`
- `tests/browser/test_navigation_smoke.py -k timeline`
- `tests/api/test_search_api.py tests/core/test_route_map.py`
- `py_compile app/api/timelines.py`
- `git diff --check`