### PR TITLE
Updates to Parker Social Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
 - **User System**
   - Multi‑library access with row‑level security
   - Age-rating-aware access control
+  - Anonymous Social Insights participation is enabled for new users by default, with an account-level opt-out
   - Avatar uploads
   - Hybrid authentication (JWT + secure cookies)
 
@@ -33,6 +34,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
 
 - **Discovery**
   - Netflix‑style home page with content rails
+  - Anonymous aggregate social insights such as reader counts and `Popular with Others`
   - `Continue Reading`, `Jump Back In`, `Trending`, and `New from Following`
   - Library Timeline for character and team histories generated from embedded metadata
   - Recommendations by creator or metadata

--- a/alembic/versions/2f4a9c8d1e3b_default_social_insights_opt_in.py
+++ b/alembic/versions/2f4a9c8d1e3b_default_social_insights_opt_in.py
@@ -1,0 +1,38 @@
+"""Default social insights to enabled for new users
+
+Revision ID: 2f4a9c8d1e3b
+Revises: e1d5f6a7b8c9
+Create Date: 2026-07-20 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2f4a9c8d1e3b"
+down_revision: Union[str, None] = "e1d5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.alter_column(
+            "share_progress_enabled",
+            existing_type=sa.Boolean(),
+            existing_nullable=False,
+            server_default=sa.true(),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("users", schema=None) as batch_op:
+        batch_op.alter_column(
+            "share_progress_enabled",
+            existing_type=sa.Boolean(),
+            existing_nullable=False,
+            server_default=sa.false(),
+        )

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -444,7 +444,7 @@ def get_trending(
         db.query(Series)
         .join(Volume).join(Comic).join(ReadingProgress)
         .join(User)
-        .filter(User.share_progress_enabled == True)
+        .filter(User.social_insights_enabled == True)
         .filter(ReadingProgress.user_id != current_user.id)
         .filter(ReadingProgress.last_read_at >= cutoff_date)
     )
@@ -597,7 +597,7 @@ def get_popular(
 ):
     """
     Get "Popular with Others" series based on other users' reading activity.
-    Respects the 'share_progress_enabled' privacy setting.
+    Respects the anonymous social insights preference.
     Secured for age rating
     """
 
@@ -607,7 +607,7 @@ def get_popular(
         db.query(Series)
         .join(Volume).join(Comic).join(ReadingProgress)
         .join(User)
-        .filter(User.share_progress_enabled == True)
+        .filter(User.social_insights_enabled == True)
         .filter(ReadingProgress.user_id != current_user.id) # Dont include ourselves
     )
 

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -81,11 +81,11 @@ class UserPasswordUpdateRequest(BaseModel):
 
 class UserPreferencesResponse(BaseModel):
     user_id: int
-    share_progress_enabled: bool
+    social_insights_enabled: bool
     monthly_reading_goal: int
 
 class UserPreferencesUpdateRequest(BaseModel):
-    share_progress_enabled: Optional[bool] = None
+    social_insights_enabled: Optional[bool] = None
     monthly_reading_goal: Optional[int] = Field(None, ge=1)
 
 
@@ -155,7 +155,8 @@ async def get_user_dashboard(db: SessionDep, current_user: CurrentUser):
         "user": {
             "username": current_user.username,
             "created_at": current_user.created_at,
-            "avatar_url": f"/api/users/{current_user.id}/avatar" if current_user.avatar_path else None
+            "avatar_url": f"/api/users/{current_user.id}/avatar" if current_user.avatar_path else None,
+            "social_insights_enabled": current_user.social_insights_enabled,
         },
         "pull_lists": [{"id": pl.id, "name": pl.name, "count": len(pl.items)} for pl in pull_lists],
         "continue_reading": continue_reading,
@@ -232,7 +233,7 @@ async def get_preferences(db: SessionDep, current_user: CurrentUser):
         raise HTTPException(status_code=404, detail="User not found")
 
     return {
-        "share_progress_enabled": user.share_progress_enabled,
+        "social_insights_enabled": user.social_insights_enabled,
         "monthly_reading_goal": current_user.monthly_reading_goal,
     }
 
@@ -242,8 +243,8 @@ async def update_preferences(payload: UserPreferencesUpdateRequest, db: SessionD
 
     have_settings_changed = False
 
-    if payload.share_progress_enabled is not None:
-        current_user.share_progress_enabled = payload.share_progress_enabled
+    if payload.social_insights_enabled is not None:
+        current_user.social_insights_enabled = payload.social_insights_enabled
         have_settings_changed = True
 
     if payload.monthly_reading_goal is not None:

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -20,7 +20,7 @@ class User(Base):
     username = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     avatar_path = Column(String, nullable=True)
-    share_progress_enabled = Column(Boolean, default=False)
+    social_insights_enabled = Column("share_progress_enabled", Boolean, default=True)
 
     max_age_rating = Column(String, nullable=True, default=None)
     allow_unknown_age_ratings = Column(Boolean, default=False)

--- a/app/services/social_insights.py
+++ b/app/services/social_insights.py
@@ -24,7 +24,7 @@ def get_visible_comic_reader_count(db: Session, comic_id: int) -> int | None:
         .join(User, User.id == ReadingProgress.user_id)
         .filter(ReadingProgress.comic_id == comic_id)
         .filter(ReadingProgress.completed == True)
-        .filter(User.share_progress_enabled == True)
+        .filter(User.social_insights_enabled == True)
         .scalar()
         or 0
     )
@@ -46,7 +46,7 @@ def get_visible_series_reader_count(db: Session, series_id: int) -> int | None:
         .join(Volume, Volume.id == Comic.volume_id)
         .filter(Volume.series_id == series_id)
         .filter(or_(ReadingProgress.completed == True, ReadingProgress.current_page > 0))
-        .filter(User.share_progress_enabled == True)
+        .filter(User.social_insights_enabled == True)
         .scalar()
         or 0
     )

--- a/app/templates/user/dashboard.html
+++ b/app/templates/user/dashboard.html
@@ -45,6 +45,36 @@
         </div>
     </template>
 
+    <template x-if="shouldShowSocialInsightsPrompt()" x-cloak>
+        <div class="rounded-xl border border-blue-500/30 bg-blue-950/30 p-5 shadow-xl">
+            <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div class="space-y-1">
+                    <div class="text-xs font-bold uppercase tracking-wider text-blue-300">Parker Social Insights</div>
+                    <h2 class="text-xl font-bold text-white">Help anonymous social rails feel more alive</h2>
+                    <p class="max-w-3xl text-sm text-gray-300">
+                        Parker can include your reading activity in anonymous aggregate features like reader counts and Popular with Others. No one sees your individual reading history.
+                    </p>
+                </div>
+                <div class="flex flex-col gap-2 sm:flex-row">
+                    <button
+                        type="button"
+                        x-on:click="enableSocialInsights()"
+                        class="rounded-full bg-blue-600 px-5 py-2.5 text-sm font-bold text-white transition-colors hover:bg-blue-500"
+                    >
+                        Enable Insights
+                    </button>
+                    <button
+                        type="button"
+                        x-on:click="dismissSocialInsightsPrompt()"
+                        class="rounded-full border border-gray-600 px-5 py-2.5 text-sm font-bold text-gray-300 transition-colors hover:border-gray-400 hover:text-white"
+                    >
+                        Not Now
+                    </button>
+                </div>
+            </div>
+        </div>
+    </template>
+
 
     <!-- User Header with Core Stats -->
     <div class="bg-gradient-to-br from-gray-800 to-gray-900 rounded-xl p-4 md:p-6 border border-gray-700 shadow-xl flex flex-col md:flex-row md:items-center gap-4 md:gap-6 relative overflow-hidden">
@@ -669,6 +699,7 @@ function dashboard() {
 
         // IMMEDIATE CHECK: Set the state synchronously during object creation
         bannerDismissed: localStorage.getItem('dismissed_review_year') == activeReviewYear,
+        socialInsightsPromptDismissed: localStorage.getItem('dismissed_social_insights_prompt') === 'true',
 
         async init() {
 
@@ -854,6 +885,35 @@ function dashboard() {
         dismissBanner() {
             this.bannerDismissed = true;
             localStorage.setItem('dismissed_review_year', this.reviewYear);
+        },
+
+        shouldShowSocialInsightsPrompt() {
+            return this.data?.user?.social_insights_enabled === false && !this.socialInsightsPromptDismissed;
+        },
+
+        async enableSocialInsights() {
+            try {
+                const res = await fetch(window.parker.route('users.update_preferences'), {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ social_insights_enabled: true })
+                });
+
+                if (!res.ok) throw new Error('Unable to update social insights preference');
+
+                this.data.user.social_insights_enabled = true;
+                this.socialInsightsPromptDismissed = true;
+                localStorage.removeItem('dismissed_social_insights_prompt');
+                window.parker.showToast("Social insights enabled", "success");
+            } catch (e) {
+                console.error(e);
+                window.parker.showToast("Failed to update setting", "error");
+            }
+        },
+
+        dismissSocialInsightsPrompt() {
+            this.socialInsightsPromptDismissed = true;
+            localStorage.setItem('dismissed_social_insights_prompt', 'true');
         }
 
     }

--- a/app/templates/user/settings.html
+++ b/app/templates/user/settings.html
@@ -18,7 +18,7 @@
                 <input
                     id="share_progress"
                     type="checkbox"
-                    x-model="preferences.share_progress_enabled"
+                    x-model="preferences.social_insights_enabled"
                     x-on:change="updatePreferences"
                     class="w-5 h-5 bg-gray-900 border-gray-600 rounded text-blue-600 focus:ring-blue-500 focus:ring-offset-gray-800"
                 >
@@ -29,6 +29,11 @@
                     Allow your reading activity to be anonymously included in community features like "Popular with Others"
                     and reader counts on comics and series. No one will see your individual reading history.
                 </p>
+                <template x-if="preferences.social_insights_enabled === false">
+                    <p class="mt-3 rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-sm text-blue-100">
+                        Parker's social rails work best when more readers contribute anonymous aggregate activity. You can turn this on or off anytime.
+                    </p>
+                </template>
             </div>
         </div>
     </div>
@@ -146,7 +151,7 @@ function userSettings() {
                     method: 'PATCH',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        share_progress_enabled: this.preferences.share_progress_enabled,
+                        social_insights_enabled: this.preferences.social_insights_enabled,
                         monthly_reading_goal: this.preferences.monthly_reading_goal
                     })
                 });
@@ -203,7 +208,7 @@ function userSettings() {
         revertValuesOnFail()
         {
             // Revert toggle if failed
-            this.preferences.share_progress_enabled = !this.preferences.share_progress_enabled;
+            this.preferences.social_insights_enabled = !this.preferences.social_insights_enabled;
         },
     }
 }

--- a/docs/releases/0.1.23.md
+++ b/docs/releases/0.1.23.md
@@ -11,6 +11,7 @@ Status: Draft
 - Added an appearance setting, `ui.auto_redirect_single_volume_series`, that can open single-volume series directly on their volume detail page.
 - Added Library Timeline pages for character and team tags, generated from embedded comic metadata with story arc, reading list, and collection context.
 - Added timeline autocomplete and deep-linkable timeline routes so character and team tag chips can open chronology views directly from comic detail and quick search.
+- Added a dashboard prompt for users who have anonymous Parker Social Insights disabled, with an inline action to opt into aggregate reader-count and social-rail features.
 
 ## Changed
 
@@ -29,6 +30,9 @@ Status: Draft
 - Timeline subject type switching now clears pending autocomplete text so character and team searches do not leak into each other.
 - Timeline issue rows now cap visible entries per year and switch longer histories into expandable decade groups when a subject spans more than 12 distinct dated years.
 - Timeline context badges now use shared story arc, reading list, and collection pill styling for consistent metadata color semantics.
+- Renamed the application-facing social participation preference from `share_progress_enabled` to `social_insights_enabled` while preserving the existing `users.share_progress_enabled` database column.
+- New users now default into anonymous Parker Social Insights, while existing users keep their current stored preference.
+- Account settings copy now more clearly explains that Parker Social Insights powers anonymous aggregate reader counts and social home rails.
 
 ## Fixed
 
@@ -69,3 +73,7 @@ Status: Draft
 - JavaScript syntax verification passed: `node --check static/js/app.js`.
 - Elevated API verification passed: `tests/api/test_auth.py tests/api/test_deps.py`.
 - Elevated browser verification passed: `tests/browser/test_saved_search_pull_list_and_session_flows.py -k "session_refresh_resyncs_access_cookie_before_navigation or idle_session_clears_instead_of_refreshing" -rs`.
+- Elevated API verification passed: `tests/api/test_users.py tests/api/test_comics.py::test_get_comic_detail_exposes_opted_in_completed_reader_count tests/api/test_series.py::test_series_detail_exposes_distinct_opted_in_reader_count tests/api/test_home.py`.
+- Elevated API verification passed: `tests/api/test_users.py`.
+- Alembic verification passed: `alembic heads` reports `2f4a9c8d1e3b (head)`.
+- In-memory SQLite migration verification passed: `DATABASE_URL=sqlite:///:memory: alembic upgrade head`.

--- a/tests/api/test_comics.py
+++ b/tests/api/test_comics.py
@@ -376,28 +376,28 @@ def test_get_comic_detail_exposes_opted_in_completed_reader_count(auth_client, d
         username="social-reader-a",
         email="social-reader-a@example.com",
         hashed_password="fakehash",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
         is_active=True,
     )
     reader_b = User(
         username="social-reader-b",
         email="social-reader-b@example.com",
         hashed_password="fakehash",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
         is_active=True,
     )
     hidden_reader = User(
         username="social-reader-hidden",
         email="social-reader-hidden@example.com",
         hashed_password="fakehash",
-        share_progress_enabled=False,
+        social_insights_enabled=False,
         is_active=True,
     )
     in_progress_only = User(
         username="social-reader-progress",
         email="social-reader-progress@example.com",
         hashed_password="fakehash",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
         is_active=True,
     )
     db.add_all([reader_a, reader_b, hidden_reader, in_progress_only])

--- a/tests/api/test_home.py
+++ b/tests/api/test_home.py
@@ -34,14 +34,14 @@ def _add_comic(db, volume: Volume, *, number: str, title: str, **kwargs):
     return comic
 
 
-def _add_user(db, *, username: str, email: str, share_progress_enabled: bool):
+def _add_user(db, *, username: str, email: str, social_insights_enabled: bool):
     user = User(
         username=username,
         email=email,
         hashed_password="x",
         is_superuser=False,
         is_active=True,
-        share_progress_enabled=share_progress_enabled,
+        social_insights_enabled=social_insights_enabled,
     )
     db.add(user)
     db.flush()
@@ -181,10 +181,10 @@ def test_home_top_parker_rated_orders_by_average_then_count(auth_client, db):
     lower = _add_comic(db, volume, number="1", title="Parker Lower")
     fourth = _add_comic(db, volume, number="4", title="Parker Fourth")
 
-    user_a = _add_user(db, username="parker-rater-a", email="parker-rater-a@example.com", share_progress_enabled=False)
-    user_b = _add_user(db, username="parker-rater-b", email="parker-rater-b@example.com", share_progress_enabled=False)
-    user_c = _add_user(db, username="parker-rater-c", email="parker-rater-c@example.com", share_progress_enabled=False)
-    user_d = _add_user(db, username="parker-rater-d", email="parker-rater-d@example.com", share_progress_enabled=False)
+    user_a = _add_user(db, username="parker-rater-a", email="parker-rater-a@example.com", social_insights_enabled=False)
+    user_b = _add_user(db, username="parker-rater-b", email="parker-rater-b@example.com", social_insights_enabled=False)
+    user_c = _add_user(db, username="parker-rater-c", email="parker-rater-c@example.com", social_insights_enabled=False)
+    user_d = _add_user(db, username="parker-rater-d", email="parker-rater-d@example.com", social_insights_enabled=False)
 
     db.add_all([
         UserComicRating(user_id=user_a.id, comic_id=top.id, rating=5),
@@ -220,9 +220,9 @@ def test_home_top_parker_rated_returns_empty_without_enough_qualifying_items(aut
     second = _add_comic(db, volume, number="2", title="Threshold Second")
     third = _add_comic(db, volume, number="3", title="Threshold Third")
 
-    user_a = _add_user(db, username="parker-threshold-a", email="parker-threshold-a@example.com", share_progress_enabled=False)
-    user_b = _add_user(db, username="parker-threshold-b", email="parker-threshold-b@example.com", share_progress_enabled=False)
-    user_c = _add_user(db, username="parker-threshold-c", email="parker-threshold-c@example.com", share_progress_enabled=False)
+    user_a = _add_user(db, username="parker-threshold-a", email="parker-threshold-a@example.com", social_insights_enabled=False)
+    user_b = _add_user(db, username="parker-threshold-b", email="parker-threshold-b@example.com", social_insights_enabled=False)
+    user_c = _add_user(db, username="parker-threshold-c", email="parker-threshold-c@example.com", social_insights_enabled=False)
 
     db.add_all([
         UserComicRating(user_id=user_a.id, comic_id=first.id, rating=5),
@@ -252,7 +252,7 @@ def test_home_top_parker_rated_applies_age_filter(auth_client, db, normal_user):
     safe_four = _add_comic(db, fourth_safe_volume, number="1", title="Parker Safe Four", age_rating="Teen")
     banned = _add_comic(db, banned_volume, number="1", title="Parker Banned", age_rating="Mature 17+")
 
-    rater = _add_user(db, username="parker-age-rater", email="parker-age-rater@example.com", share_progress_enabled=False)
+    rater = _add_user(db, username="parker-age-rater", email="parker-age-rater@example.com", social_insights_enabled=False)
     db.add_all([
         UserComicRating(user_id=rater.id, comic_id=safe.id, rating=4),
         UserComicRating(user_id=normal_user.id, comic_id=safe.id, rating=4),
@@ -283,7 +283,7 @@ def test_home_trending_returns_empty_below_threshold(auth_client, db):
         db,
         username="trending-threshold-sharer",
         email="trending-threshold-sharer@example.com",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
     )
 
     now = datetime.now(timezone.utc)
@@ -323,25 +323,25 @@ def test_home_trending_orders_by_recent_activity_then_readers_then_latest(auth_c
         db,
         username="trending-sharer-a",
         email="trending-sharer-a@example.com",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
     )
     sharer_b = _add_user(
         db,
         username="trending-sharer-b",
         email="trending-sharer-b@example.com",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
     )
     sharer_c = _add_user(
         db,
         username="trending-sharer-c",
         email="trending-sharer-c@example.com",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
     )
     hidden = _add_user(
         db,
         username="trending-hidden",
         email="trending-hidden@example.com",
-        share_progress_enabled=False,
+        social_insights_enabled=False,
     )
 
     _, top_series, top_volume = _create_series_graph(db, lib_name="home-trending-top-lib", series_name="Trending Top")
@@ -415,13 +415,13 @@ def test_home_trending_applies_age_filter(auth_client, db, normal_user):
         db,
         username="trending-age-a",
         email="trending-age-a@example.com",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
     )
     sharer_b = _add_user(
         db,
         username="trending-age-b",
         email="trending-age-b@example.com",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
     )
 
     safe_ids = set()
@@ -688,7 +688,7 @@ def test_home_popular_returns_empty_below_threshold(auth_client, db, normal_user
         db,
         username="popular-threshold-sharer",
         email="popular-threshold-sharer@example.com",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
     )
 
     comics = []
@@ -724,7 +724,7 @@ def test_home_popular_secondary_guard_when_cover_picker_drops_items(auth_client,
         db,
         username="popular-cover-sharer",
         email="popular-cover-sharer@example.com",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
     )
 
     for idx in range(1, 5):
@@ -758,13 +758,13 @@ def test_home_popular_returns_series_when_enough_data(auth_client, db):
         db,
         username="popular-full-sharer-a",
         email="popular-full-sharer-a@example.com",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
     )
     sharer_b = _add_user(
         db,
         username="popular-full-sharer-b",
         email="popular-full-sharer-b@example.com",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
     )
 
     series_ids = []

--- a/tests/api/test_series.py
+++ b/tests/api/test_series.py
@@ -384,28 +384,28 @@ def test_series_detail_exposes_distinct_opted_in_reader_count(auth_client, db, n
         username="series-reader-a",
         email="series-reader-a@example.com",
         hashed_password="fakehash",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
         is_active=True,
     )
     reader_b = User(
         username="series-reader-b",
         email="series-reader-b@example.com",
         hashed_password="fakehash",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
         is_active=True,
     )
     hidden_reader = User(
         username="series-reader-hidden",
         email="series-reader-hidden@example.com",
         hashed_password="fakehash",
-        share_progress_enabled=False,
+        social_insights_enabled=False,
         is_active=True,
     )
     zero_progress_reader = User(
         username="series-reader-zero",
         email="series-reader-zero@example.com",
         hashed_password="fakehash",
-        share_progress_enabled=True,
+        social_insights_enabled=True,
         is_active=True,
     )
     db.add_all([reader_a, reader_b, hidden_reader, zero_progress_reader])

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -54,6 +54,7 @@ def test_user_dashboard_returns_expected_sections(auth_client, db, normal_user):
     payload = response.json()
     assert payload["opds_enabled"] is True
     assert payload["user"]["username"] == normal_user.username
+    assert payload["user"]["social_insights_enabled"] is True
     assert len(payload["pull_lists"]) == 1
     assert payload["pull_lists"][0]["name"] == "Weekly Pulls"
     assert len(payload["continue_reading"]) == 1
@@ -71,17 +72,17 @@ def test_user_dashboard_page_shows_base_aware_opds_url(auth_client):
 def test_get_and_update_preferences(auth_client):
     initial = auth_client.get("/api/users/me/preferences")
     assert initial.status_code == 200
-    assert initial.json()["share_progress_enabled"] is False
+    assert initial.json()["social_insights_enabled"] is True
 
     update = auth_client.patch(
         "/api/users/me/preferences",
-        json={"share_progress_enabled": True, "monthly_reading_goal": 15},
+        json={"social_insights_enabled": False, "monthly_reading_goal": 15},
     )
     assert update.status_code == 200
 
     after = auth_client.get("/api/users/me/preferences")
     assert after.status_code == 200
-    assert after.json() == {"share_progress_enabled": True, "monthly_reading_goal": 15}
+    assert after.json() == {"social_insights_enabled": False, "monthly_reading_goal": 15}
 
 
 def test_update_preferences_rejects_invalid_goal(auth_client):


### PR DESCRIPTION

This updates Parker Social Insights so the application-facing preference is now `social_insights_enabled` while preserving the existing `users.share_progress_enabled` database column. New users now default into anonymous Social Insights, existing users keep their stored preference, and opted-out users get clearer UI prompts explaining what the feature powers.

**Changes**

- Renamed the Python/API/UI preference from `share_progress_enabled` to `social_insights_enabled`.
- Kept the underlying DB column as `users.share_progress_enabled`.
- Added an Alembic migration to default future users into Social Insights.
- Added a dashboard prompt for users who currently have Social Insights disabled.
- Updated Account Settings copy to better explain anonymous aggregate participation.
- Updated social rail queries, tests, README, and `docs/releases/0.1.23.md`.

**Existing Users**

Existing users are not migrated to enabled. Their current stored value is preserved so intentional opt-outs are respected.

**Validation**

- `pytest tests/api/test_users.py tests/api/test_comics.py::test_get_comic_detail_exposes_opted_in_completed_reader_count tests/api/test_series.py::test_series_detail_exposes_distinct_opted_in_reader_count tests/api/test_home.py`
- `pytest tests/api/test_users.py`
- `alembic heads`
- `DATABASE_URL=sqlite:///:memory: alembic upgrade head`