### PR TITLE
Add OPDS pagination for large feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
 
 - **OPDS Support**
   - OPDS 1.2 compliant feeds
+  - Paginated library and series feeds
   - Dublin Core metadata
   - Legacy client authentication
   - JPEG cover thumbnails for reader compatibility

--- a/app/routers/opds.py
+++ b/app/routers/opds.py
@@ -5,9 +5,11 @@ from datetime import datetime, timezone
 from collections import defaultdict
 from io import BytesIO
 from pathlib import Path
+from typing import Annotated
 from urllib.parse import quote
 from PIL import Image
 
+from app.api.deps import PaginationParams
 from app.api.opds_deps import OPDSUser, SessionDep
 from app.models import ComicCredit
 from app.models.library import Library
@@ -34,6 +36,7 @@ OPDS_ACQUISITION_TYPES = {
 }
 
 INVALID_FILENAME_CHARS = set('<>:"/\\|?*')
+OPDS_CATALOG_FEED_TYPE = "application/atom+xml;profile=opds-catalog"
 
 
 def format_opds_datetime(value: datetime | None) -> str:
@@ -144,8 +147,31 @@ def get_opds_thumbnail_path(comic: Comic) -> Path | None:
     return None
 
 
+def get_opds_pagination_links(request: Request, total: int, params: PaginationParams) -> list[dict[str, str]]:
+    """Return Atom pagination links for OPDS feeds."""
+    total_pages = max(1, (total + params.size - 1) // params.size)
+
+    def page_url(page: int) -> str:
+        return str(request.url.include_query_params(page=page, size=params.size))
+
+    links = [
+        {"rel": "self", "href": page_url(params.page), "type": OPDS_CATALOG_FEED_TYPE},
+        {"rel": "first", "href": page_url(1), "type": OPDS_CATALOG_FEED_TYPE},
+        {"rel": "last", "href": page_url(total_pages), "type": OPDS_CATALOG_FEED_TYPE},
+    ]
+
+    if params.page > 1:
+        links.append({"rel": "previous", "href": page_url(params.page - 1), "type": OPDS_CATALOG_FEED_TYPE})
+
+    if params.page < total_pages:
+        links.append({"rel": "next", "href": page_url(params.page + 1), "type": OPDS_CATALOG_FEED_TYPE})
+
+    return links
+
+
 # Helper to render XML
 def render_xml(request: Request, context: dict):
+    context.setdefault("feed_links", [])
     return templates.TemplateResponse(
         request=request,
         name="opds/feed.xml",
@@ -199,7 +225,13 @@ async def opds_root(request: Request, user: OPDSUser, db: SessionDep):
 
 # 2. LIBRARY: List Series
 @router.get("/libraries/{library_id}", name="library")
-async def opds_library(library_id: int, request: Request, user: OPDSUser, db: SessionDep):
+async def opds_library(
+        library_id: int,
+        request: Request,
+        user: OPDSUser,
+        db: SessionDep,
+        params: Annotated[PaginationParams, Depends()]
+):
     # Security check using your existing accessible_libraries logic
 
     if not user.is_superuser:
@@ -218,17 +250,20 @@ async def opds_library(library_id: int, request: Request, user: OPDSUser, db: Se
         query = query.filter(age_filter)
     # -------------------------------------
 
-    series_list = query.order_by(Series.name).all()
+    total = query.count()
+    series_list = query.order_by(Series.name).offset(params.skip).limit(params.size).all()
 
     # Collect Series IDs
     series_ids = [s.id for s in series_list]
     # Fetch ALL Comics for these series in one go (Lightweight columns only)
-    raw_comics = (
-        db.query(Comic.id, Comic.number, Comic.year,
-                 Comic.format, Comic.updated_at, Comic.thumbnail_path,
-            Volume.series_id, Volume.volume_number
-        ).join(Volume).filter(Volume.series_id.in_(series_ids)).all()
-    )
+    raw_comics = []
+    if series_ids:
+        raw_comics = (
+            db.query(Comic.id, Comic.number, Comic.year,
+                     Comic.format, Comic.updated_at, Comic.thumbnail_path,
+                Volume.series_id, Volume.volume_number
+            ).join(Volume).filter(Volume.series_id.in_(series_ids)).all()
+        )
 
     # Group Comics by Series in Python
     series_map = defaultdict(list)
@@ -268,6 +303,7 @@ async def opds_library(library_id: int, request: Request, user: OPDSUser, db: Se
         "feed_id": f"urn:parker:lib:{library_id}",
         "feed_title": library.name,
         "updated_at": format_opds_datetime(datetime.now(timezone.utc)),
+        "feed_links": get_opds_pagination_links(request, total, params),
         "entries": entries,
         "books": []
     })
@@ -276,7 +312,13 @@ async def opds_library(library_id: int, request: Request, user: OPDSUser, db: Se
 # 3. SERIES: List Comics (Flattening Volumes)
 
 @router.get("/series/{series_id}", name="series")
-async def opds_series(series_id: int, request: Request, user: OPDSUser, db: SessionDep):
+async def opds_series(
+        series_id: int,
+        request: Request,
+        user: OPDSUser,
+        db: SessionDep,
+        params: Annotated[PaginationParams, Depends()]
+):
 
     # Security check for Series existence and Library Access would ideally happen here too
     # Assuming 'get_series_age_restriction' at library level helps, but let's be strict.
@@ -295,11 +337,12 @@ async def opds_series(series_id: int, request: Request, user: OPDSUser, db: Sess
         query = query.filter(age_filter)
     # ---------------------------------------
 
+    total = query.count()
     comics = query.options(
             joinedload(Comic.credits).joinedload(ComicCredit.person), # Load credits + person names
             joinedload(Comic.genres),    # Load Genres
             joinedload(Comic.volume).joinedload(Volume.series) # Load Series Name
-        ).order_by(Volume.volume_number, Comic.number).all()
+        ).order_by(Volume.volume_number, Comic.number).offset(params.skip).limit(params.size).all()
 
     # If all comics are restricted, handle empty list gracefully
     feed_title = "Series"
@@ -314,6 +357,7 @@ async def opds_series(series_id: int, request: Request, user: OPDSUser, db: Sess
         "feed_id": f"urn:parker:series:{series_id}",
         "feed_title": feed_title,
         "updated_at": format_opds_datetime(datetime.now(timezone.utc)),
+        "feed_links": get_opds_pagination_links(request, total, params),
         "entries": [],
         "books": comics
     })

--- a/app/templates/opds/feed.xml
+++ b/app/templates/opds/feed.xml
@@ -10,6 +10,12 @@
     <name>Parker Media Server</name>
   </author>
 
+  {% for link in feed_links %}
+  <link rel="{{ link.rel }}"
+        type="{{ link.type }}"
+        href="{{ link.href }}"/>
+  {% endfor %}
+
   {# --- NAVIGATION ENTRIES (Libraries/Series) --- #}
   {% for entry in entries %}
   <entry>

--- a/docs/opds-expansion-scope.md
+++ b/docs/opds-expansion-scope.md
@@ -44,6 +44,7 @@ Current compatibility choices:
 
 - OPDS feeds use a realm-bearing Basic Auth challenge.
 - navigation links are absolute.
+- library and series feeds support page/size pagination.
 - issue acquisition links use filename-bearing download URLs.
 - each issue emits one acquisition link.
 - OPDS cover links point at a JPEG-specific thumbnail endpoint.
@@ -64,12 +65,15 @@ Out of scope for the first expansion pass:
 
 ### 1. Pagination
 
-Add pagination to large OPDS feeds before adding many more feed types.
+Initial support has been added for the library series feed and the series issue feed. Future OPDS feed types should reuse the same `page`/`size` query params and Atom pagination links.
 
-This should cover:
+Initial coverage:
 
 - library series feeds
 - series issue feeds if needed
+
+Future coverage:
+
 - future collection, reading list, smart list, and search feeds
 
 The feed should expose standard OPDS/Atom navigation links such as `next`, `previous`, `first`, and `last` where practical.
@@ -225,4 +229,3 @@ Suggested smoke tests:
 - download a CBR and confirm client-specific behavior
 - test a large library feed once pagination exists
 - test access restrictions for users with limited libraries or age ratings
-

--- a/docs/releases/0.1.24.md
+++ b/docs/releases/0.1.24.md
@@ -14,6 +14,8 @@ release.
 - Added per-user pinned libraries, letting users pin favorite libraries from the library list or detail page.
 - Added a Pinned Libraries home block that shows recently updated series rails for each pinned library, capped at 15 series per library and ordered by pin time.
 - Added an admin folder browser for the Add/Edit Library dialog, scoped to the configured `COMICS_PATH` root.
+- Added OPDS pagination for library series feeds and series issue feeds using `page`/`size` query params plus Atom pagination links.
+- Added a draft OPDS expansion scope note covering future pagination reuse, richer root feeds, Continue From entries, OPDS search, structured volume browsing, revocable OPDS tokens, progress markers, and OPDS-PS.
 - Candidate: Expand the admin diagnostics support snapshot with proven-useful fields such as recent scan-job summaries, selected safe runtime settings, and lightweight storage/cache health checks.
 
 ## Changed
@@ -24,6 +26,7 @@ release.
 - Clarified Docker port configuration by mapping `PARKER_PORT` to the host port while keeping Parker's internal container port fixed at `8000`.
 - Clarified `COMICS_PATH` usage for local installs and made the admin folder browser fall back to the configured root when the current field is outside that root.
 - Captured future planning for safe library relocation and multi-root library support around root identity and relative paths.
+- Improved OPDS reader compatibility with a realm-bearing Basic Auth challenge, absolute feed links, filename-bearing acquisition URLs, one acquisition link per issue, and JPEG-specific OPDS cover thumbnails.
 - Candidate: Decide and document the long-term behavior for followed volumes that later become inaccessible through library permissions or age-rating filters.
 - Candidate: Improve the WebP/transcoding pipeline for modern source formats, especially `AVIF` and `JPEG XL`, if the scope stays focused and testable.
 - Candidate: Keep multi-root library support in design/scoping unless `0.1.24` becomes a deliberate storage-architecture release.
@@ -31,6 +34,7 @@ release.
 ## Fixed
 
 - Candidate: Improve container-level Continue behavior so reading lists, collections, stacks, and story arcs can resume at the best in-progress or next unread item within that specific context.
+- Fixed OPDS cover metadata so reader clients receive JPEG image links that match the advertised MIME type instead of WebP thumbnail URLs labelled as JPEG.
 - Candidate: Tune startup diagnostics so true first-run installs are less likely to be confused with rebuilt-storage or wrong-database scenarios.
 - Candidate: Sweep for regressions from the `0.1.23` bookmark, Library Timeline, reader-return, and Social Insights changes once real use shakes out.
 
@@ -46,3 +50,4 @@ release.
 - Verified the full non-browser pytest suite: `496 passed, 1 skipped, 64 deselected`.
 - Verified the full Playwright browser suite: `64 passed`.
 - Verified the full combined pytest suite with coverage: `560 passed, 1 skipped`, total coverage `91%`.
+- Verified OPDS authentication, navigation links, acquisition links, JPEG thumbnail responses, and library/series pagination with focused OPDS API tests: `12 passed`.

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -179,6 +179,48 @@ def test_opds_library_feed_renders_series_entries(client, db, normal_user):
     assert "Team book" in response.text
 
 
+def test_opds_library_feed_paginates_series_entries(client, db, normal_user):
+    _enable_opds(db)
+
+    library = Library(name="Paged Library", path="/tmp/opds-paged-library")
+    series_names = ["Alpha", "Beta", "Gamma"]
+    for name in series_names:
+        series = Series(name=name, library=library)
+        volume = Volume(series=series, volume_number=1)
+        Comic(
+            volume=volume,
+            number="1",
+            title=f"{name} One",
+            filename=f"{name.lower()}-001.cbz",
+            file_path=f"/tmp/{name.lower()}-001.cbz",
+        )
+
+    db.add(library)
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    from unittest.mock import patch
+
+    with patch("app.api.opds_deps.verify_password", return_value=True):
+        response = client.get(
+            f"/opds/libraries/{library.id}?page=1&size=2",
+            auth=(normal_user.username, "any_password")
+        )
+
+    assert response.status_code == 200
+    root = ET.fromstring(response.text)
+    ns = {"atom": "http://www.w3.org/2005/Atom"}
+    entries = root.findall("atom:entry", ns)
+    assert [entry.findtext("atom:title", namespaces=ns) for entry in entries] == ["Alpha", "Beta"]
+
+    next_link = root.find("atom:link[@rel='next']", ns)
+    last_link = root.find("atom:link[@rel='last']", ns)
+    assert next_link is not None
+    assert next_link.get("href") == f"http://testserver/opds/libraries/{library.id}?page=2&size=2"
+    assert last_link is not None
+    assert last_link.get("href") == f"http://testserver/opds/libraries/{library.id}?page=2&size=2"
+
+
 def test_opds_series_feed_handles_missing_month_and_day(client, db, normal_user):
     _enable_opds(db)
 
@@ -221,6 +263,48 @@ def test_opds_series_feed_handles_missing_month_and_day(client, db, normal_user)
     assert acquisition.get("type") == "application/vnd.comicbook+zip"
     assert acquisition.get("href", "").startswith("http://testserver/opds/download/")
     assert acquisition.get("href", "").endswith("/Comic%20-%20Stormbreaker.cbz")
+
+
+def test_opds_series_feed_paginates_issue_entries(client, db, normal_user):
+    _enable_opds(db)
+
+    library = Library(name="Paged Series Library", path="/tmp/opds-paged-series-library")
+    series = Series(name="Paged Issues", library=library)
+    volume = Volume(series=series, volume_number=1)
+    for number in ("1", "2", "3"):
+        Comic(
+            volume=volume,
+            number=number,
+            title=f"Issue {number}",
+            filename=f"paged-issues-{number}.cbz",
+            file_path=f"/tmp/paged-issues-{number}.cbz",
+            file_size=123,
+        )
+
+    db.add(library)
+    normal_user.accessible_libraries.append(library)
+    db.commit()
+
+    from unittest.mock import patch
+
+    with patch("app.api.opds_deps.verify_password", return_value=True):
+        response = client.get(
+            f"/opds/series/{series.id}?page=2&size=2",
+            auth=(normal_user.username, "any_password")
+        )
+
+    assert response.status_code == 200
+    root = ET.fromstring(response.text)
+    ns = {"atom": "http://www.w3.org/2005/Atom"}
+    entries = root.findall("atom:entry", ns)
+    assert len(entries) == 1
+    assert entries[0].findtext("atom:title", namespaces=ns) == "Paged Issues #3 - Issue 3"
+
+    previous_link = root.find("atom:link[@rel='previous']", ns)
+    next_link = root.find("atom:link[@rel='next']", ns)
+    assert previous_link is not None
+    assert previous_link.get("href") == f"http://testserver/opds/series/{series.id}?page=1&size=2"
+    assert next_link is None
 
 
 def test_opds_thumbnail_links_use_jpeg_endpoint(client, db, normal_user, tmp_path):


### PR DESCRIPTION
## Summary
- Add `page`/`size` pagination to OPDS library series feeds and series issue feeds
- Emit Atom pagination links for `self`, `first`, `last`, `next`, and `previous`
- Apply DB-level `offset`/`limit` so large OPDS feeds do not render everything at once
- Document OPDS pagination in the README and OPDS expansion scope
- Update 0.1.24 release notes with the OPDS pagination and compatibility work

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\api\test_opds.py`
- Result: `12 passed`