### PR TITLE
Namespace browser storage behind shared Parker helper

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,11 +36,6 @@ This file captures follow-up work that should not get lost between releases.
   Current risk: A fresh install with a valid comics mount and no configured libraries can still look superficially similar to a "wrong storage directory" situation.
   Follow-up goal: Reassess the signals used for `storage_mismatch_suspected` once we have another real-world report or a better synthetic repro, and tune the messaging so first-run onboarding is not mistaken for a broken upgrade.
 
-- Migrate browser `localStorage` keys to a Parker namespace.
-  Context: Several long-lived browser keys were created before Parker consistently used a `parker.*` prefix, including auth tokens and UI preferences.
-  Follow-up goal: Introduce a backwards-compatible migration that copies existing unprefixed keys into namespaced keys such as `parker.token`, then updates runtime reads/writes to use the namespaced keys.
-  Guardrail: Preserve existing user sessions and preferences during the migration; avoid duplicate auth state by removing legacy auth keys only after a successful copy.
-
 - Decide the long-term policy for inaccessible followed volumes.
   Context: `user_volume_follows` rows currently remain persisted even if a user's library access or age-rating settings later hide that volume from all user-facing follow surfaces.
   Current behavior: The follow is filtered out of the `Following` page, the `New from Following` home rail, and direct volume access checks, but the row is not pruned automatically.

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,6 +11,8 @@
     {% from "partials/config_context.html" import config_context %}
     {{ config_context(request, base_url) }}
 
+    <script src="{{ url('/static/js/storage.js') }}?v={{ asset_version('static/js/storage.js') }}"></script>
+
     <!-- Alpine.js Collapse plugin -->
     <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.x.x/dist/cdn.min.js"></script>
 
@@ -37,7 +39,7 @@
         mobileMenuOpen: false,
         isAdmin: false,
         async init() {
-            if (!localStorage.getItem('token')) {
+            if (!window.parker.storage.has('token')) {
                 this.isAdmin = false;
                 return;
             }
@@ -127,16 +129,16 @@
                     </div>
 
                     <div class="flex items-center border-l border-gray-700 pl-3 ml-1">
-                        <template x-if="localStorage.getItem('token')">
+                        <template x-if="window.parker.storage.has('token')">
                             <button
-                                x-on:click="localStorage.removeItem('token'); localStorage.removeItem('refresh_token'); document.cookie = 'access_token=; path=/; max-age=0; SameSite=Lax'; window.location.href = window.parker.route('pages.login');"
+                                x-on:click="window.parker.auth.clearSession(); window.location.href = window.parker.route('pages.login');"
                                 class="text-sm font-medium text-gray-400 hover:text-white transition-colors"
                             >
                                 Logout
                             </button>
                         </template>
 
-                        <template x-if="!localStorage.getItem('token')">
+                        <template x-if="!window.parker.storage.has('token')">
                             <a :href="window.parker.route('login')" class="text-sm font-bold text-blue-400 hover:text-blue-300 transition-colors">
                                 Login
                             </a>

--- a/app/templates/login_full.html
+++ b/app/templates/login_full.html
@@ -11,6 +11,8 @@
     {% from "partials/config_context.html" import config_context %}
     {{ config_context(request, base_url) }}
 
+    <script src="{{ base_url }}/static/js/storage.js?v={{ asset_version('static/js/storage.js') }}"></script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
@@ -156,7 +158,7 @@ function loginCycler() {
 
         // Seasonal FX State
         activeEffect: '{{ active_effect or "" }}',
-        fxEnabled: localStorage.getItem('parker-fx-enabled') !== 'false',
+        fxEnabled: window.parker.storage.get('fx.enabled', true) !== false,
 
         init() {
             if (this.bgStyle === 'random_covers') {
@@ -214,7 +216,7 @@ function loginCycler() {
 
         toggleFx() {
             this.fxEnabled = !this.fxEnabled;
-            localStorage.setItem('parker-fx-enabled', this.fxEnabled);
+            window.parker.storage.set('fx.enabled', this.fxEnabled);
         },
 
         async login() {
@@ -239,10 +241,10 @@ function loginCycler() {
                 }
 
                 // Store Token for API calls (Alpine/JS)
-                localStorage.setItem('token', data.access_token);
+                window.parker.storage.setString('token', data.access_token);
 
                 // Store Refresh Token (Long-lived)
-                localStorage.setItem('refresh_token', data.refresh_token);
+                window.parker.storage.setString('refresh_token', data.refresh_token);
 
                 // Store Token for Server-Side Rendering (HTML Routes)
                 document.cookie = `access_token=${data.access_token}; path=/; max-age=${data.lifetime_in_seconds}; SameSite=Lax`;

--- a/app/templates/user/dashboard.html
+++ b/app/templates/user/dashboard.html
@@ -698,8 +698,8 @@ function dashboard() {
         reviewYear:activeReviewYear,
 
         // IMMEDIATE CHECK: Set the state synchronously during object creation
-        bannerDismissed: localStorage.getItem('dismissed_review_year') == activeReviewYear,
-        socialInsightsPromptDismissed: localStorage.getItem('dismissed_social_insights_prompt') === 'true',
+        bannerDismissed: window.parker.storage.getString('dismissed_review_year') == activeReviewYear,
+        socialInsightsPromptDismissed: window.parker.storage.getString('dismissed_social_insights_prompt') === 'true',
 
         async init() {
 
@@ -884,7 +884,7 @@ function dashboard() {
 
         dismissBanner() {
             this.bannerDismissed = true;
-            localStorage.setItem('dismissed_review_year', this.reviewYear);
+            window.parker.storage.setString('dismissed_review_year', this.reviewYear);
         },
 
         shouldShowSocialInsightsPrompt() {
@@ -903,7 +903,7 @@ function dashboard() {
 
                 this.data.user.social_insights_enabled = true;
                 this.socialInsightsPromptDismissed = true;
-                localStorage.removeItem('dismissed_social_insights_prompt');
+                window.parker.storage.remove('dismissed_social_insights_prompt');
                 window.parker.showToast("Social insights enabled", "success");
             } catch (e) {
                 console.error(e);
@@ -913,7 +913,7 @@ function dashboard() {
 
         dismissSocialInsightsPrompt() {
             this.socialInsightsPromptDismissed = true;
-            localStorage.setItem('dismissed_social_insights_prompt', 'true');
+            window.parker.storage.setString('dismissed_social_insights_prompt', 'true');
         }
 
     }

--- a/docs/releases/0.1.24.md
+++ b/docs/releases/0.1.24.md
@@ -1,0 +1,38 @@
+# Parker 0.1.24 Release Notes
+
+Status: Draft
+
+`0.1.24` is currently planned as a post-`0.1.23` polish and follow-up release.
+
+Likely shape: prioritize smaller user-facing affordances, support/diagnostics
+improvements, and browser-state cleanup. Treat full multi-root library support and
+metadata writeback as larger projects unless they are explicitly promoted into this
+release.
+
+## Added
+
+- Candidate: Add a pinned-libraries surface on the front page so favorite or most-used libraries can be reached without scanning the full library list.
+- Candidate: Add a folder-browse affordance to the admin Add Library flow, reducing path-entry friction for local installs where browsing is available.
+- Candidate: Expand the admin diagnostics support snapshot with proven-useful fields such as recent scan-job summaries, selected safe runtime settings, and lightweight storage/cache health checks.
+
+## Changed
+
+- Centralized Parker's browser `localStorage` access behind the shared storage helper and moved app-owned keys into the `parker.*` namespace.
+- Added backwards-compatible browser-state migration so existing auth tokens, reader preferences, dashboard dismissals, and login-effect preferences continue working when old keys are encountered.
+- Split the browser storage helper into a lightweight standalone script so the login page can share namespaced storage without loading the full app shell JavaScript.
+- Candidate: Decide and document the long-term behavior for followed volumes that later become inaccessible through library permissions or age-rating filters.
+- Candidate: Improve the WebP/transcoding pipeline for modern source formats, especially `AVIF` and `JPEG XL`, if the scope stays focused and testable.
+- Candidate: Keep multi-root library support in design/scoping unless `0.1.24` becomes a deliberate storage-architecture release.
+
+## Fixed
+
+- Candidate: Improve container-level Continue behavior so reading lists, collections, stacks, and story arcs can resume at the best in-progress or next unread item within that specific context.
+- Candidate: Tune startup diagnostics so true first-run installs are less likely to be confused with rebuilt-storage or wrong-database scenarios.
+- Candidate: Sweep for regressions from the `0.1.23` bookmark, Library Timeline, reader-return, and Social Insights changes once real use shakes out.
+
+## Validation
+
+- Pending: Run focused backend tests for any touched APIs, services, migrations, and diagnostics.
+- Verified the storage helper, browser-state migration, auth refresh, idle-session cleanup, dashboard prompt dismissal, reader preference persistence, incognito reader behavior, and broader browser flows with the full Playwright browser suite.
+- Pending: Verify Alembic reports a single head and upgrades cleanly if the release includes schema changes.
+- Pending: Update README feature and roadmap notes once the final `0.1.24` scope is known.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -4,6 +4,7 @@
  */
 (function() {
 
+    const storage = window.parker.storage;
     const originalFetch = window.fetch;
     let isRefreshing = false;
     let refreshPromise = null;
@@ -11,7 +12,7 @@
     let failedQueue = [];
     const REFRESH_SKEW_SECONDS = 90;
     const IDLE_TIMEOUT_SECONDS = 2 * 60 * 60;
-    const LAST_ACTIVITY_KEY = 'parker.lastActivityAt';
+    const LAST_ACTIVITY_KEY = 'lastActivityAt';
 
     const processQueue = (error, token = null) => {
         failedQueue.forEach(prom => {
@@ -52,16 +53,16 @@
     const nowSeconds = () => Math.floor(Date.now() / 1000);
 
     const getLastActivityAt = () => {
-        const stored = parseInt(localStorage.getItem(LAST_ACTIVITY_KEY), 10);
+        const stored = parseInt(storage.getString(LAST_ACTIVITY_KEY), 10);
         return Number.isFinite(stored) && stored > 0 ? stored : nowSeconds();
     };
 
     const setLastActivityAt = (timestamp = nowSeconds()) => {
-        localStorage.setItem(LAST_ACTIVITY_KEY, String(timestamp));
+        storage.setString(LAST_ACTIVITY_KEY, String(timestamp));
     };
 
     const isIdleExpired = () => {
-        const refreshToken = localStorage.getItem('refresh_token');
+        const refreshToken = storage.getString('refresh_token');
         return !!refreshToken && (nowSeconds() - getLastActivityAt()) > IDLE_TIMEOUT_SECONDS;
     };
 
@@ -70,14 +71,14 @@
     };
 
     const clearSession = () => {
-        localStorage.removeItem('token');
-        localStorage.removeItem('refresh_token');
-        localStorage.removeItem(LAST_ACTIVITY_KEY);
+        storage.remove('token');
+        storage.remove('refresh_token');
+        storage.remove(LAST_ACTIVITY_KEY);
         document.cookie = 'access_token=; path=/; max-age=0; SameSite=Lax';
     };
 
     const markActivity = () => {
-        if (!localStorage.getItem('refresh_token') || isIdleExpired()) return;
+        if (!storage.getString('refresh_token') || isIdleExpired()) return;
         const now = nowSeconds();
         if ((now - getLastActivityAt()) < 15) return;
         setLastActivityAt(now);
@@ -89,8 +90,8 @@
             refreshTimer = null;
         }
 
-        const token = localStorage.getItem('token');
-        const refreshToken = localStorage.getItem('refresh_token');
+        const token = storage.getString('token');
+        const refreshToken = storage.getString('refresh_token');
         if (!token || !refreshToken) return;
 
         if (isIdleExpired()) {
@@ -111,7 +112,7 @@
             throw new Error('Session idle timeout');
         }
 
-        const token = localStorage.getItem('token');
+        const token = storage.getString('token');
         const secondsRemaining = getTokenSecondsRemaining(token);
 
         if (!force && token && secondsRemaining > REFRESH_SKEW_SECONDS) {
@@ -119,7 +120,7 @@
             return token;
         }
 
-        const refreshToken = localStorage.getItem('refresh_token');
+        const refreshToken = storage.getString('refresh_token');
         if (!refreshToken) {
             return null;
         }
@@ -141,8 +142,8 @@
             }
 
             const data = await refreshRes.json();
-            localStorage.setItem('token', data.access_token);
-            localStorage.setItem('refresh_token', data.refresh_token);
+            storage.setString('token', data.access_token);
+            storage.setString('refresh_token', data.refresh_token);
             setAccessCookie(data.access_token, data.lifetime_in_seconds);
             scheduleRefresh();
 
@@ -174,8 +175,8 @@
         const anchor = event.target instanceof Element ? event.target.closest('a') : null;
         if (!shouldPrepareNavigation(anchor)) return;
 
-        const token = localStorage.getItem('token');
-        const refreshToken = localStorage.getItem('refresh_token');
+        const token = storage.getString('token');
+        const refreshToken = storage.getString('refresh_token');
         if (!refreshToken || getTokenSecondsRemaining(token) > REFRESH_SKEW_SECONDS) {
             return;
         }
@@ -217,7 +218,7 @@
         };
 
         // Initial Token Attempt
-        const token = localStorage.getItem('token');
+        const token = storage.getString('token');
         if (token) { injectToken(token); }
 
         try {
@@ -239,7 +240,7 @@
                 }
 
                 // Start Refresh Logic
-                const refreshToken = localStorage.getItem('refresh_token');
+                const refreshToken = storage.getString('refresh_token');
 
                 // If no refresh token, or if we are calling the login/refresh endpoints themselves, abort
                 const requestUrl = typeof url === 'string' ? url : (url && url.url) || String(url);
@@ -294,7 +295,7 @@
             refreshSession().catch(() => {});
         }
     });
-    if (localStorage.getItem('refresh_token') && !localStorage.getItem(LAST_ACTIVITY_KEY)) {
+    if (storage.getString('refresh_token') && !storage.getString(LAST_ACTIVITY_KEY)) {
         setLastActivityAt();
     }
     scheduleRefresh();
@@ -558,25 +559,7 @@ document.addEventListener('error', function(e) {
     }
 
     // Storage & Prefs
-    const storage = {
-        get(key, defaultValue = null) {
-            try {
-                const item = localStorage.getItem(key);
-                return item ? JSON.parse(item) : defaultValue;
-            } catch (e) {
-                console.error('Error reading from localStorage:', e);
-                return defaultValue;
-            }
-        },
-        set(key, value) {
-            try {
-                localStorage.setItem(key, JSON.stringify(value));
-            } catch (e) { console.error('Error writing to localStorage:', e); }
-        },
-        remove(key) {
-            try { localStorage.removeItem(key); } catch (e) { }
-        }
-    };
+    const storage = window.parker.storage;
 
     /**
      * Generic Pagination Logic

--- a/static/js/reader.js
+++ b/static/js/reader.js
@@ -1,4 +1,6 @@
 (() => {
+    const storage = window.parker.storage;
+
     const DEFAULT_FILTERS = Object.freeze({
         transcode: false,
         grayscale: false,
@@ -39,16 +41,16 @@
     }
 
     function loadBooleanPreference(key, fallback) {
-        const rawValue = localStorage.getItem(key);
+        const rawValue = storage.getString(key);
         return rawValue === null ? fallback : JSON.parse(rawValue);
     }
 
     function persistJsonPreference(key, value) {
-        localStorage.setItem(key, JSON.stringify(value));
+        storage.set(key, value);
     }
 
     function loadFilters() {
-        const savedFilters = localStorage.getItem(STORAGE_KEYS.filters);
+        const savedFilters = storage.getString(STORAGE_KEYS.filters);
         if (!savedFilters) {
             return cloneDefaultFilters();
         }
@@ -62,7 +64,7 @@
     }
 
     function loadComicOverrides() {
-        const savedOverrides = localStorage.getItem(STORAGE_KEYS.comicOverrides);
+        const savedOverrides = storage.getString(STORAGE_KEYS.comicOverrides);
         if (!savedOverrides) {
             return {};
         }
@@ -86,7 +88,7 @@
             throw new Error(`Unsupported comic override setting: ${settingName}`);
         }
 
-        return localStorage.getItem(config.storageKey) || config.fallback;
+        return storage.getString(config.storageKey) || config.fallback;
     }
 
     function getStoredReaderPreference(reader, settingName) {
@@ -183,7 +185,7 @@
         reader.readingMode = getStoredReaderPreference(reader, 'readingMode');
         reader.viewMode = getStoredReaderPreference(reader, 'viewMode');
         reader.readDirection = getStoredReaderPreference(reader, 'readDirection');
-        reader.fitMode = localStorage.getItem(STORAGE_KEYS.fitMode) || 'contain';
+        reader.fitMode = storage.getString(STORAGE_KEYS.fitMode) || 'contain';
         reader.doublePageOffset = loadBooleanPreference(STORAGE_KEYS.doublePageOffset, true);
         reader.showSpineShadow = loadBooleanPreference(STORAGE_KEYS.showSpineShadow, true);
         reader.uiLocked = loadBooleanPreference(STORAGE_KEYS.uiLocked, false);
@@ -216,7 +218,7 @@
         });
         reader.$watch('viewMode', (value) => persistComicOverridePreference(reader, 'viewMode', value));
         reader.$watch('readDirection', (value) => persistComicOverridePreference(reader, 'readDirection', value));
-        reader.$watch('fitMode', (value) => localStorage.setItem(STORAGE_KEYS.fitMode, value));
+        reader.$watch('fitMode', (value) => storage.setString(STORAGE_KEYS.fitMode, value));
         reader.$watch('doublePageOffset', (value) => persistJsonPreference(STORAGE_KEYS.doublePageOffset, value));
         reader.$watch('showSpineShadow', (value) => persistJsonPreference(STORAGE_KEYS.showSpineShadow, value));
         reader.$watch('uiLocked', (value) => persistJsonPreference(STORAGE_KEYS.uiLocked, value));

--- a/static/js/storage.js
+++ b/static/js/storage.js
@@ -1,0 +1,92 @@
+(() => {
+    const STORAGE_PREFIX = 'parker.';
+    const LEGACY_KEY_ALIASES = Object.freeze({
+        'fx.enabled': ['parker-fx-enabled']
+    });
+
+    const normalizeStorageKey = (key) => {
+        const rawKey = String(key);
+        return rawKey.startsWith(STORAGE_PREFIX) ? rawKey : `${STORAGE_PREFIX}${rawKey}`;
+    };
+
+    const legacyStorageKeys = (key) => {
+        const rawKey = String(key);
+        const normalizedKey = normalizeStorageKey(rawKey);
+        const aliases = LEGACY_KEY_ALIASES[rawKey] || [];
+        const keys = rawKey === normalizedKey ? [] : [rawKey];
+        return [...new Set([...keys, ...aliases])].filter((candidate) => candidate !== normalizedKey);
+    };
+
+    const storage = {
+        prefix: STORAGE_PREFIX,
+        key(key) {
+            return normalizeStorageKey(key);
+        },
+        getString(key, defaultValue = null) {
+            const storageKey = normalizeStorageKey(key);
+
+            try {
+                const item = localStorage.getItem(storageKey);
+                if (item !== null) {
+                    legacyStorageKeys(key).forEach((legacyKey) => localStorage.removeItem(legacyKey));
+                    return item;
+                }
+
+                for (const legacyKey of legacyStorageKeys(key)) {
+                    const legacyItem = localStorage.getItem(legacyKey);
+                    if (legacyItem !== null) {
+                        localStorage.setItem(storageKey, legacyItem);
+                        localStorage.removeItem(legacyKey);
+                        return legacyItem;
+                    }
+                }
+
+                return defaultValue;
+            } catch (e) {
+                console.error('Error reading from localStorage:', e);
+                return defaultValue;
+            }
+        },
+        setString(key, value) {
+            const storageKey = normalizeStorageKey(key);
+
+            try {
+                localStorage.setItem(storageKey, String(value));
+                legacyStorageKeys(key).forEach((legacyKey) => localStorage.removeItem(legacyKey));
+            } catch (e) {
+                console.error('Error writing to localStorage:', e);
+            }
+        },
+        get(key, defaultValue = null) {
+            const item = this.getString(key, null);
+            if (item === null) {
+                return defaultValue;
+            }
+
+            try {
+                return JSON.parse(item);
+            } catch (e) {
+                console.error('Error parsing localStorage value:', e);
+                return defaultValue;
+            }
+        },
+        set(key, value) {
+            this.setString(key, JSON.stringify(value));
+        },
+        remove(key) {
+            const storageKey = normalizeStorageKey(key);
+
+            try {
+                localStorage.removeItem(storageKey);
+                legacyStorageKeys(key).forEach((legacyKey) => localStorage.removeItem(legacyKey));
+            } catch (e) {
+                console.error('Error removing from localStorage:', e);
+            }
+        },
+        has(key) {
+            return this.getString(key, null) !== null;
+        }
+    };
+
+    window.parker = { ...(window.parker || {}), storage };
+})();

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -177,6 +177,9 @@ def reset_browser_state(browser_db_factory, browser_seed_data):
         session.query(SavedSearch).delete()
         session.query(Bookmark).delete()
         session.query(ReadingProgress).delete()
+        user = session.scalar(select(User).where(User.id == browser_seed_data["user_id"]))
+        if user is not None:
+            user.social_insights_enabled = True
         session.add_all(
             [
                 ReadingProgress(

--- a/tests/browser/test_navigation_smoke.py
+++ b/tests/browser/test_navigation_smoke.py
@@ -57,7 +57,7 @@ def test_continue_reading_page_shows_in_progress_items_and_opens_reader(page, br
 
     page.get_by_role("link", name="Continue").click()
 
-    page.wait_for_url(f"**/reader/{seed['in_progress_comic_id']}")
+    page.wait_for_url(f"**/reader/{seed['in_progress_comic_id']}*")
     page.locator(".reader-container").wait_for()
     page.locator(".nav-zone.center").click()
     assert page.locator(".reader-toolbar").filter(has_text=seed["in_progress_comic_title"]).first.is_visible()

--- a/tests/browser/test_reader_smoke.py
+++ b/tests/browser/test_reader_smoke.py
@@ -612,7 +612,7 @@ def test_reader_incognito_mode_does_not_persist_per_book_overrides(page, browser
         """
     )
 
-    stored_overrides = page.evaluate("() => window.localStorage.getItem('reader_comicOverrides')")
+    stored_overrides = page.evaluate("() => window.parker.storage.getString('reader_comicOverrides')")
     assert stored_overrides is None
 
     page.goto(active_reader_url, wait_until="networkidle")

--- a/tests/browser/test_saved_search_pull_list_and_session_flows.py
+++ b/tests/browser/test_saved_search_pull_list_and_session_flows.py
@@ -7,6 +7,7 @@ from app.core.security import create_access_token, create_refresh_token
 from app.models.bookmark import Bookmark
 from app.models.pull_list import PullList, PullListItem
 from app.models.reading_progress import ReadingProgress
+from app.models.user import User
 
 
 def _create_pull_list(db_factory, user_id, name, description=None):
@@ -50,6 +51,61 @@ def _add_comic_to_pull_list(db_factory, pull_list_id, comic_id):
 
 
 @pytest.mark.browser
+def test_storage_helper_namespaces_and_migrates_legacy_keys_on_login_page(page, browser_server):
+    page.goto(f"{browser_server['base_url']}/login", wait_until="networkidle")
+
+    state = page.evaluate(
+        """
+        () => {
+            localStorage.setItem('plainString', 'legacy-value');
+            localStorage.setItem('jsonValue', JSON.stringify({ enabled: true }));
+            localStorage.setItem('parker-fx-enabled', 'false');
+            localStorage.setItem('brokenJson', 'not-json');
+
+            const plainString = window.parker.storage.getString('plainString');
+            const jsonValue = window.parker.storage.get('jsonValue', {});
+            const fxEnabled = window.parker.storage.get('fx.enabled', true);
+            const brokenJson = window.parker.storage.get('brokenJson', 'fallback');
+
+            window.parker.storage.setString('plainString', 'new-value');
+            window.parker.storage.set('jsonValue', { enabled: false });
+            window.parker.storage.remove('brokenJson');
+
+            return {
+                plainString,
+                jsonValue,
+                fxEnabled,
+                brokenJson,
+                namespacedPlainString: localStorage.getItem('parker.plainString'),
+                legacyPlainString: localStorage.getItem('plainString'),
+                namespacedJsonValue: JSON.parse(localStorage.getItem('parker.jsonValue')),
+                legacyJsonValue: localStorage.getItem('jsonValue'),
+                namespacedFxEnabled: localStorage.getItem('parker.fx.enabled'),
+                legacyFxEnabled: localStorage.getItem('parker-fx-enabled'),
+                namespacedBrokenJson: localStorage.getItem('parker.brokenJson'),
+                legacyBrokenJson: localStorage.getItem('brokenJson')
+            };
+        }
+        """
+    )
+
+    assert state == {
+        "plainString": "legacy-value",
+        "jsonValue": {"enabled": True},
+        "fxEnabled": False,
+        "brokenJson": "fallback",
+        "namespacedPlainString": "new-value",
+        "legacyPlainString": None,
+        "namespacedJsonValue": {"enabled": False},
+        "legacyJsonValue": None,
+        "namespacedFxEnabled": "false",
+        "legacyFxEnabled": None,
+        "namespacedBrokenJson": None,
+        "legacyBrokenJson": None,
+    }
+
+
+@pytest.mark.browser
 def test_login_next_redirect_and_logout_clears_session(page, browser_server):
     page.goto(f"{browser_server['base_url']}/login?next=/search", wait_until="networkidle")
 
@@ -63,15 +119,42 @@ def test_login_next_redirect_and_logout_clears_session(page, browser_server):
     session_state = page.evaluate(
         """
         () => ({
-            token: localStorage.getItem('token'),
-            refreshToken: localStorage.getItem('refresh_token'),
+            token: window.parker.storage.getString('token'),
+            refreshToken: window.parker.storage.getString('refresh_token'),
+            namespacedToken: localStorage.getItem(window.parker.storage.key('token')),
+            namespacedRefreshToken: localStorage.getItem(window.parker.storage.key('refresh_token')),
+            legacyToken: localStorage.getItem('token'),
+            legacyRefreshToken: localStorage.getItem('refresh_token'),
             hasAccessCookie: document.cookie.includes('access_token=')
         })
         """
     )
     assert session_state["token"]
     assert session_state["refreshToken"]
+    assert session_state["namespacedToken"] == session_state["token"]
+    assert session_state["namespacedRefreshToken"] == session_state["refreshToken"]
+    assert session_state["legacyToken"] is None
+    assert session_state["legacyRefreshToken"] is None
     assert session_state["hasAccessCookie"] is True
+
+    migrated_legacy_state = page.evaluate(
+        """
+        () => {
+            localStorage.setItem('token', 'legacy-token');
+            const value = window.parker.storage.getString('token');
+            return {
+                value,
+                namespacedToken: localStorage.getItem(window.parker.storage.key('token')),
+                legacyToken: localStorage.getItem('token')
+            };
+        }
+        """
+    )
+    assert migrated_legacy_state == {
+        "value": session_state["token"],
+        "namespacedToken": session_state["token"],
+        "legacyToken": None,
+    }
 
     page.get_by_role("button", name="Logout").click()
 
@@ -81,15 +164,78 @@ def test_login_next_redirect_and_logout_clears_session(page, browser_server):
     cleared_state = page.evaluate(
         """
         () => ({
-            token: localStorage.getItem('token'),
-            refreshToken: localStorage.getItem('refresh_token'),
+            token: window.parker.storage.getString('token'),
+            refreshToken: window.parker.storage.getString('refresh_token'),
+            namespacedToken: localStorage.getItem(window.parker.storage.key('token')),
+            namespacedRefreshToken: localStorage.getItem(window.parker.storage.key('refresh_token')),
+            legacyToken: localStorage.getItem('token'),
+            legacyRefreshToken: localStorage.getItem('refresh_token'),
             hasAccessCookie: document.cookie.includes('access_token=')
         })
         """
     )
     assert cleared_state["token"] is None
     assert cleared_state["refreshToken"] is None
+    assert cleared_state["namespacedToken"] is None
+    assert cleared_state["namespacedRefreshToken"] is None
+    assert cleared_state["legacyToken"] is None
+    assert cleared_state["legacyRefreshToken"] is None
     assert cleared_state["hasAccessCookie"] is False
+
+    legacy_migration_state = page.evaluate(
+        """
+        () => {
+            localStorage.setItem('token', 'legacy-token');
+            const value = window.parker.storage.getString('token');
+            const state = {
+                value,
+                namespacedToken: localStorage.getItem(window.parker.storage.key('token')),
+                legacyToken: localStorage.getItem('token')
+            };
+            window.parker.storage.remove('token');
+            return state;
+        }
+        """
+    )
+    assert legacy_migration_state == {
+        "value": "legacy-token",
+        "namespacedToken": "legacy-token",
+        "legacyToken": None,
+    }
+
+
+@pytest.mark.browser
+def test_dashboard_social_insights_prompt_dismissal_uses_namespaced_storage(page, browser_server):
+    seed = browser_server["seed"]
+    session = browser_server["db_factory"]()
+    try:
+        user = session.get(User, seed["user_id"])
+        user.social_insights_enabled = False
+        session.commit()
+    finally:
+        session.close()
+
+    page.goto(f"{browser_server['base_url']}/user/dashboard", wait_until="networkidle")
+    page.get_by_role("heading", name="Help anonymous social rails feel more alive").wait_for()
+    page.get_by_role("button", name="Not Now").click()
+
+    state = page.evaluate(
+        """
+        () => ({
+            helperValue: window.parker.storage.getString('dismissed_social_insights_prompt'),
+            namespacedValue: localStorage.getItem('parker.dismissed_social_insights_prompt'),
+            legacyValue: localStorage.getItem('dismissed_social_insights_prompt')
+        })
+        """
+    )
+    assert state == {
+        "helperValue": "true",
+        "namespacedValue": "true",
+        "legacyValue": None,
+    }
+
+    page.reload(wait_until="networkidle")
+    assert page.get_by_role("heading", name="Help anonymous social rails feel more alive").count() == 0
 
 
 @pytest.mark.browser
@@ -105,8 +251,8 @@ def test_session_refresh_resyncs_access_cookie_before_navigation(page, browser_s
     page.evaluate(
         """
         ({ expiredAccessToken, refreshToken }) => {
-            localStorage.setItem('token', expiredAccessToken);
-            localStorage.setItem('refresh_token', refreshToken);
+            window.parker.storage.setString('token', expiredAccessToken);
+            window.parker.storage.setString('refresh_token', refreshToken);
             document.cookie = 'access_token=; path=/; max-age=0; SameSite=Lax';
         }
         """,
@@ -120,7 +266,7 @@ def test_session_refresh_resyncs_access_cookie_before_navigation(page, browser_s
         """
         async () => {
             await window.parker.auth.refreshSession({ force: true });
-            return localStorage.getItem('token');
+            return window.parker.storage.getString('token');
         }
         """
     )
@@ -128,8 +274,8 @@ def test_session_refresh_resyncs_access_cookie_before_navigation(page, browser_s
     session_state = page.evaluate(
         """
         () => ({
-            token: localStorage.getItem('token'),
-            refreshToken: localStorage.getItem('refresh_token'),
+            token: window.parker.storage.getString('token'),
+            refreshToken: window.parker.storage.getString('refresh_token'),
             hasAccessCookie: document.cookie.includes('access_token=')
         })
         """
@@ -154,9 +300,9 @@ def test_idle_session_clears_instead_of_refreshing(page, browser_server):
         """
         async ({ expiredAccessToken, refreshToken }) => {
             const staleActivityAt = Math.floor(Date.now() / 1000) - window.parker.auth.idleTimeoutSeconds - 10;
-            localStorage.setItem('token', expiredAccessToken);
-            localStorage.setItem('refresh_token', refreshToken);
-            localStorage.setItem('parker.lastActivityAt', String(staleActivityAt));
+            window.parker.storage.setString('token', expiredAccessToken);
+            window.parker.storage.setString('refresh_token', refreshToken);
+            window.parker.storage.setString('lastActivityAt', String(staleActivityAt));
             document.cookie = 'access_token=; path=/; max-age=0; SameSite=Lax';
 
             try {
@@ -176,9 +322,9 @@ def test_idle_session_clears_instead_of_refreshing(page, browser_server):
     session_state = page.evaluate(
         """
         () => ({
-            token: localStorage.getItem('token'),
-            refreshToken: localStorage.getItem('refresh_token'),
-            lastActivityAt: localStorage.getItem('parker.lastActivityAt'),
+            token: window.parker.storage.getString('token'),
+            refreshToken: window.parker.storage.getString('refresh_token'),
+            lastActivityAt: window.parker.storage.getString('lastActivityAt'),
             hasAccessCookie: document.cookie.includes('access_token=')
         })
         """

--- a/tests/browser/test_search_and_series_smoke.py
+++ b/tests/browser/test_search_and_series_smoke.py
@@ -130,7 +130,7 @@ def test_home_following_arrival_appears_after_import_and_clears_after_reading(pa
     rail.locator(f"text={new_issue_title}").first.wait_for()
 
     rail.locator(f'a[href*="/reader/{new_issue_id}"]').first.click()
-    page.wait_for_url(f"**/reader/{new_issue_id}")
+    page.wait_for_url(f"**/reader/{new_issue_id}*")
     page.locator(".reader-container").wait_for()
     page.keyboard.press("ArrowRight")
     page.wait_for_timeout(300)


### PR DESCRIPTION
## Summary

- Centralize Parker browser storage behind a new `window.parker.storage` helper in `static/js/storage.js`.
- Move app-owned `localStorage` keys into the `parker.*` namespace with backwards-compatible legacy key migration.
- Update auth/session, login, dashboard dismissals, and reader preferences to use the shared storage helper.
- Load the lightweight storage helper on login without loading the full `app.js` shell.
- Add browser coverage for storage migration, auth/session continuity, dashboard dismissals, and reader preference persistence.

## Details

This migrates old keys such as `token`, `refresh_token`, `reader_viewMode`, `reader_comicOverrides`, and dashboard dismissal flags into namespaced keys like `parker.token`, `parker.refresh_token`, and `parker.reader_viewMode`.

Migration is lazy: when Parker reads a key through `window.parker.storage`, it checks the namespaced key first, falls back to the legacy key if needed, copies the value forward, and removes the old key. The existing `parker-fx-enabled` login effect key is also mapped to `parker.fx.enabled`.

The login page now loads only `storage.js`, avoiding the need to execute the full app shell just to share token/prefs storage.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests/browser -m browser -q`
  - `63 passed`
- `node --check static\js\storage.js`
- `git diff --check`
