### PR TITLE
Add pinned library rails to Home

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
   - Netflix‑style home page with content rails
   - Anonymous aggregate social insights such as reader counts and `Popular with Others`
   - `Continue Reading`, `Jump Back In`, `Trending`, and `New from Following`
+  - Pinned library rails for recently updated series from favorite libraries
   - Library Timeline for character and team histories generated from embedded metadata
   - Recommendations by creator or metadata
   - Random gems, recently updated series
@@ -159,7 +160,6 @@ virtualenv from these pinned requirements.
 - Enhanced WebP transcoding pipeline (JXL, AVIF to WebP)
 - Additional unit test coverage
 - Migration tooling improvements
-- Pin libraries to front page
 - Improve admin Add Library dialog to be able to browse to a folder rather than type it in
 - Support multiple folder locations per library
 - Light metadata editing with file writeback (Tentative)

--- a/alembic/versions/3a6f4d2b9c10_add_user_library_pins_table.py
+++ b/alembic/versions/3a6f4d2b9c10_add_user_library_pins_table.py
@@ -1,0 +1,34 @@
+"""add_user_library_pins_table
+
+Revision ID: 3a6f4d2b9c10
+Revises: 2f4a9c8d1e3b
+Create Date: 2026-07-20 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "3a6f4d2b9c10"
+down_revision: Union[str, None] = "2f4a9c8d1e3b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_library_pins",
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("library_id", sa.Integer(), nullable=False),
+        sa.Column("pinned_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["library_id"], ["libraries.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("user_id", "library_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_library_pins")

--- a/app/api/home.py
+++ b/app/api/home.py
@@ -11,7 +11,9 @@ from app.api.deps import SessionDep, CurrentUser
 from app.core.comic_helpers import get_format_filters, get_smart_cover, get_series_age_restriction, get_thumbnail_url
 from app.models.comic import Comic, Volume
 from app.models.interactions import UserComicRating
+from app.models.interactions import UserLibraryPin
 from app.models.interactions import UserVolumeFollow
+from app.models.library import Library
 from app.models.series import Series
 from app.models.user import User
 from app.models.reading_progress import ReadingProgress
@@ -426,6 +428,71 @@ def get_following_arrivals(
     )
 
     return [format_home_item(comic) for comic in results]
+
+
+@router.get("/pinned-libraries", response_model=List[dict], name="pinned_libraries")
+def get_pinned_libraries(
+        db: SessionDep,
+        current_user: CurrentUser,
+        limit: int = 15,
+):
+    """
+    Get home-page rails for libraries the current user pinned.
+    Each pinned library rail contains recently updated series for that library.
+    """
+    limit = max(1, min(limit, 15))
+
+    pins_query = (
+        db.query(UserLibraryPin, Library)
+        .join(Library, UserLibraryPin.library_id == Library.id)
+        .filter(UserLibraryPin.user_id == current_user.id)
+        .order_by(UserLibraryPin.pinned_at.asc(), Library.name.asc())
+    )
+
+    if not current_user.is_superuser:
+        allowed_ids = [lib.id for lib in current_user.accessible_libraries]
+        if not allowed_ids:
+            return []
+
+        pins_query = pins_query.filter(UserLibraryPin.library_id.in_(allowed_ids))
+
+    pinned_libraries = pins_query.all()
+    if not pinned_libraries:
+        return []
+
+    age_filter = get_series_age_restriction(current_user)
+    rails = []
+
+    for _pin, library in pinned_libraries:
+        recent_series_query = (
+            db.query(Series)
+            .join(Volume)
+            .join(Comic)
+            .filter(Series.library_id == library.id)
+        )
+
+        if age_filter is not None:
+            recent_series_query = recent_series_query.filter(age_filter)
+
+        recent_series = (
+            recent_series_query
+            .group_by(Series.id)
+            .order_by(desc(func.max(Comic.updated_at)), Series.name.asc())
+            .limit(limit)
+            .all()
+        )
+
+        items = _serialize_series_rail_items(db, recent_series)
+        if not items:
+            continue
+
+        rails.append({
+            "library_id": library.id,
+            "name": library.name,
+            "items": items,
+        })
+
+    return rails
 
 
 @router.get("/trending", response_model=List[dict], name="trending")

--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Annotated, Optional
 from pydantic import BaseModel
 from sqlalchemy import func, case
+from datetime import datetime, timezone
 import logging
 import os
 
@@ -9,6 +10,7 @@ from app.core.comic_helpers import get_thumbnail_url, NON_PLAIN_FORMATS, REVERSE
 from app.models.library import Library
 from app.models.series import Series
 from app.models.comic import Comic, Volume
+from app.models.interactions import UserLibraryPin
 from app.models.reading_progress import ReadingProgress
 from app.services.scan_manager import scan_manager
 from app.services.watcher import library_watcher
@@ -63,6 +65,28 @@ def _has_library_access(library_id: int, current_user: CurrentUser) -> bool:
     return True
 
 
+def _library_payload(lib: Library, *, pinned: bool = False, stats: Optional[dict] = None) -> dict:
+    payload = {
+        "id": lib.id,
+        "name": lib.name,
+        "path": lib.path,
+        "scan_on_startup": lib.scan_on_startup,
+        "watch_mode": lib.watch_mode,
+        "parse_reading_lists": lib.parse_reading_lists,
+        "parse_collections": lib.parse_collections,
+        "parse_story_arcs": lib.parse_story_arcs,
+        "last_scanned": lib.last_scanned,
+        "is_scanning": lib.is_scanning,
+        "created_at": lib.created_at,
+        "pinned": pinned,
+    }
+
+    if stats is not None:
+        payload["stats"] = stats
+
+    return payload
+
+
 @router.get("/", name="list")
 async def list_libraries(db: SessionDep,
                          current_user: CurrentUser,
@@ -87,6 +111,15 @@ async def list_libraries(db: SessionDep,
         return []
 
     lib_ids = [lib.id for lib in libs]
+    pinned_ids = {
+        row.library_id
+        for row in db.query(UserLibraryPin.library_id)
+        .filter(
+            UserLibraryPin.user_id == current_user.id,
+            UserLibraryPin.library_id.in_(lib_ids),
+        )
+        .all()
+    }
 
     # --- AGE RATING FILTER PREP ---
     # We prepare the filter once to reuse inside the loop
@@ -118,34 +151,58 @@ async def list_libraries(db: SessionDep,
     results = []
     for lib in libs:
 
-        # Construct the response dict
-        # We manually build the dict to inject the 'stats' object
-        results.append({
-            "id": lib.id,
-            "name": lib.name,
-            "path": lib.path,
-            "scan_on_startup": lib.scan_on_startup,
-            "watch_mode": lib.watch_mode,
-            "parse_reading_lists": lib.parse_reading_lists,
-            "parse_collections": lib.parse_collections,
-            "parse_story_arcs": lib.parse_story_arcs,
-            "last_scanned": lib.last_scanned,
-            "is_scanning": lib.is_scanning,
-            "created_at": lib.created_at,
-            # Lookup stats from our dictionaries (default to 0)
-            "stats": {
+        results.append(_library_payload(
+            lib,
+            pinned=lib.id in pinned_ids,
+            stats={
                 "series": series_counts.get(lib.id, 0),
                 "issues": issue_counts.get(lib.id, 0)
             }
-        })
+        ))
 
     return results
 
 
 @router.get("/{library_id}", name="detail")
-async def get_library(library: LibraryDep):
+async def get_library(library: LibraryDep, db: SessionDep, current_user: CurrentUser):
+    pin = db.query(UserLibraryPin).filter(
+        UserLibraryPin.user_id == current_user.id,
+        UserLibraryPin.library_id == library.id,
+    ).first()
 
-    return library
+    return _library_payload(library, pinned=pin is not None)
+
+
+@router.post("/{library_id}/pin", name="pin")
+async def pin_library(library: LibraryDep, db: SessionDep, current_user: CurrentUser):
+    existing = db.query(UserLibraryPin).filter(
+        UserLibraryPin.user_id == current_user.id,
+        UserLibraryPin.library_id == library.id,
+    ).first()
+
+    if existing is None:
+        db.add(UserLibraryPin(
+            user_id=current_user.id,
+            library_id=library.id,
+            pinned_at=datetime.now(timezone.utc),
+        ))
+        db.commit()
+
+    return {"library_id": library.id, "pinned": True}
+
+
+@router.delete("/{library_id}/pin", name="unpin")
+async def unpin_library(library: LibraryDep, db: SessionDep, current_user: CurrentUser):
+    pin = db.query(UserLibraryPin).filter(
+        UserLibraryPin.user_id == current_user.id,
+        UserLibraryPin.library_id == library.id,
+    ).first()
+
+    if pin is not None:
+        db.delete(pin)
+        db.commit()
+
+    return {"library_id": library.id, "pinned": False}
 
 
 @router.get("/{library_id}/series", response_model=PaginatedResponse, name="series")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,7 +10,7 @@ from app.models.reading_progress import ReadingProgress
 from app.models.bookmark import Bookmark
 from app.models.job import ScanJob
 from app.models.user import User
-from app.models.interactions import UserSeries, UserVolumeFollow, UserComicRating
+from app.models.interactions import UserSeries, UserVolumeFollow, UserLibraryPin, UserComicRating
 from app.models.saved_search import SavedSearch
 from app.models.setting import SystemSetting
 from app.models.pull_list import PullList, PullListItem
@@ -27,7 +27,7 @@ __all__ = [
     'ReadingProgress', 'ActivityLog', 'Bookmark',
     'ScanJob',
     'User',
-    'UserSeries', 'UserVolumeFollow', 'UserComicRating',
+    'UserSeries', 'UserVolumeFollow', 'UserLibraryPin', 'UserComicRating',
     'SavedSearch', 'SmartList',
     'SystemSetting',
     'PullList', 'PullListItem',

--- a/app/models/interactions.py
+++ b/app/models/interactions.py
@@ -41,6 +41,25 @@ class UserVolumeFollow(Base):
     volume = relationship("Volume", backref="user_follows")
 
 
+class UserLibraryPin(Base):
+    """
+    Junction table for User <-> Library home-page pins.
+    Stores pin order through the original pin timestamp.
+    """
+    __tablename__ = "user_library_pins"
+
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    library_id = Column(Integer, ForeignKey("libraries.id", ondelete="CASCADE"), primary_key=True)
+    pinned_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    user = relationship("User", backref="library_pins")
+    library = relationship("Library", backref="user_pins")
+
+
 class UserComicRating(Base):
     """
     Junction table for User <-> Comic rating interactions.

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -57,6 +57,31 @@
             </div>
         </div>
 
+        <div x-show="!loading.pinnedLibraries && pinnedLibraryRails.length > 0" class="space-y-12">
+            <div class="flex items-center justify-between border-b border-gray-700 pb-2">
+                <h2 class="text-xl font-bold text-white">Pinned Libraries</h2>
+                <a :href="window.parker.route('pages.libraries')" class="text-xs text-blue-400 hover:text-white transition-colors">Manage Pins</a>
+            </div>
+
+            <template x-for="rail in pinnedLibraryRails" :key="rail.library_id">
+                <div>
+                    <div class="flex items-center justify-between mb-4">
+                        <div>
+                            <h3 class="text-lg font-bold text-white" x-text="rail.name"></h3>
+                            <p class="text-xs text-gray-500">Recently updated series</p>
+                        </div>
+                        <a :href="window.parker.route('pages.library_detail', { library_id: rail.library_id })" class="text-xs text-blue-400 hover:text-white transition-colors">View Library</a>
+                    </div>
+
+                    <div class="flex space-x-4 overflow-x-auto pb-6 scrollbar-thin scrollbar-thumb-gray-700 scrollbar-track-transparent">
+                        <template x-for="series in rail.items" :key="series.id">
+                            {% include "partials/series_card.html" %}
+                        </template>
+                    </div>
+                </div>
+            </template>
+        </div>
+
         <template x-for="list in smartLists" :key="list.id">
 
             <div x-data="smartRail(list)" x-show="!loading && items.length > 0" class="mb-12">
@@ -306,6 +331,7 @@ function homePage(bootstrap = {}) {
         trendingSeries: [],
         resumeComics: [],
         followingArrivals: [],
+        pinnedLibraryRails: [],
         smartLists: [],
         popularSeries: [],
 
@@ -320,6 +346,7 @@ function homePage(bootstrap = {}) {
             trending: true,
             resume: true,
             following: true,
+            pinnedLibraries: true,
             popular: true,
         },
 
@@ -330,6 +357,7 @@ function homePage(bootstrap = {}) {
                 || this.loading.topRated || this.loading.resume
                 || this.loading.parkerTopRated
                 || this.loading.following
+                || this.loading.pinnedLibraries
                 ;
         },
 
@@ -338,7 +366,8 @@ function homePage(bootstrap = {}) {
             return this.recentSeries.length === 0
                 && this.resumeComics.length === 0
                 && this.starredSeries.length === 0
-                && this.followingArrivals.length === 0;
+                && this.followingArrivals.length === 0
+                && this.pinnedLibraryRails.length === 0;
         },
 
         get showStartupNotice() {
@@ -359,6 +388,7 @@ function homePage(bootstrap = {}) {
             this.fetchOnDeck();
             this.fetchResume();
             this.fetchFollowingArrivals();
+            this.fetchPinnedLibraries();
             this.fetchRandom();
             this.fetchTopRated();
             this.fetchTopParkerRated();
@@ -427,6 +457,14 @@ function homePage(bootstrap = {}) {
                 if (res.ok) this.followingArrivals = await res.json();
             } catch(e) { console.error(e); }
             finally { this.loading.following = false; }
+        },
+
+        async fetchPinnedLibraries() {
+            try {
+                const res = await fetch(window.parker.route('home.pinned_libraries', {}, 'limit=15'));
+                if (res.ok) this.pinnedLibraryRails = await res.json();
+            } catch(e) { console.error(e); }
+            finally { this.loading.pinnedLibraries = false; }
         },
 
         async fetchRandom() {

--- a/app/templates/libraries/index.html
+++ b/app/templates/libraries/index.html
@@ -47,6 +47,30 @@ function librariesPage() {
             } finally { 
                 this.loading = false; 
             }
+        },
+
+        async toggleLibraryPin(lib) {
+            const nextPinned = !lib.pinned;
+            lib.pinned = nextPinned;
+
+            try {
+                const res = await fetch(
+                    window.parker.route('libraries.' + (nextPinned ? 'pin' : 'unpin'), { library_id: lib.id }),
+                    { method: nextPinned ? 'POST' : 'DELETE' }
+                );
+
+                if (!res.ok) {
+                    throw new Error(nextPinned ? 'Failed to pin library' : 'Failed to unpin library');
+                }
+
+                const payload = await res.json();
+                lib.pinned = payload.pinned;
+                window.parker.showToast(payload.pinned ? 'Library pinned to Home' : 'Library unpinned from Home');
+            } catch(e) {
+                lib.pinned = !nextPinned;
+                console.error(e);
+                window.parker.showToast(e.message || 'Unable to update library pin', 'error');
+            }
         }
     }
 }

--- a/app/templates/libraries/library.html
+++ b/app/templates/libraries/library.html
@@ -14,8 +14,14 @@
             <h1 x-show="!loading.meta" class="text-3xl font-bold text-white" x-text="library?.name"></h1>
         </div>
 
-        <div x-show="!loading.meta && library?.path" class="hidden md:block text-xs text-gray-500 font-mono bg-gray-800 px-3 py-1 rounded border border-gray-700">
-            <span x-text="library?.path"></span>
+        <div x-show="!loading.meta && library">
+            <button
+                type="button"
+                x-on:click="toggleLibraryPin()"
+                class="rounded-full border px-4 py-2 text-sm font-bold transition-colors"
+                :class="library?.pinned ? 'border-blue-400/50 bg-blue-500/20 text-blue-100 hover:bg-blue-500/30' : 'border-gray-600 bg-gray-800 text-gray-300 hover:border-blue-400 hover:text-blue-100'"
+                x-text="library?.pinned ? 'Pinned to Home' : 'Pin to Home'"
+            ></button>
         </div>
     </div>
 
@@ -140,6 +146,32 @@ function libraryView() {
                 console.error(e);
             } finally {
                 this.loading.meta = false;
+            }
+        },
+
+        async toggleLibraryPin() {
+            if (!this.library) return;
+
+            const nextPinned = !this.library.pinned;
+            this.library.pinned = nextPinned;
+
+            try {
+                const res = await fetch(
+                    window.parker.route('libraries.' + (nextPinned ? 'pin' : 'unpin'), { library_id: this.libraryId }),
+                    { method: nextPinned ? 'POST' : 'DELETE' }
+                );
+
+                if (!res.ok) {
+                    throw new Error(nextPinned ? 'Failed to pin library' : 'Failed to unpin library');
+                }
+
+                const payload = await res.json();
+                this.library.pinned = payload.pinned;
+                window.parker.showToast(payload.pinned ? 'Library pinned to Home' : 'Library unpinned from Home');
+            } catch (e) {
+                this.library.pinned = !nextPinned;
+                console.error(e);
+                window.parker.showToast(e.message || 'Unable to update library pin', 'error');
             }
         },
 

--- a/app/templates/partials/library_card.html
+++ b/app/templates/partials/library_card.html
@@ -1,28 +1,43 @@
-<a :href="window.parker.route('pages.library_detail', { library_id: lib.id })"
-   class="block group bg-gray-800 hover:bg-gray-750 border border-gray-700 hover:border-blue-500/50 rounded-lg p-3 transition-all shadow-sm hover:shadow-md flex flex-col h-full relative overflow-hidden">
+<div class="group bg-gray-800 hover:bg-gray-750 border border-gray-700 hover:border-blue-500/50 rounded-lg p-3 transition-all shadow-sm hover:shadow-md flex flex-col h-full relative overflow-hidden">
 
     <div class="absolute top-0 right-0 w-16 h-16 bg-blue-500/10 rounded-bl-full -mr-8 -mt-8 transition-transform group-hover:scale-150"></div>
 
-    <div class="flex items-center gap-3 mb-2 relative z-10">
-        <div class="text-xl group-hover:scale-110 transition-transform">📂</div>
+    <button
+        type="button"
+        x-on:click.stop="toggleLibraryPin(lib)"
+        class="absolute right-2 top-2 z-20 rounded-full border px-2 py-1 text-[10px] font-bold transition-colors"
+        :class="lib.pinned ? 'border-blue-400/50 bg-blue-500/20 text-blue-100 hover:bg-blue-500/30' : 'border-gray-600 bg-gray-900/80 text-gray-300 hover:border-blue-400 hover:text-blue-100'"
+        :title="lib.pinned ? 'Unpin from Home' : 'Pin to Home'"
+        :aria-label="lib.pinned ? `Unpin ${lib.name} from Home` : `Pin ${lib.name} to Home`"
+        x-text="lib.pinned ? 'Pinned' : 'Pin'"
+    ></button>
 
-        <div class="min-w-0 flex-1">
-            <h3 class="font-bold text-gray-200 text-lg truncate group-hover:text-white" x-text="lib.name"></h3>
-            <p class="text-[10px] text-gray-500 font-mono truncate" x-text="lib.path"></p>
-        </div>
-    </div>
+    <a :href="window.parker.route('pages.library_detail', { library_id: lib.id })" class="relative z-10 flex flex-col h-full">
+        <div class="flex items-center gap-3 mb-2 pr-16">
+            <div class="text-blue-300 group-hover:scale-110 transition-transform" aria-hidden="true">
+                <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"></path>
+                </svg>
+            </div>
 
-    <template x-if="lib.stats">
-        <div class="mt-auto flex items-center gap-3 text-[12px] font-medium text-gray-400 group-hover:text-gray-300">
-            <div class="flex items-center gap-1">
-                <span class="text-blue-400">#</span>
-                <span x-text="`${lib.stats.series} Series`"></span>
-            </div>
-            <div class="w-0.5 h-3 bg-gray-700"></div>
-            <div class="flex items-center gap-1">
-                <span class="text-green-400">#</span>
-                <span x-text="`${lib.stats.issues} Issues`"></span>
+            <div class="min-w-0 flex-1">
+                <h3 class="font-bold text-gray-200 text-lg truncate group-hover:text-white" x-text="lib.name"></h3>
+                <p class="text-[10px] text-gray-500 font-mono truncate" x-text="lib.path"></p>
             </div>
         </div>
-    </template>
-</a>
+
+        <template x-if="lib.stats">
+            <div class="mt-auto flex items-center gap-3 text-[12px] font-medium text-gray-400 group-hover:text-gray-300">
+                <div class="flex items-center gap-1">
+                    <span class="text-blue-400">#</span>
+                    <span x-text="`${lib.stats.series} Series`"></span>
+                </div>
+                <div class="w-0.5 h-3 bg-gray-700"></div>
+                <div class="flex items-center gap-1">
+                    <span class="text-green-400">#</span>
+                    <span x-text="`${lib.stats.issues} Issues`"></span>
+                </div>
+            </div>
+        </template>
+    </a>
+</div>

--- a/docs/releases/0.1.24.md
+++ b/docs/releases/0.1.24.md
@@ -11,7 +11,8 @@ release.
 
 ## Added
 
-- Candidate: Add a pinned-libraries surface on the front page so favorite or most-used libraries can be reached without scanning the full library list.
+- Added per-user pinned libraries, letting users pin favorite libraries from the library list or detail page.
+- Added a Pinned Libraries home block that shows recently updated series rails for each pinned library, capped at 15 series per library and ordered by pin time.
 - Candidate: Add a folder-browse affordance to the admin Add Library flow, reducing path-entry friction for local installs where browsing is available.
 - Candidate: Expand the admin diagnostics support snapshot with proven-useful fields such as recent scan-job summaries, selected safe runtime settings, and lightweight storage/cache health checks.
 
@@ -32,7 +33,8 @@ release.
 
 ## Validation
 
-- Pending: Run focused backend tests for any touched APIs, services, migrations, and diagnostics.
+- Verified pinned-library API behavior and home rail ordering with focused library and home API tests.
 - Verified the storage helper, browser-state migration, auth refresh, idle-session cleanup, dashboard prompt dismissal, reader preference persistence, incognito reader behavior, and broader browser flows with the full Playwright browser suite.
-- Pending: Verify Alembic reports a single head and upgrades cleanly if the release includes schema changes.
-- Pending: Update README feature and roadmap notes once the final `0.1.24` scope is known.
+- Verified Alembic reports a single head and upgrades a fresh SQLite database through `3a6f4d2b9c10`.
+- Verified the pinned-library browser flow from library pinning through the home rail series clickthrough.
+- Updated README feature and roadmap notes for pinned-library home rails.

--- a/tests/api/test_home.py
+++ b/tests/api/test_home.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from app.api.home import _pick_best_cover, format_home_item
 from app.models.comic import Comic, Volume
-from app.models.interactions import UserComicRating, UserVolumeFollow
+from app.models.interactions import UserComicRating, UserLibraryPin, UserVolumeFollow
 from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
@@ -609,6 +609,63 @@ def test_home_following_arrivals_respects_baseline_formats_and_progress(auth_cli
     assert annual.id not in [item["id"] for item in payload]
     assert started_plain.id not in [item["id"] for item in payload]
     assert completed_plain.id not in [item["id"] for item in payload]
+
+
+def test_home_pinned_libraries_returns_recently_updated_series_by_pin_order(auth_client, db, normal_user):
+    first_library = Library(name="Pinned First", path="/tmp/pinned-first")
+    second_library = Library(name="Pinned Second", path="/tmp/pinned-second")
+    empty_library = Library(name="Pinned Empty", path="/tmp/pinned-empty")
+    hidden_library = Library(name="Pinned Hidden", path="/tmp/pinned-hidden")
+    db.add_all([first_library, second_library, empty_library, hidden_library])
+    db.flush()
+
+    normal_user.accessible_libraries.extend([first_library, second_library, empty_library])
+    pinned_at = datetime(2026, 7, 20, tzinfo=timezone.utc)
+    db.add_all([
+        UserLibraryPin(user_id=normal_user.id, library_id=first_library.id, pinned_at=pinned_at),
+        UserLibraryPin(user_id=normal_user.id, library_id=second_library.id, pinned_at=pinned_at + timedelta(minutes=1)),
+        UserLibraryPin(user_id=normal_user.id, library_id=empty_library.id, pinned_at=pinned_at + timedelta(minutes=2)),
+        UserLibraryPin(user_id=normal_user.id, library_id=hidden_library.id, pinned_at=pinned_at + timedelta(minutes=3)),
+    ])
+
+    for index in range(16):
+        series = Series(name=f"First Updated {index:02d}", library=first_library)
+        volume = Volume(series=series, volume_number=1)
+        db.add_all([series, volume])
+        db.flush()
+        _add_comic(
+            db,
+            volume,
+            number="1",
+            title=f"First Updated Comic {index:02d}",
+            year=2020 + index,
+            updated_at=pinned_at + timedelta(hours=index),
+        )
+
+    older_second = Series(name="Second Older", library=second_library)
+    newer_second = Series(name="Second Newer", library=second_library)
+    older_volume = Volume(series=older_second, volume_number=1)
+    newer_volume = Volume(series=newer_second, volume_number=1)
+    hidden_series = Series(name="Hidden Series", library=hidden_library)
+    hidden_volume = Volume(series=hidden_series, volume_number=1)
+    db.add_all([older_second, newer_second, older_volume, newer_volume, hidden_series, hidden_volume])
+    db.flush()
+    _add_comic(db, older_volume, number="1", title="Second Older Comic", updated_at=pinned_at)
+    _add_comic(db, newer_volume, number="1", title="Second Newer Comic", updated_at=pinned_at + timedelta(days=1))
+    _add_comic(db, hidden_volume, number="1", title="Hidden Comic", updated_at=pinned_at + timedelta(days=2))
+    db.commit()
+
+    response = auth_client.get("/api/home/pinned-libraries?limit=99")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [rail["name"] for rail in payload] == ["Pinned First", "Pinned Second"]
+    assert len(payload[0]["items"]) == 15
+    assert payload[0]["items"][0]["name"] == "First Updated 15"
+    assert payload[0]["items"][-1]["name"] == "First Updated 01"
+    assert [item["name"] for item in payload[1]["items"]] == ["Second Newer", "Second Older"]
+    assert "Pinned Empty" not in [rail["name"] for rail in payload]
+    assert "Pinned Hidden" not in [rail["name"] for rail in payload]
 
 
 def test_home_up_next_handles_duplicates_reverse_and_non_numeric(auth_client, db, normal_user):

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -6,6 +6,7 @@ from app.api.deps import get_current_user
 from app.models.comic import Comic, Volume
 from app.models.collection import Collection, CollectionItem
 from app.models.library import Library
+from app.models.interactions import UserLibraryPin
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
@@ -198,6 +199,51 @@ def test_get_library_detail_as_admin(admin_client, db):
     payload = response.json()
     assert payload["id"] == library.id
     assert payload["name"] == "Visible"
+    assert payload["pinned"] is False
+
+
+def test_user_can_pin_and_unpin_accessible_library_idempotently(auth_client, db, normal_user):
+    library = Library(name="Pinned Access", path="/tmp/pinned-access")
+    db.add(library)
+    db.commit()
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    first_pin = auth_client.post(f"/api/libraries/{library.id}/pin")
+    second_pin = auth_client.post(f"/api/libraries/{library.id}/pin")
+
+    assert first_pin.status_code == 200
+    assert second_pin.status_code == 200
+    assert first_pin.json() == {"library_id": library.id, "pinned": True}
+    assert second_pin.json() == {"library_id": library.id, "pinned": True}
+    assert db.query(UserLibraryPin).filter_by(user_id=normal_user.id, library_id=library.id).count() == 1
+
+    list_payload = auth_client.get("/api/libraries/").json()
+    assert list_payload[0]["pinned"] is True
+
+    detail_payload = auth_client.get(f"/api/libraries/{library.id}").json()
+    assert detail_payload["pinned"] is True
+
+    first_unpin = auth_client.delete(f"/api/libraries/{library.id}/pin")
+    second_unpin = auth_client.delete(f"/api/libraries/{library.id}/pin")
+
+    assert first_unpin.status_code == 200
+    assert second_unpin.status_code == 200
+    assert first_unpin.json() == {"library_id": library.id, "pinned": False}
+    assert second_unpin.json() == {"library_id": library.id, "pinned": False}
+    assert db.query(UserLibraryPin).filter_by(user_id=normal_user.id, library_id=library.id).count() == 0
+
+
+def test_user_cannot_pin_inaccessible_library(auth_client, db):
+    library = Library(name="Pinned Hidden", path="/tmp/pinned-hidden")
+    db.add(library)
+    db.commit()
+
+    pin_response = auth_client.post(f"/api/libraries/{library.id}/pin")
+    unpin_response = auth_client.delete(f"/api/libraries/{library.id}/pin")
+
+    assert pin_response.status_code == 404
+    assert unpin_response.status_code == 404
 
 
 def test_get_library_series_sorts_and_computes_cover_and_read_state(auth_client, db, normal_user):

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -20,7 +20,7 @@ from app.main import app
 from app.models.bookmark import Bookmark
 from app.models.comic import Comic, Volume
 from app.models.credits import ComicCredit, Person
-from app.models.interactions import UserVolumeFollow
+from app.models.interactions import UserLibraryPin, UserVolumeFollow
 from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.reading_list import ReadingList, ReadingListItem
@@ -172,6 +172,7 @@ def reset_browser_state(browser_db_factory, browser_seed_data):
     session = browser_db_factory()
     try:
         session.query(UserVolumeFollow).delete()
+        session.query(UserLibraryPin).delete()
         session.query(PullListItem).delete()
         session.query(PullList).delete()
         session.query(SavedSearch).delete()

--- a/tests/browser/test_search_and_series_smoke.py
+++ b/tests/browser/test_search_and_series_smoke.py
@@ -112,6 +112,25 @@ def test_dashboard_following_page_can_unfollow_volume(page, browser_server):
 
 
 @pytest.mark.browser
+def test_pinned_library_home_rail_opens_series_detail(page, browser_server):
+    seed = browser_server["seed"]
+
+    page.goto(f"{browser_server['base_url']}/libraries", wait_until="networkidle")
+    page.get_by_role("heading", name="Your Libraries").wait_for()
+    page.get_by_role("button", name="Pin Browser Test Library to Home").click()
+    page.get_by_role("button", name="Unpin Browser Test Library from Home").wait_for()
+
+    page.goto(f"{browser_server['base_url']}/", wait_until="networkidle")
+    page.get_by_role("heading", name="Pinned Libraries").wait_for()
+    pinned_block = page.locator("div").filter(has=page.get_by_role("heading", name="Pinned Libraries")).first
+    pinned_block.get_by_role("heading", name="Browser Test Library").wait_for()
+    pinned_block.locator(f'a[href*="/series/{seed["series_id"]}"]').first.click()
+
+    page.wait_for_url(f"**/series/{seed['series_id']}")
+    page.get_by_role("heading", name=seed["series_name"]).wait_for()
+
+
+@pytest.mark.browser
 def test_home_following_arrival_appears_after_import_and_clears_after_reading(page, browser_server):
     seed = browser_server["seed"]
 


### PR DESCRIPTION
## Summary

- Add per-user library pins with a new `user_library_pins` table and migration
- Add pin/unpin actions from the library list and library detail page
- Add a Home “Pinned Libraries” block showing recently updated series for pinned libraries, ordered by pin time and capped at 15 series per library
- Update README and `0.1.24` release notes for the new feature

## Validation

- `python -m pytest tests/api/test_libraries.py tests/api/test_home.py -q --no-cov`
- `python -m pytest tests/browser/test_search_and_series_smoke.py -q --no-cov`
- `python -m compileall app`
- `python -m alembic heads`
- `python -m alembic upgrade head` against a temporary SQLite database
- `git diff --check`