### PR TITLE
Mult root libaries phase 1

### DIFF
--- a/alembic/versions/d4a1f6e8b3c2_add_library_roots_table.py
+++ b/alembic/versions/d4a1f6e8b3c2_add_library_roots_table.py
@@ -1,0 +1,154 @@
+"""add_library_roots_table
+
+Revision ID: d4a1f6e8b3c2
+Revises: 3a6f4d2b9c10
+Create Date: 2026-07-22 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+import os
+from datetime import datetime, timezone
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d4a1f6e8b3c2"
+down_revision: Union[str, None] = "3a6f4d2b9c10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _normalize_for_match(path: str) -> str:
+    # Mirrors app/api/libraries.py:_normalize_library_path. Used only to decide
+    # whether file_path lives under a root, not for computing relative_path,
+    # since normcase() folds case and would corrupt it on case-sensitive filesystems.
+    return os.path.normcase(os.path.normpath(path.strip()))
+
+
+def _normalize_preserve_case(path: str) -> str:
+    return os.path.normpath(path.strip())
+
+
+def upgrade() -> None:
+    op.create_table(
+        "library_roots",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("library_id", sa.Integer(), nullable=False),
+        sa.Column("path", sa.String(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False),
+        sa.Column("last_scanned_at", sa.DateTime(), nullable=True),
+        sa.Column("last_scan_error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["library_id"], ["libraries.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("library_roots", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_library_roots_id"), ["id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_library_roots_library_id"), ["library_id"], unique=False)
+
+    with op.batch_alter_table("comics", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("library_root_id", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("relative_path", sa.String(), nullable=True))
+        batch_op.create_index(batch_op.f("ix_comics_library_root_id"), ["library_root_id"], unique=False)
+        batch_op.create_index(
+            "idx_comic_library_root_relative_path", ["library_root_id", "relative_path"], unique=False
+        )
+        batch_op.create_foreign_key(
+            "fk_comics_library_root_id", "library_roots", ["library_root_id"], ["id"]
+        )
+
+    # --- Backfill: one root per library, then match each comic to it by relative path ---
+    bind = op.get_bind()
+    now = datetime.now(timezone.utc)
+
+    libraries = bind.execute(sa.text("SELECT id, path FROM libraries")).fetchall()
+
+    library_root_ids: dict[int, tuple[int, str]] = {}
+    for lib_id, lib_path in libraries:
+        result = bind.execute(
+            sa.text(
+                """
+                INSERT INTO library_roots (library_id, path, is_active, created_at, updated_at)
+                VALUES (:library_id, :path, 1, :created_at, :updated_at)
+                """
+            ),
+            {"library_id": lib_id, "path": lib_path, "created_at": now, "updated_at": now},
+        )
+        root_id = result.lastrowid
+        library_root_ids[lib_id] = (root_id, lib_path)
+
+    comics = bind.execute(
+        sa.text(
+            """
+            SELECT comics.id, comics.file_path, series.library_id
+            FROM comics
+            JOIN volumes ON comics.volume_id = volumes.id
+            JOIN series ON volumes.series_id = series.id
+            """
+        )
+    ).fetchall()
+
+    updates = []
+    unmatched = 0
+    for comic_id, file_path, library_id in comics:
+        root = library_root_ids.get(library_id)
+        if root is None:
+            unmatched += 1
+            continue
+
+        root_id, root_path = root
+
+        match_root = _normalize_for_match(root_path)
+        match_file = _normalize_for_match(file_path)
+        case_root = _normalize_preserve_case(root_path)
+        case_file = _normalize_preserve_case(file_path)
+
+        if match_file == match_root:
+            relative_path = ""
+        elif match_file.startswith(match_root + os.sep):
+            # case_root/case_file only ran through normpath() (separators normalized,
+            # case preserved). Slicing case_file at len(case_root) is safe because
+            # normcase() — applied on top of normpath() to build match_root/match_file —
+            # only folds case and does not change string length, so len(case_root) ==
+            # len(match_root): the same boundary the startswith() check just verified.
+            # Store with '/' regardless of host OS — this ships via a Linux Docker image
+            # but is also run loose on Windows, and a stored '\\' would be unusable
+            # (read as a literal filename, not a subdirectory) on the other platform.
+            relative_path = case_file[len(case_root):].lstrip("/\\").replace("\\", "/")
+        else:
+            unmatched += 1
+            continue
+
+        updates.append({"comic_id": comic_id, "library_root_id": root_id, "relative_path": relative_path})
+
+    if updates:
+        bind.execute(
+            sa.text(
+                """
+                UPDATE comics
+                SET library_root_id = :library_root_id, relative_path = :relative_path
+                WHERE id = :comic_id
+                """
+            ),
+            updates,
+        )
+
+    print(f"library relocation backfill: {unmatched} comic(s) could not be matched to a root")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("comics", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_comics_library_root_id", type_="foreignkey")
+        batch_op.drop_index("idx_comic_library_root_relative_path")
+        batch_op.drop_index(batch_op.f("ix_comics_library_root_id"))
+        batch_op.drop_column("relative_path")
+        batch_op.drop_column("library_root_id")
+
+    with op.batch_alter_table("library_roots", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_library_roots_library_id"))
+        batch_op.drop_index(batch_op.f("ix_library_roots_id"))
+
+    op.drop_table("library_roots")

--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -10,6 +10,7 @@ import os
 from app.config import settings
 from app.core.comic_helpers import get_thumbnail_url, NON_PLAIN_FORMATS, REVERSE_NUMBERING_SERIES, get_series_age_restriction
 from app.models.library import Library
+from app.models.library_root import LibraryRoot
 from app.models.series import Series
 from app.models.comic import Comic, Volume
 from app.models.interactions import UserLibraryPin
@@ -471,6 +472,9 @@ async def create_library(lib_in: LibraryCreate,
     db.commit()
     db.refresh(library)
 
+    db.add(LibraryRoot(library_id=library.id, path=library.path, is_active=True))
+    db.commit()
+
     # Notify Watcher
     if library.watch_mode:
         library_watcher.refresh_watches()
@@ -505,17 +509,13 @@ async def update_library(
             raise HTTPException(status_code=400, detail="Library name already exists")
         library.name = updates.name
 
-    if updates.path:
-        overlapping = _find_overlapping_library(db, updates.path, exclude_library_id=library_id)
-        if overlapping:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Library path overlaps with existing library '{overlapping.name}'"
-            )
-
-        library.path = updates.path
-        # Note: Changing path doesn't delete existing comics, but the next scan
-        # might mark them as 'missing' if the new path is totally different.
+    if updates.path and updates.path != library.path:
+        raise HTTPException(
+            status_code=400,
+            detail="Changing a library's path is temporarily disabled. Library relocation is "
+                   "being rebuilt to preserve reading progress and other data; support is "
+                   "coming in a future release.",
+        )
 
     if updates.watch_mode is not None:
         library.watch_mode = updates.watch_mode

--- a/app/core/path_utils.py
+++ b/app/core/path_utils.py
@@ -1,0 +1,25 @@
+import os
+from typing import Optional
+
+
+def compute_relative_path(root_path: str, file_path: str) -> Optional[str]:
+    """
+    Compute file_path's location relative to root_path, tolerating separator/case
+    normalization differences (e.g. mixed '/' vs '\\', or case-insensitive filesystems).
+    Returns None if file_path is not under root_path.
+
+    The result always uses '/' as the separator, regardless of host OS — this repo
+    primarily ships via a Linux Docker image but is also run loose on Windows, and a
+    stored '\\'-separated path would be unusable (treated as a literal filename, not
+    a subdirectory) if ever read back on the other platform.
+    """
+    match_root = os.path.normcase(os.path.normpath(root_path.strip()))
+    match_file = os.path.normcase(os.path.normpath(file_path.strip()))
+    case_root = os.path.normpath(root_path.strip())
+    case_file = os.path.normpath(file_path.strip())
+
+    if match_file == match_root:
+        return ""
+    if match_file.startswith(match_root + os.sep):
+        return case_file[len(case_root):].lstrip("/\\").replace("\\", "/")
+    return None

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 # Import all models here so SQLAlchemy can set up relationships
 from app.models.library import Library
+from app.models.library_root import LibraryRoot
 from app.models.series import Series
 from app.models.comic import Volume, Comic  # Both Volume and Comic are in comic.py
 from app.models.tags import Character, Team, Location, Genre
@@ -19,7 +20,7 @@ from app.models.activity_log import ActivityLog
 
 # This ensures all models are loaded before relationships are configured
 __all__ = [
-    'Library', 'Series', 'Volume', 'Comic',
+    'Library', 'LibraryRoot', 'Series', 'Volume', 'Comic',
     'Character', 'Team', 'Location', 'Genre',
     'Person', 'ComicCredit',
     'ReadingList', 'ReadingListItem',

--- a/app/models/comic.py
+++ b/app/models/comic.py
@@ -24,6 +24,7 @@ class Comic(Base):
 
     __table_args__ = (
         Index('idx_comic_volume_age_rating', 'volume_id', 'age_rating'),
+        Index('idx_comic_library_root_relative_path', 'library_root_id', 'relative_path'),
     )
 
     id = Column(Integer, primary_key=True, index=True)
@@ -31,6 +32,12 @@ class Comic(Base):
 
     filename = Column(String, nullable=False)
     file_path = Column(String, unique=True, nullable=False)
+    # Physical location only (which root this file was scanned under) — must stay within
+    # the same library as volume.series.library_id. Not a substitute for that field: logical
+    # library membership always flows through Series. Comics never move between libraries
+    # in place; a library change means delete + re-import, which assigns a fresh root.
+    library_root_id = Column(Integer, ForeignKey("library_roots.id"), nullable=True, index=True)
+    relative_path = Column(String, nullable=True)
     file_modified_at = Column(Float)
     file_size = Column(Integer)
     thumbnail_path = Column(String, nullable=True)  # Path to cached thumbnail
@@ -91,6 +98,7 @@ class Comic(Base):
 
     # Relationships
     volume = relationship("Volume", back_populates="comics")
+    library_root = relationship("LibraryRoot")
     reading_list_items = relationship("ReadingListItem", back_populates="comic", cascade="all, delete-orphan")
     collection_items = relationship("CollectionItem", back_populates="comic", cascade="all, delete-orphan")
     reading_progress = relationship("ReadingProgress", back_populates="comic", cascade="all, delete-orphan")

--- a/app/models/library.py
+++ b/app/models/library.py
@@ -22,3 +22,4 @@ class Library(Base):
 
     # Relationships - use string reference to avoid circular import
     series = relationship("Series", back_populates="library", cascade="all, delete-orphan")
+    roots = relationship("LibraryRoot", back_populates="library", cascade="all, delete-orphan")

--- a/app/models/library_root.py
+++ b/app/models/library_root.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Text, ForeignKey
+from sqlalchemy.orm import relationship
+from datetime import datetime, timezone
+from app.database import Base
+
+
+class LibraryRoot(Base):
+    __tablename__ = "library_roots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    library_id = Column(Integer, ForeignKey("libraries.id", ondelete="CASCADE"), nullable=False, index=True)
+    path = Column(String, nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False)
+
+    last_scanned_at = Column(DateTime, nullable=True)
+    last_scan_error = Column(Text, nullable=True)
+
+    created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    library = relationship("Library", back_populates="roots")

--- a/app/services/workers/metadata_writer.py
+++ b/app/services/workers/metadata_writer.py
@@ -11,10 +11,13 @@ def _apply_metadata_batch(
     parse_reading_lists=True,
     parse_collections=True,
     parse_story_arcs=True,
+    library_root_id=None,
+    library_root_path=None,
 ):
 
     from pathlib import Path
     from app.models.comic import Comic
+    from app.core.path_utils import compute_relative_path
     from datetime import datetime, timezone
     import json
 
@@ -84,6 +87,12 @@ def _apply_metadata_batch(
         volume_num = _normalize_volume_number(metadata.get("volume"))
         volume = get_or_create_volume(series, volume_num, file_path)
         comic.volume_id = volume.id
+
+        if library_root_path is not None:
+            relative_path = compute_relative_path(library_root_path, file_path)
+            if relative_path is not None:
+                comic.library_root_id = library_root_id
+                comic.relative_path = relative_path
 
         # --- Basic fields ---
         comic.file_modified_at = mtime
@@ -200,7 +209,7 @@ def metadata_writer(
     try:
 
         from app.database import SessionLocal, engine
-        from app.models import Comic, Series, Volume, Library
+        from app.models import Comic, Series, Volume, Library, LibraryRoot
         from app.services.tags import TagService
         from app.services.credits import CreditService
         from app.services.reading_list import ReadingListService
@@ -214,6 +223,14 @@ def metadata_writer(
         # Get library path for sidecars
         library = db.get(Library, library_id)
         lib_path = Path(library.path)
+
+        library_root = (
+            db.query(LibraryRoot)
+            .filter(LibraryRoot.library_id == library_id, LibraryRoot.is_active == True)
+            .first()
+        )
+        library_root_id = library_root.id if library_root else None
+        library_root_path = library_root.path if library_root else None
 
         # Preload existing comics
         existing = {
@@ -311,6 +328,8 @@ def metadata_writer(
                     parse_reading_lists=parse_reading_lists,
                     parse_collections=parse_collections,
                     parse_story_arcs=parse_story_arcs,
+                    library_root_id=library_root_id,
+                    library_root_path=library_root_path,
                 )
                 for key in ("imported", "updated", "errors", "skipped"):
                     processed[key] += stats.get(key, 0)
@@ -328,6 +347,8 @@ def metadata_writer(
                     parse_reading_lists=parse_reading_lists,
                     parse_collections=parse_collections,
                     parse_story_arcs=parse_story_arcs,
+                    library_root_id=library_root_id,
+                    library_root_path=library_root_path,
             )
             for key in ("imported", "updated", "errors", "skipped"):
                 processed[key] += stats.get(key, 0)

--- a/app/templates/admin/libraries.html
+++ b/app/templates/admin/libraries.html
@@ -82,9 +82,10 @@
                 <div>
                     <label class="block text-sm text-gray-400 mb-1">Folder Path</label>
                     <div class="flex gap-2">
-                        <input type="text" x-model="form.path" class="flex-1 bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none" placeholder="/comics/dc">
+                        <input type="text" x-model="form.path" :disabled="isEditing" :class="isEditing ? 'opacity-60 cursor-not-allowed' : ''" class="flex-1 bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none" placeholder="/comics/dc">
                         <button
                             type="button"
+                            x-show="!isEditing"
                             x-on:click="openDirectoryBrowser()"
                             class="bg-gray-700 hover:bg-gray-600 text-white px-3 py-2 rounded transition-colors text-sm font-medium"
                         >
@@ -92,11 +93,11 @@
                         </button>
                     </div>
                     <p class="text-xs text-gray-500 mt-1">Server-side path where files are located.</p>
-                    <div x-show="isPathChanged" class="mt-2 rounded border border-amber-500/30 bg-amber-950/30 px-3 py-2 text-xs text-amber-100" style="display: none;">
-                        Changing a library path can cause Parker to remove and re-import comics on the next scan. Reading progress, bookmarks, ratings, and list membership may not be preserved unless files keep the same server-visible paths.
+                    <div x-show="isEditing" class="mt-2 rounded border border-amber-500/30 bg-amber-950/30 px-3 py-2 text-xs text-amber-100" style="display: none;">
+                        The path is locked for existing libraries. Moving a library's files can break reading progress, bookmarks, ratings, and list membership — safe relocation support is coming in a future release.
                     </div>
 
-                    <div x-show="pathBrowser.open" class="mt-3 border border-gray-700 rounded bg-gray-900 overflow-hidden" style="display: none;">
+                    <div x-show="!isEditing && pathBrowser.open" class="mt-3 border border-gray-700 rounded bg-gray-900 overflow-hidden" style="display: none;">
                         <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-gray-700">
                             <div class="min-w-0">
                                 <p class="text-[10px] uppercase tracking-wide text-gray-500">Browsing</p>
@@ -217,7 +218,6 @@ function libraryManager() {
             id: null,
             name: '',
             path: '',
-            original_path: '',
             watch_mode: false,
             parse_reading_lists: true,
             parse_collections: true,
@@ -234,10 +234,6 @@ function libraryManager() {
             entries: [],
         },
         pollInterval: null,
-
-        get isPathChanged() {
-            return this.isEditing && this.form.path !== this.form.original_path;
-        },
 
         init() {
             this.loadLibraries();
@@ -265,7 +261,6 @@ function libraryManager() {
                 id: null,
                 name: '',
                 path: '',
-                original_path: '',
                 watch_mode: false,
                 parse_reading_lists: true,
                 parse_collections: true,
@@ -281,7 +276,6 @@ function libraryManager() {
                 id: lib.id,
                 name: lib.name,
                 path: lib.path,
-                original_path: lib.path,
                 watch_mode: lib.watch_mode,
                 parse_reading_lists: lib.parse_reading_lists ?? true,
                 parse_collections: lib.parse_collections ?? true,
@@ -376,7 +370,6 @@ function libraryManager() {
                         id: null,
                         name: '',
                         path: '',
-                        original_path: '',
                         watch_mode: false,
                         parse_reading_lists: true,
                         parse_collections: true,

--- a/docs/library-relocation-scope.md
+++ b/docs/library-relocation-scope.md
@@ -179,6 +179,8 @@ It introduces the root table, relative path identity, scanner lookup rules, and 
 
 Once relocation exists, multi-root support becomes an extension from one root per library to many roots per library.
 
+Relocation does not become unnecessary once multi-root ships — it stays a required primitive, not a stepping-stone that gets superseded. Multi-root introduces "remove a root" and "add a root" as admin actions, and if removing a root deletes the comics under it, then "remove root, move files, add a new root, rescan" reintroduces the exact same data-loss hazard this doc exists to prevent, just triggered by a different button. Multi-root arguably makes this *more* likely to come up, not less — swapping or reorganizing one root among several (splitting across drives, consolidating storage) is a more routine operation than editing a single-root library's only path ever was. `Relocate Root` and `Remove Root` need to stay distinct, explicit admin actions: the system can't safely infer "this new root is the old one, just moved" on its own — matching by `relative_path` without that explicit signal risks silently merging coincidentally-identical paths from genuinely unrelated content. So relocation should be built as a general root-lifecycle primitive from the start, not a single-root-era feature to retire once multi-root lands.
+
 ## Non-Goals
 
 Out of scope for an initial relocation feature:

--- a/docs/library-relocation-scope.md
+++ b/docs/library-relocation-scope.md
@@ -1,8 +1,18 @@
 # Library Relocation Scope
 
-Status: Draft
+Status: Phase 1 implemented (schema + guardrail); relocation flow not yet built
 
 This note captures a future enhancement for safely changing the filesystem path of an existing Parker library without losing comic identity.
+
+## Implementation Status
+
+Phase 1 (schema + guardrail) is done:
+
+- `library_roots` table added; `Comic.library_root_id` and `Comic.relative_path` added (migration `d4a1f6e8b3c2`).
+- Migration backfills one root per existing library and each comic's relative path (see `app/core/path_utils.py:compute_relative_path`).
+- `create_library` now creates a matching `LibraryRoot`, and the metadata writer populates `library_root_id`/`relative_path` for every newly scanned or updated comic going forward — not just the historical backfill.
+- Editing a library's path is hard-blocked in the API and admin UI (400 on change) until the relocation flow below exists.
+- `library_root_id`/`relative_path` are written but not yet read by anything — `LibraryScanner` still matches on `Comic.file_path`, unchanged. See Compatibility Field Removal Plan for what's still ahead.
 
 The immediate user problem is simple: admins can edit a library path today, either by typing a new path or by using the admin folder browser. Parker accepts the change, but the next scan can treat all old files as deleted and all files under the new path as new imports.
 
@@ -139,6 +149,16 @@ During scanning:
 
 Cleanup should operate within the relevant root identity, not by comparing old absolute paths against new absolute paths.
 
+## Compatibility Field Removal Plan
+
+`Library.path` and `Comic.file_path` are not meant to be permanent. The end state is both columns removed once nothing depends on them. Getting there is three stages, not one:
+
+1. **Identity cutover.** `LibraryScanner`, the metadata writer's existing-comic lookup, and the maintenance janitor's missing-file cleanup switch from keying on `Comic.file_path` to `(library_root_id, relative_path)`. This is the stage that actually fixes the data-loss bug described at the top of this doc — everything after it is cleanup, not correctness.
+2. **Read-path cutover.** Every remaining reader of `file_path`/`Library.path` — the comic reader/page-count lookup, thumbnail generation, comic detail/report API responses, OPDS feed entries, and their templates — switches to reconstructing the absolute path on demand from `library_root.path + relative_path` instead of reading the cached column. Needs a small companion helper to `compute_relative_path` for the reverse operation.
+3. **Column removal.** Once nothing reads either field, a final migration drops `Comic.file_path` and `Library.path` for good.
+
+Stage 1 is required before relocation can be considered safe. Stages 2 and 3 should be scheduled explicitly rather than left open-ended — a "temporary" compatibility field that nothing forces out tends to become permanent.
+
 ## Admin UI Guardrails
 
 Short term, Parker should warn when an admin edits the path field.
@@ -187,7 +207,6 @@ Minimum coverage should include:
 - Should Parker allow relocation when some files are missing from the new root?
 - Should relocation update `last_scanned` or require a follow-up scan?
 - Should unmatched files remain in the database as disabled/missing records, or continue using current cleanup behavior after confirmation?
-- How long should `Library.path` and `Comic.file_path` remain as compatibility fields?
 
 ## Effort Estimate
 

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -6,6 +6,7 @@ from app.api.deps import get_current_user
 from app.models.comic import Comic, Volume
 from app.models.collection import Collection, CollectionItem
 from app.models.library import Library
+from app.models.library_root import LibraryRoot
 from app.models.interactions import UserLibraryPin
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
@@ -117,6 +118,11 @@ def test_admin_can_create_library(admin_client, db):
     assert lib.parse_reading_lists is True
     assert lib.parse_collections is True
     assert lib.parse_story_arcs is True
+
+    root = db.query(LibraryRoot).filter_by(library_id=lib.id).first()
+    assert root is not None
+    assert root.path == "/data/marvel"
+    assert root.is_active is True
 
 
 def test_create_library_duplicate_name_returns_400(admin_client, db):
@@ -393,7 +399,7 @@ def test_update_library_applies_fields_and_refreshes_watches(admin_client, db):
             f"/api/libraries/{library.id}",
             json={
                 "name": "Updated",
-                "path": "/tmp/updated",
+                "path": "/tmp/update-me",
                 "watch_mode": True,
                 "parse_reading_lists": False,
                 "parse_collections": False,
@@ -404,7 +410,7 @@ def test_update_library_applies_fields_and_refreshes_watches(admin_client, db):
     assert response.status_code == 200
     payload = response.json()
     assert payload["name"] == "Updated"
-    assert payload["path"] == "/tmp/updated"
+    assert payload["path"] == "/tmp/update-me"
     assert payload["watch_mode"] is True
     assert payload["parse_reading_lists"] is False
     assert payload["parse_collections"] is False
@@ -568,21 +574,36 @@ def test_update_library_rejects_duplicate_name(admin_client, db):
     assert response.json() == {"detail": "Library name already exists"}
 
 
-def test_update_library_rejects_overlapping_path(admin_client, db):
+def test_update_library_rejects_changed_path(admin_client, db):
     original = Library(name="Original", path="/tmp/original")
-    existing = Library(name="Main Library", path="/tmp/comics")
-    db.add_all([original, existing])
+    db.add(original)
     db.commit()
 
     response = admin_client.patch(
         f"/api/libraries/{original.id}",
-        json={"path": "/tmp/comics/DC"},
+        json={"path": "/tmp/relocated"},
     )
 
     assert response.status_code == 400
-    assert response.json() == {
-        "detail": "Library path overlaps with existing library 'Main Library'"
-    }
+    assert "temporarily disabled" in response.json()["detail"]
+
+    db.refresh(original)
+    assert original.path == "/tmp/original"
+
+
+def test_update_library_allows_unchanged_path(admin_client, db):
+    original = Library(name="Original", path="/tmp/original")
+    db.add(original)
+    db.commit()
+
+    response = admin_client.patch(
+        f"/api/libraries/{original.id}",
+        json={"name": "Renamed", "path": "/tmp/original"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "Renamed"
+    assert response.json()["path"] == "/tmp/original"
 
 
 def test_update_library_returns_404_for_missing_library(admin_client):

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -129,7 +129,7 @@ def test_admin_libraries_page_exposes_folder_browser_route(admin_client):
     body = response.text
     assert "Browse" in body
     assert "libraries.browse" in body
-    assert "Changing a library path can cause Parker to remove and re-import comics" in body
+    assert "The path is locked for existing libraries" in body
 
 
 def test_search_widget_people_results_use_generic_creator_handoff(auth_client):

--- a/tests/core/test_path_utils.py
+++ b/tests/core/test_path_utils.py
@@ -1,0 +1,35 @@
+from app.core.path_utils import compute_relative_path
+
+
+def test_compute_relative_path_basic_match():
+    assert compute_relative_path("C:\\Comics\\DC", "C:\\Comics\\DC\\Batman\\Batman 001.cbz") == \
+        "Batman/Batman 001.cbz"
+
+
+def test_compute_relative_path_uses_forward_slash_even_with_backslash_input():
+    result = compute_relative_path("C:\\Comics\\DC", "C:\\Comics\\DC\\OMAC Project\\OMAC 004.cbr")
+    assert result == "OMAC Project/OMAC 004.cbr"
+    assert "\\" not in result
+
+
+def test_compute_relative_path_tolerates_mixed_separators():
+    assert compute_relative_path("C:/Comics/DC", "C:\\Comics\\DC\\Batman\\Batman 001.cbz") == \
+        "Batman/Batman 001.cbz"
+
+
+def test_compute_relative_path_tolerates_case_difference():
+    assert compute_relative_path("c:\\comics\\dc", "C:\\Comics\\DC\\Batman\\Batman 001.cbz") == \
+        "Batman/Batman 001.cbz"
+
+
+def test_compute_relative_path_file_at_root_returns_empty_string():
+    assert compute_relative_path("C:\\Comics\\DC", "C:\\Comics\\DC") == ""
+
+
+def test_compute_relative_path_returns_none_when_not_under_root():
+    assert compute_relative_path("C:\\Comics\\DC", "C:\\Comics\\Marvel\\Spiderman.cbz") is None
+
+
+def test_compute_relative_path_returns_none_for_sibling_with_shared_prefix():
+    # "DC" should not match "DComics" — must respect the path separator boundary
+    assert compute_relative_path("C:\\Comics\\DC", "C:\\Comics\\DComics\\file.cbz") is None

--- a/tests/services/test_metadata_writer.py
+++ b/tests/services/test_metadata_writer.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 from app.models.comic import Comic, Volume
 from app.models.library import Library
+from app.models.library_root import LibraryRoot
 from app.models.series import Series
 import app.database as database_module
 import app.services.workers.metadata_writer as metadata_writer_module
@@ -522,5 +523,121 @@ def test_metadata_writer_creates_series_volume_once_and_reuses_cache(monkeypatch
     assert created_series[0].summary_override == "series:Brand Series"
     assert created_volumes[0].summary_override == "volume:Vol 2"
     assert sidecar_lookup.call_count == 2
+
+
+def test_metadata_writer_populates_library_root_and_relative_path(monkeypatch, db, tmp_path):
+    library_path = tmp_path / "root-lib"
+    library_path.mkdir(parents=True, exist_ok=True)
+
+    library = Library(name="root-lib", path=str(library_path))
+    db.add(library)
+    db.flush()
+
+    root = LibraryRoot(library_id=library.id, path=str(library_path), is_active=True)
+    db.add(root)
+    db.commit()
+    db.refresh(library)
+    db.refresh(root)
+    library_id = library.id
+    root_id = root.id
+
+    series = Series(name="Unmatched Series", library_id=library.id)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    existing_path = str(library_path / "Existing" / "existing.cbz")
+    existing_comic = Comic(
+        volume_id=volume.id,
+        filename="existing.cbz",
+        file_path=existing_path,
+        page_count=1,
+        number="1",
+    )
+    db.add(existing_comic)
+    db.commit()
+
+    class DummyTagService:
+        def __init__(self, _db):
+            pass
+
+        def get_or_create_characters(self, _vals):
+            return []
+
+        def get_or_create_teams(self, _vals):
+            return []
+
+        def get_or_create_locations(self, _vals):
+            return []
+
+        def get_or_create_genres(self, _vals):
+            return []
+
+    class DummyCreditService:
+        def __init__(self, _db):
+            pass
+
+        def add_credits_to_comic(self, comic, _metadata):
+            return comic
+
+    class DummyReadingListService:
+        def __init__(self, _db):
+            pass
+
+        def update_comic_reading_lists(self, comic, _alt_series, _alt_number):
+            return comic
+
+    class DummyCollectionService:
+        def __init__(self, _db):
+            pass
+
+        def update_comic_collections(self, comic, _series_group):
+            return comic
+
+    monkeypatch.setattr(database_module.engine, "dispose", MagicMock())
+    monkeypatch.setattr(database_module, "SessionLocal", lambda: db)
+    monkeypatch.setattr("app.services.tags.TagService", DummyTagService)
+    monkeypatch.setattr("app.services.credits.CreditService", DummyCreditService)
+    monkeypatch.setattr("app.services.reading_list.ReadingListService", DummyReadingListService)
+    monkeypatch.setattr("app.services.collection.CollectionService", DummyCollectionService)
+
+    new_path = str(library_path / "Fresh" / "fresh.cbz")
+
+    result_queue = _ReadQueue([
+        {
+            "file_path": existing_path,
+            "mtime": 1.0,
+            "size": 100,
+            "metadata": _metadata(series="Unmatched Series", volume="1", number="1"),
+            "error": False,
+        },
+        {
+            "file_path": new_path,
+            "mtime": 2.0,
+            "size": 200,
+            "metadata": _metadata(series="Fresh Series", volume="1", number="1"),
+            "error": False,
+        },
+        None,
+    ])
+    stats_queue = _WriteQueue()
+
+    metadata_writer_module.metadata_writer(result_queue, stats_queue, library_id=library_id, batch_size=50)
+
+    summary = stats_queue.items[-1]
+    assert summary["summary"] is True
+    assert summary["imported"] == 1
+    assert summary["updated"] == 1
+    assert summary["errors"] == 0
+
+    refreshed_existing = db.query(Comic).filter_by(file_path=existing_path).first()
+    new_comic = db.query(Comic).filter_by(file_path=new_path).first()
+
+    assert refreshed_existing.library_root_id == root_id
+    assert refreshed_existing.relative_path == "Existing/existing.cbz"
+
+    assert new_comic is not None
+    assert new_comic.library_root_id == root_id
+    assert new_comic.relative_path == "Fresh/fresh.cbz"
 
 


### PR DESCRIPTION

This is phase 1 of adding multi-root library support.  This adds the schema and data model needed to track comics by a durable `(library_root_id, relative_path)` identity instead of only an absolute `file_path`, plus a guardrail so library relocation can't silently corrupt existing comic state before the real relocation flow exists. This is schema/prep work only — no read paths (scanner, reader, thumbnailer, etc.) have been switched over yet.

## Changes

- **New `library_roots` table** (`LibraryRoot` model) — a library can eventually have multiple physical roots; each tracks `path`, `is_active`, and future scan-status fields (`last_scanned_at`, `last_scan_error`, currently unused).
- **`Comic.library_root_id` / `Comic.relative_path`** added — physical file location, kept separate from logical library membership (which still flows through `Series`).
- **Migration `d4a1f6e8b3c2`** backfills one `LibraryRoot` per existing library and computes each existing comic's `relative_path` via the new `compute_relative_path` helper (`app/core/path_utils.py`), which tolerates separator/case differences between platforms and always stores `/`-separated paths for consistency.
- **`create_library`** now creates a matching root automatically.
- **`update_library`** hard-blocks changing a library's path (400) until the relocation flow is rebuilt — both the API and the admin UI enforce this, replacing the old "warn but allow" behavior.
- **Metadata writer** populates `library_root_id`/`relative_path` for every comic it imports or updates going forward, not just the historical backfill.

## Not yet implemented

- `LibraryScanner` and the maintenance janitor still key off `Comic.file_path` unchanged — nothing reads the new columns yet.
- The actual relocation UI/flow (preview, confirm, `Relocate Root` action).
- `LibraryRoot.last_scanned_at`/`last_scan_error` are defined but intentionally left unwritten until the scanner is restructured to operate per-root.

