### PR TITLE
Add admin library path browser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,16 @@ DATABASE_URL=sqlite:///./storage/database/comics.db
 BASE_URL=/
 
 # Comics path
+# Docker Compose mounts ./comics to /comics by default.
+# Local installs should set this to the folder Parker should browse from.
 COMICS_PATH=/path/to/your/comics
 
 # Unrar path
 UNRAR_PATH=unrar
 
-# Server
-HOST=0.0.0.0
-PORT=8000
-RELOAD=false
+# Docker host port
+# Parker listens on 8000 inside the container; this controls the host port.
+PARKER_PORT=8000
 
 # Security (change in production!)
 SECRET_KEY=your-secret-key-here

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
 - **Library Management**
   - Hierarchy: `Library → Series → Volume → Comic`
   - Rich metadata (credits, tags, page counts, colors)
+  - Admin folder browser for selecting server-side library paths under `COMICS_PATH`
   - Reading Lists, Collections, Story Arcs, Stacks, Smart Lists
   - Volume-level `Following` for future issue tracking by run
   - Optional single-volume series shortcut to open the volume detail page directly
@@ -152,6 +153,20 @@ python -m pip install -r requirements.txt -r requirements-dev.txt
 If behavior differs between machines, verify both are using a freshly created
 virtualenv from these pinned requirements.
 
+### Library Browser Root
+
+The admin folder browser is scoped to `COMICS_PATH`. Docker Compose sets this to
+`/comics` by default. For local Python installs, set `COMICS_PATH` in `.env` to
+the local folder Parker should browse from, such as `D:\Comics` or
+`C:\Users\you\Comics`.
+
+### Docker Port Configuration
+
+The Docker image listens on port `8000` inside the container. To change the host
+port exposed by Docker Compose, set `PARKER_PORT` in `.env`; for example,
+`PARKER_PORT=9000` exposes Parker at host port `9000` while the container still
+uses port `8000` internally.
+
 
 ## 📌 Roadmap
 - Improve Documentation
@@ -160,7 +175,6 @@ virtualenv from these pinned requirements.
 - Enhanced WebP transcoding pipeline (JXL, AVIF to WebP)
 - Additional unit test coverage
 - Migration tooling improvements
-- Improve admin Add Library dialog to be able to browse to a folder rather than type it in
 - Support multiple folder locations per library
 - Light metadata editing with file writeback (Tentative)
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,8 +41,13 @@ This file captures follow-up work that should not get lost between releases.
   Current behavior: The follow is filtered out of the `Following` page, the `New from Following` home rail, and direct volume access checks, but the row is not pruned automatically.
   Follow-up goal: Confirm whether Parker should keep this hidden-and-persisted behavior, surface inaccessible follows in a disabled state, or automatically prune them after some explicit rule.
 
-- Design support for multi-root libraries.
+- Design safe library relocation before multi-root libraries.
+  Context: Parker currently treats absolute comic file paths as durable identity. Changing a library path can cause the next scan to remove old comic rows and import the same files at new paths, risking reading progress, bookmarks, ratings, and list membership continuity.
+  Follow-up goal: Introduce root identity and relative-path matching so a single library root can be relocated without changing matched `Comic.id` values.
+  Design note: `docs/library-relocation-scope.md`
+
+- Design support for multi-root libraries after relocation groundwork exists.
   Context: Parker currently assumes one configured filesystem root per library, but some users may want a single logical library to aggregate comics from multiple folder locations across disks, shares, or staged/import storage.
-  Scope risk: This is likely a medium-to-large architectural change rather than a simple admin-form enhancement because it would affect the data model, scanning, file watching, duplicate handling, library stats, and background-job fairness assumptions.
-  Follow-up goal: Define whether Parker should support multiple roots under one library, how root-level failures and duplicate files should be handled, and what scanner/watcher changes would be required before implementation work begins.
+  Scope risk: This is likely a medium-to-large architectural change rather than a simple admin-form enhancement because it would affect the data model, scanning, file watching, duplicate handling, library stats, and background-job fairness assumptions. It should build on `library_roots`, `Comic.library_root_id`, and `Comic.relative_path` rather than inventing a separate root model.
+  Follow-up goal: Define root add/relocate/disable/remove flows, how root-level failures and duplicate files should be handled, and what scanner/watcher changes would be required before implementation work begins.
   Design note: `docs/multi-root-library-scope.md`

--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -3,9 +3,11 @@ from typing import List, Annotated, Optional
 from pydantic import BaseModel
 from sqlalchemy import func, case
 from datetime import datetime, timezone
+from pathlib import Path as FsPath
 import logging
 import os
 
+from app.config import settings
 from app.core.comic_helpers import get_thumbnail_url, NON_PLAIN_FORMATS, REVERSE_NUMBERING_SERIES, get_series_age_restriction
 from app.models.library import Library
 from app.models.series import Series
@@ -87,6 +89,19 @@ def _library_payload(lib: Library, *, pinned: bool = False, stats: Optional[dict
     return payload
 
 
+def _resolve_library_browser_path(path: Optional[str] = None) -> tuple[FsPath, FsPath]:
+    root = settings.comics_path.expanduser().resolve()
+    requested = FsPath(path).expanduser() if path else root
+    current = requested.resolve()
+
+    try:
+        current.relative_to(root)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Path must be within the configured comics root")
+
+    return root, current
+
+
 @router.get("/", name="list")
 async def list_libraries(db: SessionDep,
                          current_user: CurrentUser,
@@ -161,6 +176,54 @@ async def list_libraries(db: SessionDep,
         ))
 
     return results
+
+
+@router.get("/browse/paths", tags=["admin"], name="browse")
+async def browse_library_paths(admin_user: AdminUser, path: Optional[str] = Query(None)):
+    root, current = _resolve_library_browser_path(path)
+
+    if not root.exists() or not root.is_dir():
+        raise HTTPException(status_code=404, detail="Configured comics root was not found")
+
+    if not current.exists() or not current.is_dir():
+        raise HTTPException(status_code=404, detail="Directory was not found")
+
+    entries = []
+    try:
+        children = sorted(current.iterdir(), key=lambda child: child.name.lower())
+    except OSError:
+        raise HTTPException(status_code=403, detail="Directory cannot be read")
+
+    for child in children:
+        try:
+            resolved_child = child.resolve()
+            resolved_child.relative_to(root)
+        except (OSError, ValueError):
+            continue
+
+        if not resolved_child.is_dir():
+            continue
+
+        entries.append({
+            "name": child.name,
+            "path": str(resolved_child),
+        })
+
+    parent = None
+    if current != root:
+        parent_path = current.parent.resolve()
+        try:
+            parent_path.relative_to(root)
+            parent = str(parent_path)
+        except ValueError:
+            parent = str(root)
+
+    return {
+        "root": str(root),
+        "current": str(current),
+        "parent": parent,
+        "entries": entries,
+    }
 
 
 @router.get("/{library_id}", name="detail")

--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     unrar_path: str = "unrar"
 
     # Storage paths
+    comics_path: Path = Path("/comics")
     log_dir: Path = Path("storage/logs")
     cache_dir: Path = Path("storage/cache")
     cover_dir: Path = Path("storage/cover")

--- a/app/templates/admin/libraries.html
+++ b/app/templates/admin/libraries.html
@@ -81,8 +81,73 @@
                 </div>
                 <div>
                     <label class="block text-sm text-gray-400 mb-1">Folder Path</label>
-                    <input type="text" x-model="form.path" class="w-full bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none" placeholder="/comics/dc">
+                    <div class="flex gap-2">
+                        <input type="text" x-model="form.path" class="flex-1 bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none" placeholder="/comics/dc">
+                        <button
+                            type="button"
+                            x-on:click="openDirectoryBrowser()"
+                            class="bg-gray-700 hover:bg-gray-600 text-white px-3 py-2 rounded transition-colors text-sm font-medium"
+                        >
+                            Browse
+                        </button>
+                    </div>
                     <p class="text-xs text-gray-500 mt-1">Server-side path where files are located.</p>
+
+                    <div x-show="pathBrowser.open" class="mt-3 border border-gray-700 rounded bg-gray-900 overflow-hidden" style="display: none;">
+                        <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-gray-700">
+                            <div class="min-w-0">
+                                <p class="text-[10px] uppercase tracking-wide text-gray-500">Browsing</p>
+                                <p class="text-xs text-gray-300 font-mono truncate" x-text="pathBrowser.current || 'Loading...'"></p>
+                            </div>
+                            <button
+                                type="button"
+                                x-on:click="closeDirectoryBrowser()"
+                                class="text-gray-500 hover:text-white text-sm"
+                            >
+                                Close
+                            </button>
+                        </div>
+
+                        <div x-show="pathBrowser.error" class="px-3 py-3 text-sm text-red-300 bg-red-950/30 border-b border-red-900/50" x-text="pathBrowser.error"></div>
+                        <div x-show="pathBrowser.notice" class="px-3 py-3 text-sm text-amber-200 bg-amber-950/30 border-b border-amber-900/50" x-text="pathBrowser.notice"></div>
+                        <div x-show="pathBrowser.loading" class="px-3 py-4 text-sm text-gray-400">Loading folders...</div>
+
+                        <div x-show="!pathBrowser.loading && !pathBrowser.error" class="max-h-64 overflow-y-auto">
+                            <button
+                                type="button"
+                                x-show="pathBrowser.parent"
+                                x-on:click="browseDirectory(pathBrowser.parent)"
+                                class="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-800 border-b border-gray-800"
+                            >
+                                ../
+                            </button>
+
+                            <template x-for="entry in pathBrowser.entries" :key="entry.path">
+                                <button
+                                    type="button"
+                                    x-on:click="browseDirectory(entry.path)"
+                                    class="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-800 border-b border-gray-800 last:border-b-0"
+                                >
+                                    <span class="text-blue-300 mr-2">/</span><span x-text="entry.name"></span>
+                                </button>
+                            </template>
+
+                            <div x-show="pathBrowser.entries.length === 0" class="px-3 py-4 text-sm text-gray-500">
+                                No subfolders found.
+                            </div>
+                        </div>
+
+                        <div class="flex justify-end gap-2 px-3 py-2 border-t border-gray-700 bg-gray-950/50">
+                            <button
+                                type="button"
+                                x-on:click="useBrowsedDirectory()"
+                                class="bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 rounded text-sm transition-colors"
+                                :disabled="!pathBrowser.current"
+                            >
+                                Use This Folder
+                            </button>
+                        </div>
+                    </div>
                 </div>
                 <div>
                     <label class="flex items-center gap-2 cursor-pointer">
@@ -154,6 +219,16 @@ function libraryManager() {
             parse_collections: true,
             parse_story_arcs: true,
         },
+        pathBrowser: {
+            open: false,
+            loading: false,
+            error: '',
+            notice: '',
+            root: '',
+            current: '',
+            parent: null,
+            entries: [],
+        },
         pollInterval: null,
 
         init() {
@@ -187,6 +262,7 @@ function libraryManager() {
                 parse_collections: true,
                 parse_story_arcs: true,
             };
+            this.closeDirectoryBrowser();
             this.showModal = true;
         },
 
@@ -201,7 +277,64 @@ function libraryManager() {
                 parse_collections: lib.parse_collections ?? true,
                 parse_story_arcs: lib.parse_story_arcs ?? true,
             };
+            this.closeDirectoryBrowser();
             this.showModal = true;
+        },
+
+        async openDirectoryBrowser() {
+            this.pathBrowser.open = true;
+            const requestedPath = this.form.path || null;
+            const openedRequestedPath = await this.browseDirectory(requestedPath);
+
+            if (!openedRequestedPath && requestedPath) {
+                const originalError = this.pathBrowser.error;
+                const openedRoot = await this.browseDirectory(null);
+                if (openedRoot) {
+                    this.pathBrowser.notice = `${originalError}. Showing the configured comics root instead.`;
+                }
+            }
+        },
+
+        closeDirectoryBrowser() {
+            this.pathBrowser.open = false;
+            this.pathBrowser.loading = false;
+            this.pathBrowser.error = '';
+            this.pathBrowser.notice = '';
+        },
+
+        async browseDirectory(path) {
+            this.pathBrowser.loading = true;
+            this.pathBrowser.error = '';
+            this.pathBrowser.notice = '';
+
+            try {
+                const query = path ? `path=${encodeURIComponent(path)}` : '';
+                const res = await fetch(window.parker.route('libraries.browse', {}, query));
+                const payload = await res.json();
+
+                if (!res.ok) {
+                    throw new Error(payload.detail || 'Unable to browse folders');
+                }
+
+                this.pathBrowser.root = payload.root;
+                this.pathBrowser.current = payload.current;
+                this.pathBrowser.parent = payload.parent;
+                this.pathBrowser.entries = payload.entries || [];
+                return true;
+            } catch (e) {
+                console.error(e);
+                this.pathBrowser.error = e.message || 'Unable to browse folders';
+                this.pathBrowser.entries = [];
+                return false;
+            } finally {
+                this.pathBrowser.loading = false;
+            }
+        },
+
+        useBrowsedDirectory() {
+            if (!this.pathBrowser.current) return;
+            this.form.path = this.pathBrowser.current;
+            this.closeDirectoryBrowser();
         },
 
         async saveLibrary() {

--- a/app/templates/admin/libraries.html
+++ b/app/templates/admin/libraries.html
@@ -92,6 +92,9 @@
                         </button>
                     </div>
                     <p class="text-xs text-gray-500 mt-1">Server-side path where files are located.</p>
+                    <div x-show="isPathChanged" class="mt-2 rounded border border-amber-500/30 bg-amber-950/30 px-3 py-2 text-xs text-amber-100" style="display: none;">
+                        Changing a library path can cause Parker to remove and re-import comics on the next scan. Reading progress, bookmarks, ratings, and list membership may not be preserved unless files keep the same server-visible paths.
+                    </div>
 
                     <div x-show="pathBrowser.open" class="mt-3 border border-gray-700 rounded bg-gray-900 overflow-hidden" style="display: none;">
                         <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-gray-700">
@@ -214,6 +217,7 @@ function libraryManager() {
             id: null,
             name: '',
             path: '',
+            original_path: '',
             watch_mode: false,
             parse_reading_lists: true,
             parse_collections: true,
@@ -230,6 +234,10 @@ function libraryManager() {
             entries: [],
         },
         pollInterval: null,
+
+        get isPathChanged() {
+            return this.isEditing && this.form.path !== this.form.original_path;
+        },
 
         init() {
             this.loadLibraries();
@@ -257,6 +265,7 @@ function libraryManager() {
                 id: null,
                 name: '',
                 path: '',
+                original_path: '',
                 watch_mode: false,
                 parse_reading_lists: true,
                 parse_collections: true,
@@ -272,6 +281,7 @@ function libraryManager() {
                 id: lib.id,
                 name: lib.name,
                 path: lib.path,
+                original_path: lib.path,
                 watch_mode: lib.watch_mode,
                 parse_reading_lists: lib.parse_reading_lists ?? true,
                 parse_collections: lib.parse_collections ?? true,
@@ -366,6 +376,7 @@ function libraryManager() {
                         id: null,
                         name: '',
                         path: '',
+                        original_path: '',
                         watch_mode: false,
                         parse_reading_lists: true,
                         parse_collections: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: parker
     user: "${UID}:${GID}"
     ports:
-      - "8000:8000"
+      - "${PARKER_PORT:-8000}:8000"
     volumes:
       - ./comics:/comics:ro  # Mount your comics directory
       - ./data:/app/storage

--- a/docs/library-relocation-scope.md
+++ b/docs/library-relocation-scope.md
@@ -1,0 +1,196 @@
+# Library Relocation Scope
+
+Status: Draft
+
+This note captures a future enhancement for safely changing the filesystem path of an existing Parker library without losing comic identity.
+
+The immediate user problem is simple: admins can edit a library path today, either by typing a new path or by using the admin folder browser. Parker accepts the change, but the next scan can treat all old files as deleted and all files under the new path as new imports.
+
+That behavior is understandable from the current data model, but it is risky because user state hangs from existing `Comic.id` rows.
+
+## Why This Exists
+
+Parker currently stores physical file identity primarily as `Comic.file_path`.
+
+If a library moves from one server-visible path to another, the same archive can look like a completely different comic:
+
+- old path: `/comics/DC/Batman/Batman 001.cbz`
+- new path: `/mnt/comics/DC/Batman/Batman 001.cbz`
+
+The comic content and logical position are the same, but the stored absolute path changed.
+
+Today, changing `Library.path` does not rewrite existing comic paths. During the next scan, `LibraryScanner` scans the new root, builds a set of discovered paths, and removes existing comics whose old paths were not seen. The scanner then imports matching files at their new paths as new rows.
+
+That can break continuity for:
+
+- reading progress
+- bookmarks
+- Parker ratings
+- reading list, stack, and collection membership
+- other future user-attached comic state
+
+## Product Framing
+
+Relocation should be an explicit admin operation, not just a silent side effect of editing a text field.
+
+Recommended UI framing:
+
+- `Edit Library` for name and scanning/settings changes
+- `Relocate Library Path` or `Relocate Root` for path moves
+
+The relocation flow should preview impact before writing changes.
+
+## Recommended Direction
+
+Treat this as a library root identity problem.
+
+Introduce a durable root record and store comic paths relative to that root:
+
+- `Library` remains the logical library
+- `LibraryRoot` represents a physical filesystem root
+- `Comic.library_root_id` points to the physical root that contains the file
+- `Comic.relative_path` stores the path under that root
+- `Comic.file_path` may initially remain as a cached absolute path for compatibility
+
+This allows Parker to preserve `Comic.id` when only the root path changes.
+
+## Suggested Data Model
+
+Add `library_roots`:
+
+- `id`
+- `library_id`
+- `path`
+- `is_active`
+- `created_at`
+- `updated_at`
+- optional: `last_scanned_at`
+- optional: `last_scan_error`
+
+Add to `comics`:
+
+- `library_root_id`
+- `relative_path`
+
+Keep initially:
+
+- `libraries.path`
+- `comics.file_path`
+
+The compatibility period should be as short as practical, but keeping these fields during the transition will reduce blast radius.
+
+## Migration Strategy
+
+The first migration should preserve current behavior.
+
+1. Create `library_roots`.
+2. Backfill one root for each existing library from `libraries.path`.
+3. Add nullable `Comic.library_root_id` and `Comic.relative_path`.
+4. Backfill each comic by comparing `Comic.file_path` to its library root path.
+5. Keep unmatched comics visible and report them as migration warnings instead of deleting them.
+6. Update scanner and readers to tolerate both old and new fields during transition.
+7. Once stable, make `library_root_id` and `relative_path` required for newly scanned comics.
+
+## Relocation Flow
+
+A safe relocation should look like this:
+
+1. Admin selects an existing library root.
+2. Admin chooses a new root path.
+3. Parker computes each existing comic's expected new path from `new_root / relative_path`.
+4. Parker previews:
+   - matched files at the new root
+   - missing files at the new root
+   - new files found under the new root
+   - conflicts or duplicate candidates
+5. Admin confirms.
+6. Parker updates the root path and cached `Comic.file_path` values for matched comics.
+7. Parker queues or recommends a scan.
+
+Important rule:
+
+- relocation should preserve existing `Comic.id` for matched files
+
+That is the main reason to build a relocation flow instead of relying on delete/re-import scanning.
+
+## Matching Rules
+
+Initial matching should be conservative:
+
+1. match by `library_root_id + relative_path`
+2. optionally verify file size and modified time when available
+3. do not use content hashes in the first implementation unless there is already a hashing system
+
+If a file is missing from the new root, the preview should not delete it automatically.
+
+If a file appears at the new root but has no existing relative-path match, it should be treated as a new import candidate.
+
+## Scanner Impact
+
+The scanner should stop using absolute path as the only durable identity.
+
+During scanning:
+
+- resolve the active root
+- compute relative path for each archive
+- find existing comic by `(library_root_id, relative_path)`
+- update cached absolute `file_path` if needed
+- preserve `Comic.id` when the relative identity matches
+
+Cleanup should operate within the relevant root identity, not by comparing old absolute paths against new absolute paths.
+
+## Admin UI Guardrails
+
+Short term, Parker should warn when an admin edits the path field.
+
+Long term, the path field should move behind explicit actions:
+
+- `Relocate Root`
+- `Disable Root`
+- `Remove Root`
+
+The relocation action should have an impact preview and confirmation step.
+
+## Relationship To Multi-Root Libraries
+
+Library relocation should come before multi-root library support.
+
+It introduces the root table, relative path identity, scanner lookup rules, and safe admin preview patterns that multi-root support will need anyway.
+
+Once relocation exists, multi-root support becomes an extension from one root per library to many roots per library.
+
+## Non-Goals
+
+Out of scope for an initial relocation feature:
+
+- content-hash deduplication
+- merging two separate Parker libraries into one
+- root-level permissions
+- automatic filesystem discovery outside configured roots
+- rewriting user state by fuzzy metadata matches
+
+## Testing Notes
+
+Minimum coverage should include:
+
+- migration backfills one root per existing library
+- migration backfills comic relative paths under the root
+- relocation preview counts matched, missing, and new files
+- confirmed relocation preserves `Comic.id`
+- reading progress/bookmarks/ratings remain attached after relocation
+- scanner does not delete matched comics after root relocation
+- path overlap validation still prevents ambiguous ownership
+
+## Open Questions
+
+- Should relocation be allowed while a library scan is running?
+- Should Parker allow relocation when some files are missing from the new root?
+- Should relocation update `last_scanned` or require a follow-up scan?
+- Should unmatched files remain in the database as disabled/missing records, or continue using current cleanup behavior after confirmation?
+- How long should `Library.path` and `Comic.file_path` remain as compatibility fields?
+
+## Effort Estimate
+
+This is smaller than full multi-root support but still a meaningful schema and scanner project.
+
+It is best treated as a deliberate feature, not a small admin-form enhancement.

--- a/docs/multi-root-library-scope.md
+++ b/docs/multi-root-library-scope.md
@@ -4,6 +4,10 @@ Status: Draft
 
 This note captures a possible future enhancement where one Parker library can aggregate comics from multiple filesystem roots instead of a single configured folder.
 
+Related design note: `docs/library-relocation-scope.md`.
+
+Recommended sequencing: build graceful library-root relocation before full multi-root support. Relocation introduces the root identity and relative-path model that multi-root support should reuse.
+
 The goal is to document the likely impact area before real user demand exists, so the work can be evaluated intentionally later instead of being estimated from memory.
 
 ## Why This Exists
@@ -63,6 +67,23 @@ The admin should still explicitly decide which roots belong to a library.
 
 Recommended direction: add a dedicated child table rather than overloading `Library.path`.
 
+This should align with the relocation design:
+
+- `Library` stays the logical library
+- `LibraryRoot` represents a physical filesystem root
+- `Series.library_id` remains attached to the logical library
+- `Comic.library_root_id` identifies the root containing the physical archive
+- `Comic.relative_path` identifies the archive under that root
+
+In other words, the hierarchy remains:
+
+- `Library -> Series -> Volume -> Comic`
+
+Storage roots sit beside that hierarchy:
+
+- `Library -> LibraryRoot`
+- `Comic -> LibraryRoot`
+
 Example shape:
 
 - keep `libraries` as the logical library record
@@ -76,6 +97,7 @@ Possible columns:
 - `library_id`
 - `path`
 - `created_at`
+- `updated_at`
 
 Optional future columns if needed:
 
@@ -92,13 +114,15 @@ Why this is preferable:
 
 ## Migration Strategy
 
-The least risky migration would be:
+The least risky migration would be shared with the library relocation work:
 
 1. create `library_roots`
 2. backfill one root row from each existing `libraries.path`
-3. keep `libraries.path` temporarily for compatibility during the transition
-4. update application code to read roots from the new table
-5. remove or deprecate direct `Library.path` usage after the codebase is fully migrated
+3. add `Comic.library_root_id` and `Comic.relative_path`
+4. backfill each comic's root and relative path
+5. keep `libraries.path` and `comics.file_path` temporarily for compatibility during the transition
+6. update application code to read roots from the new table
+7. remove or deprecate direct `Library.path` usage after the codebase is fully migrated
 
 The exact length of the compatibility period is a product decision.
 If the code churn is manageable, it may be cleaner to migrate quickly rather than support dual behavior for too long.
@@ -118,13 +142,14 @@ With multi-root support, Parker would likely need to:
 
 - resolve all roots for the library
 - scan each root recursively
-- union all discovered archive paths into one logical scan set
-- preserve one cleanup pass over the combined discovered-path set
+- compute `relative_path` under the current root for each archive
+- match existing comics by `(library_root_id, relative_path)`
+- preserve one cleanup pass that understands root identity
 
 Important nuance:
 
-- cleanup should treat a file as missing only if it is absent from every configured root
-- this is conceptually simple once scanning already produces one combined `scanned_paths_on_disk`
+- cleanup should treat a file as missing only within the root that owns that comic
+- moving a file between roots is a different operation from a normal scan and should require a deliberate relocation or reconciliation flow
 
 ## Watcher Impact
 
@@ -175,7 +200,8 @@ The admin library flows in `app/api/libraries.py` currently assume:
 
 Multi-root support would need:
 
-- create/edit APIs that accept a collection of roots
+- create/edit APIs that expose a collection of roots
+- explicit root actions such as add, relocate, disable, and remove
 - root add/remove/update UI
 - validation that checks every candidate root against every existing root in the system
 
@@ -184,6 +210,7 @@ Recommended guardrails:
 - reject roots that overlap one another, even inside the same library
 - reject roots that overlap another library's roots
 - normalize path comparisons before validating
+- avoid silently changing root paths through a generic library edit form
 
 This keeps the mental model simple and avoids ambiguous ownership of the same subtree.
 
@@ -205,6 +232,7 @@ Recommended initial stance:
 - do not attempt content-level deduplication as part of the first multi-root release
 - keep prevention focused on root-overlap validation
 - treat broader duplicate detection as a separate problem
+- use `(library_root_id, relative_path)` as the physical file identity, not absolute path alone
 
 ## Diagnostics And Support Impact
 
@@ -261,6 +289,8 @@ The smallest useful implementation would likely be:
 - keep permissions library-based
 - keep duplicate handling conservative and simple
 
+This MVP assumes the relocation groundwork exists first. If it does not, the MVP should begin by introducing `library_roots`, `Comic.library_root_id`, and `Comic.relative_path` before adding multiple roots to the UI.
+
 ## Open Questions
 
 - Should an empty library be allowed to exist temporarily with zero roots during editing?
@@ -273,14 +303,13 @@ The smallest useful implementation would likely be:
 
 If Parker ever decides to build this, a safe order would likely be:
 
-1. add schema and migration for `library_roots`
-2. backfill existing library paths
-3. update internal services to read roots
-4. update scanner cleanup behavior across combined roots
+1. implement safe single-root relocation as described in `docs/library-relocation-scope.md`
+2. keep one root per library until scanner, reader, watcher, and diagnostics understand root identity
+3. add admin UI/API support for adding more roots to an existing library
+4. update scanner cleanup behavior across root identities
 5. update watcher scheduling/bookkeeping
-6. update admin APIs and UI
-7. update diagnostics and support surfaces
-8. add regression coverage
+6. update diagnostics and support surfaces
+7. add regression coverage
 
 ## Testing Notes
 

--- a/docs/releases/0.1.24.md
+++ b/docs/releases/0.1.24.md
@@ -13,7 +13,7 @@ release.
 
 - Added per-user pinned libraries, letting users pin favorite libraries from the library list or detail page.
 - Added a Pinned Libraries home block that shows recently updated series rails for each pinned library, capped at 15 series per library and ordered by pin time.
-- Candidate: Add a folder-browse affordance to the admin Add Library flow, reducing path-entry friction for local installs where browsing is available.
+- Added an admin folder browser for the Add/Edit Library dialog, scoped to the configured `COMICS_PATH` root.
 - Candidate: Expand the admin diagnostics support snapshot with proven-useful fields such as recent scan-job summaries, selected safe runtime settings, and lightweight storage/cache health checks.
 
 ## Changed
@@ -21,6 +21,8 @@ release.
 - Centralized Parker's browser `localStorage` access behind the shared storage helper and moved app-owned keys into the `parker.*` namespace.
 - Added backwards-compatible browser-state migration so existing auth tokens, reader preferences, dashboard dismissals, and login-effect preferences continue working when old keys are encountered.
 - Split the browser storage helper into a lightweight standalone script so the login page can share namespaced storage without loading the full app shell JavaScript.
+- Clarified Docker port configuration by mapping `PARKER_PORT` to the host port while keeping Parker's internal container port fixed at `8000`.
+- Clarified `COMICS_PATH` usage for local installs and made the admin folder browser fall back to the configured root when the current field is outside that root.
 - Candidate: Decide and document the long-term behavior for followed volumes that later become inaccessible through library permissions or age-rating filters.
 - Candidate: Improve the WebP/transcoding pipeline for modern source formats, especially `AVIF` and `JPEG XL`, if the scope stays focused and testable.
 - Candidate: Keep multi-root library support in design/scoping unless `0.1.24` becomes a deliberate storage-architecture release.
@@ -38,3 +40,4 @@ release.
 - Verified Alembic reports a single head and upgrades a fresh SQLite database through `3a6f4d2b9c10`.
 - Verified the pinned-library browser flow from library pinning through the home rail series clickthrough.
 - Updated README feature and roadmap notes for pinned-library home rails.
+- Verified folder browsing API coverage for root listing, child navigation, non-admin rejection, outside-root rejection, and missing-root handling.

--- a/docs/releases/0.1.24.md
+++ b/docs/releases/0.1.24.md
@@ -23,6 +23,7 @@ release.
 - Split the browser storage helper into a lightweight standalone script so the login page can share namespaced storage without loading the full app shell JavaScript.
 - Clarified Docker port configuration by mapping `PARKER_PORT` to the host port while keeping Parker's internal container port fixed at `8000`.
 - Clarified `COMICS_PATH` usage for local installs and made the admin folder browser fall back to the configured root when the current field is outside that root.
+- Captured future planning for safe library relocation and multi-root library support around root identity and relative paths.
 - Candidate: Decide and document the long-term behavior for followed volumes that later become inaccessible through library permissions or age-rating filters.
 - Candidate: Improve the WebP/transcoding pipeline for modern source formats, especially `AVIF` and `JPEG XL`, if the scope stays focused and testable.
 - Candidate: Keep multi-root library support in design/scoping unless `0.1.24` becomes a deliberate storage-architecture release.

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -202,6 +202,76 @@ def test_get_library_detail_as_admin(admin_client, db):
     assert payload["pinned"] is False
 
 
+def test_admin_can_browse_library_paths_within_configured_root(admin_client, monkeypatch, tmp_path):
+    root = tmp_path / "comics"
+    zeta = root / "Zeta"
+    alpha = root / "Alpha"
+    nested = alpha / "Nested"
+    nested.mkdir(parents=True)
+    zeta.mkdir(parents=True)
+    (root / "comic.cbz").write_text("not a directory")
+    monkeypatch.setattr("app.api.libraries.settings.comics_path", root)
+
+    root_response = admin_client.get("/api/libraries/browse/paths")
+
+    assert root_response.status_code == 200
+    root_payload = root_response.json()
+    assert root_payload["root"] == str(root.resolve())
+    assert root_payload["current"] == str(root.resolve())
+    assert root_payload["parent"] is None
+    assert root_payload["entries"] == [
+        {"name": "Alpha", "path": str(alpha.resolve())},
+        {"name": "Zeta", "path": str(zeta.resolve())},
+    ]
+
+    child_response = admin_client.get(
+        "/api/libraries/browse/paths",
+        params={"path": str(alpha)},
+    )
+
+    assert child_response.status_code == 200
+    child_payload = child_response.json()
+    assert child_payload["current"] == str(alpha.resolve())
+    assert child_payload["parent"] == str(root.resolve())
+    assert child_payload["entries"] == [{"name": "Nested", "path": str(nested.resolve())}]
+
+
+def test_library_path_browser_rejects_non_admin(auth_client, monkeypatch, tmp_path):
+    root = tmp_path / "comics"
+    root.mkdir()
+    monkeypatch.setattr("app.api.libraries.settings.comics_path", root)
+
+    response = auth_client.get("/api/libraries/browse/paths")
+
+    assert response.status_code == 400
+
+
+def test_library_path_browser_rejects_outside_paths(admin_client, monkeypatch, tmp_path):
+    root = tmp_path / "comics"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    monkeypatch.setattr("app.api.libraries.settings.comics_path", root)
+
+    response = admin_client.get(
+        "/api/libraries/browse/paths",
+        params={"path": str(outside)},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Path must be within the configured comics root"}
+
+
+def test_library_path_browser_reports_missing_root(admin_client, monkeypatch, tmp_path):
+    missing_root = tmp_path / "missing"
+    monkeypatch.setattr("app.api.libraries.settings.comics_path", missing_root)
+
+    response = admin_client.get("/api/libraries/browse/paths")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Configured comics root was not found"}
+
+
 def test_user_can_pin_and_unpin_accessible_library_idempotently(auth_client, db, normal_user):
     library = Library(name="Pinned Access", path="/tmp/pinned-access")
     db.add(library)

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -129,6 +129,7 @@ def test_admin_libraries_page_exposes_folder_browser_route(admin_client):
     body = response.text
     assert "Browse" in body
     assert "libraries.browse" in body
+    assert "Changing a library path can cause Parker to remove and re-import comics" in body
 
 
 def test_search_widget_people_results_use_generic_creator_handoff(auth_client):

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -122,6 +122,15 @@ def test_admin_settings_page_exposes_quick_navigation(admin_client):
     assert 'x-text="setting.key"' not in body
 
 
+def test_admin_libraries_page_exposes_folder_browser_route(admin_client):
+    response = admin_client.get("/admin/libraries")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Browse" in body
+    assert "libraries.browse" in body
+
+
 def test_search_widget_people_results_use_generic_creator_handoff(auth_client):
     response = auth_client.get("/")
 


### PR DESCRIPTION
## Summary

- Add a `COMICS_PATH`-scoped folder browser to the admin Add/Edit Library dialog
- Add an admin-only library path browsing API that lists immediate child directories and prevents browsing outside the configured comics root
- Clarify Docker/local configuration for `COMICS_PATH` and `PARKER_PORT`
- Updated https://github.com/parker-server/parker/wiki/Getting-Started to better reflect the change above
- Add a warning when editing an existing library path, since path changes can cause remove/re-import behavior on the next scan
- Capture future planning for safe library relocation and multi-root library support

## Validation

- `python -m pytest tests/api/test_libraries.py tests/api/test_pages.py -q --no-cov`
- `python -m compileall app`
- `git diff --check`