### PR TITLE
Multi root libraries phase 2

### DIFF
--- a/alembic/versions/71464b56eb8a_retry_comic_root_identity_backfill_with_.py
+++ b/alembic/versions/71464b56eb8a_retry_comic_root_identity_backfill_with_.py
@@ -1,0 +1,119 @@
+"""retry_comic_root_identity_backfill_with_corrected_matching
+
+Revision ID: 71464b56eb8a
+Revises: d4a1f6e8b3c2
+Create Date: 2026-07-23 14:55:15.753269
+
+The backfill in d4a1f6e8b3c2 matched comics to their library root using
+os.path.normcase()/os.path.normpath()/os.sep, which reflect whichever OS runs
+the migration, not necessarily whichever OS wrote the stored path string. That
+under-matched two shapes of otherwise-perfectly-valid data:
+
+- backslash-separated paths backfilled (or read back) on a host whose native
+  separator is '/', since POSIX normpath/normcase never treat '\\' as a
+  separator or fold its case
+- a library root configured at a filesystem root ("/" or "C:\\"), since
+  match_root + os.sep never has anything to match against
+
+Both are pure matching-logic bugs, not real data drift, so they can be safely
+re-attempted here using the corrected, OS-independent, segment-based
+comparison (see app/core/path_utils.py:compute_relative_path for the ongoing
+runtime equivalent -- duplicated here rather than imported, since migrations
+shouldnt not depend on application code that can change after this migration
+ships).
+
+This is intentionally enrichment-only: it fills previously-NULL identity
+columns for comics whose corrected relative_path can be computed, and leaves
+alone anything it still can't resolve. It never deletes a comic. Comics that
+remain unmatched after this migration weren't hit by these bugs -- their
+stored file_path genuinely doesn't resolve under their library's active root
+anymore (e.g. the library path was edited, pre-Phase-1, and never rescanned
+since). That class can only be safely resolved by an actual scan, which is
+able to verify the root is currently reachable before deciding a comic is
+really gone, something this migration deliberately does not attempt.
+"""
+from typing import List, Optional, Sequence, Union
+import posixpath
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '71464b56eb8a'
+down_revision: Union[str, None] = 'd4a1f6e8b3c2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _segments(path: str) -> List[str]:
+    normalized = posixpath.normpath(path.strip().replace("\\", "/"))
+    return [part for part in normalized.split("/") if part not in ("", ".")]
+
+
+def _compute_relative_path(root_path: str, file_path: str) -> Optional[str]:
+    root_segments = _segments(root_path)
+    file_segments = _segments(file_path)
+
+    if len(file_segments) < len(root_segments):
+        return None
+
+    prefix = file_segments[:len(root_segments)]
+    if [part.lower() for part in prefix] != [part.lower() for part in root_segments]:
+        return None
+
+    return "/".join(file_segments[len(root_segments):])
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    rows = bind.execute(
+        sa.text(
+            """
+            SELECT comics.id, comics.file_path, library_roots.id, library_roots.path
+            FROM comics
+            JOIN volumes ON comics.volume_id = volumes.id
+            JOIN series ON volumes.series_id = series.id
+            JOIN library_roots
+                ON library_roots.library_id = series.library_id
+                AND library_roots.is_active = 1
+            WHERE comics.library_root_id IS NULL OR comics.relative_path IS NULL
+            """
+        )
+    ).fetchall()
+
+    updates = []
+    still_unmatched = 0
+    for comic_id, file_path, root_id, root_path in rows:
+        relative_path = _compute_relative_path(root_path, file_path)
+        if relative_path is None:
+            still_unmatched += 1
+            continue
+
+        updates.append({"comic_id": comic_id, "library_root_id": root_id, "relative_path": relative_path})
+
+    if updates:
+        bind.execute(
+            sa.text(
+                """
+                UPDATE comics
+                SET library_root_id = :library_root_id, relative_path = :relative_path
+                WHERE id = :comic_id
+                """
+            ),
+            updates,
+        )
+
+    print(
+        f"library root identity backfill retry: matched {len(updates)} previously-unmatched "
+        f"comic(s) with the corrected comparison; {still_unmatched} still unmatched "
+        f"(need a rescan of their library, not a migration, to resolve)"
+    )
+
+
+def downgrade() -> None:
+    # Pure data enrichment of previously-NULL columns -- there is no reliable way
+    # to tell which rows this migration touched apart from ones that were already
+    # correct before it ran, so there's nothing safe to revert to.
+    pass

--- a/alembic/versions/7e3ba96ed6dc_finalize_comic_root_identity_not_null.py
+++ b/alembic/versions/7e3ba96ed6dc_finalize_comic_root_identity_not_null.py
@@ -1,0 +1,219 @@
+"""finalize_comic_root_identity_not_null
+
+Revision ID: 7e3ba96ed6dc
+Revises: 71464b56eb8a
+Create Date: 2026-07-23 16:23:05.965312
+
+This is the "close out the fallback" migration: it finalizes
+(library_root_id, relative_path) as the sole physical identity for comics, so
+application code no longer needs (and, after the next migration, no longer
+has) a Comic.file_path column to fall back to.
+
+Steps:
+1. Retry the same corrected-match logic as 71464b56eb8a one more time (cheap,
+   idempotent no-op if the database is already clean).
+2. Delete any comic still unmatched after that -- logging id/filename/
+   file_path so it's traceable. This is not a new class of data loss: a comic
+   whose file can't be located under its library's root is already treated as
+   gone everywhere else in this codebase (scanner cleanup, maintenance
+   janitor); this just performs that resolution proactively at upgrade time
+   instead of waiting on a scan that might never happen. See
+   docs/library-relocation-scope.md for the full reasoning and the release
+   note callout that accompanies this.
+3. Make comics.library_root_id / comics.relative_path NOT NULL.
+4. Upgrade idx_comic_library_root_relative_path from a plain index to a
+   unique constraint, now that it is the sole physical identity -- carrying
+   the same duplicate-prevention guarantee file_path's uniqueness used to
+   provide. Nothing today should violate it (the app's own matching logic
+   keys off this exact pair), so a conflict here means real corruption, and
+   this migration deliberately lets that fail loudly rather than silently
+   deduplicating.
+5. Log (informational only) any library with zero active library_roots --
+   not reachable through normal app flow, but worth surfacing rather than
+   silently ignoring if it somehow exists.
+"""
+from typing import List, Optional, Sequence, Union
+import posixpath
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7e3ba96ed6dc'
+down_revision: Union[str, None] = '71464b56eb8a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _segments(path: str) -> List[str]:
+    normalized = posixpath.normpath(path.strip().replace("\\", "/"))
+    return [part for part in normalized.split("/") if part not in ("", ".")]
+
+
+def _compute_relative_path(root_path: str, file_path: str) -> Optional[str]:
+    root_segments = _segments(root_path)
+    file_segments = _segments(file_path)
+
+    if len(file_segments) < len(root_segments):
+        return None
+
+    prefix = file_segments[:len(root_segments)]
+    if [part.lower() for part in prefix] != [part.lower() for part in root_segments]:
+        return None
+
+    return "/".join(file_segments[len(root_segments):])
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # --- Step 1: retry matching for anything still unresolved ---
+    rows = bind.execute(
+        sa.text(
+            """
+            SELECT comics.id, comics.file_path, library_roots.id, library_roots.path
+            FROM comics
+            JOIN volumes ON comics.volume_id = volumes.id
+            JOIN series ON volumes.series_id = series.id
+            JOIN library_roots
+                ON library_roots.library_id = series.library_id
+                AND library_roots.is_active = 1
+            WHERE comics.library_root_id IS NULL OR comics.relative_path IS NULL
+            """
+        )
+    ).fetchall()
+
+    updates = []
+    for comic_id, file_path, root_id, root_path in rows:
+        relative_path = _compute_relative_path(root_path, file_path)
+        if relative_path is None:
+            continue
+        updates.append({"comic_id": comic_id, "library_root_id": root_id, "relative_path": relative_path})
+
+    if updates:
+        bind.execute(
+            sa.text(
+                """
+                UPDATE comics
+                SET library_root_id = :library_root_id, relative_path = :relative_path
+                WHERE id = :comic_id
+                """
+            ),
+            updates,
+        )
+
+    # --- Step 2: delete whatever still can't be resolved ---
+    # Covers both "matched a root but relative_path still didn't compute" (rows
+    # above) and "no active root joined at all" (e.g. an orphaned library) --
+    # either way, nothing left to identify these comics by once file_path is gone.
+    still_unresolved = bind.execute(
+        sa.text(
+            "SELECT id, filename, file_path FROM comics "
+            "WHERE library_root_id IS NULL OR relative_path IS NULL"
+        )
+    ).fetchall()
+
+    for comic_id, filename, file_path in still_unresolved:
+        print(
+            f"finalize backfill: deleting unresolvable comic id={comic_id} "
+            f"filename={filename!r} file_path={file_path!r}"
+        )
+
+    if still_unresolved:
+        unresolved_ids = [row[0] for row in still_unresolved]
+
+        # This connection (like the rest of the app) never turns on `PRAGMA
+        # foreign_keys`, so SQLite won't enforce ON DELETE CASCADE for a raw
+        # SQL DELETE like this one -- and pull_list_items.comic_id doesn't
+        # even declare ondelete=CASCADE in the model. Every table that
+        # references comics.id needs an explicit delete here, since none of
+        # the ORM-level cascade="all, delete-orphan" relationships that
+        # normally cover this (for a `db.delete(comic)` call elsewhere in the
+        # app) apply to raw SQL.
+        dependent_tables = [
+            "activity_log",
+            "bookmarks",
+            "collection_items",
+            "comic_credits",
+            "user_comic_ratings",
+            "pull_list_items",
+            "reading_list_items",
+            "reading_progress",
+            "comic_characters",
+            "comic_teams",
+            "comic_locations",
+            "comic_genres",
+        ]
+        # Batched rather than one IN (...) with every id -- SQLite caps the
+        # number of bound parameters per statement (SQLITE_MAX_VARIABLE_NUMBER,
+        # 999 on older builds), which a large unresolved set could exceed.
+        id_batches = [unresolved_ids[i:i + 500] for i in range(0, len(unresolved_ids), 500)]
+
+        for table in dependent_tables:
+            for batch in id_batches:
+                bind.execute(
+                    sa.text(f"DELETE FROM {table} WHERE comic_id IN :ids").bindparams(
+                        sa.bindparam("ids", expanding=True)
+                    ),
+                    {"ids": batch},
+                )
+
+        for batch in id_batches:
+            bind.execute(
+                sa.text("DELETE FROM comics WHERE id IN :ids").bindparams(
+                    sa.bindparam("ids", expanding=True)
+                ),
+                {"ids": batch},
+            )
+
+    print(
+        f"finalize backfill: matched {len(updates)} previously-unmatched comic(s) with the "
+        f"corrected comparison; deleted {len(still_unresolved)} comic(s) that could not be "
+        f"resolved to a root"
+    )
+
+    # --- Step 5: surface (not block on) libraries with zero active roots ---
+    orphan_libraries = bind.execute(
+        sa.text(
+            """
+            SELECT libraries.id, libraries.name
+            FROM libraries
+            LEFT JOIN library_roots
+                ON library_roots.library_id = libraries.id AND library_roots.is_active = 1
+            WHERE library_roots.id IS NULL
+            """
+        )
+    ).fetchall()
+
+    for lib_id, lib_name in orphan_libraries:
+        print(f"finalize backfill: library id={lib_id} name={lib_name!r} has no active root")
+
+    # --- Step 3: NOT NULL ---
+    with op.batch_alter_table("comics", schema=None) as batch_op:
+        batch_op.alter_column("library_root_id", existing_type=sa.Integer(), nullable=False)
+        batch_op.alter_column("relative_path", existing_type=sa.String(), nullable=False)
+
+    # --- Step 4: unique constraint ---
+    with op.batch_alter_table("comics", schema=None) as batch_op:
+        batch_op.drop_index("idx_comic_library_root_relative_path")
+        batch_op.create_index(
+            "idx_comic_library_root_relative_path",
+            ["library_root_id", "relative_path"],
+            unique=True,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("comics", schema=None) as batch_op:
+        batch_op.drop_index("idx_comic_library_root_relative_path")
+        batch_op.create_index(
+            "idx_comic_library_root_relative_path",
+            ["library_root_id", "relative_path"],
+            unique=False,
+        )
+        batch_op.alter_column("relative_path", existing_type=sa.String(), nullable=True)
+        batch_op.alter_column("library_root_id", existing_type=sa.Integer(), nullable=True)
+
+    # No reliable way to restore comics deleted during upgrade() -- same
+    # limitation as 71464b56eb8a's downgrade.

--- a/alembic/versions/9def8df8ed7c_drop_comic_file_path_and_library_path.py
+++ b/alembic/versions/9def8df8ed7c_drop_comic_file_path_and_library_path.py
@@ -1,0 +1,45 @@
+"""drop_comic_file_path_and_library_path
+
+Revision ID: 9def8df8ed7c
+Revises: 7e3ba96ed6dc
+Create Date: 2026-07-23 16:29:22.235138
+
+Schema-only cleanup: drops the two legacy compatibility columns now that
+(library_root_id, relative_path) / (library_roots) fully replace them and
+nothing in the application reads either column anymore. 7e3ba96ed6dc already
+guaranteed every surviving comic has a usable (library_root_id,
+relative_path); this migration just removes the now-unused columns.
+
+comics.file_path had an inline UniqueConstraint (not a separately-named
+index), so dropping the column via batch mode removes that constraint along
+with it -- there's nothing left to name and drop separately.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '9def8df8ed7c'
+down_revision: Union[str, None] = '7e3ba96ed6dc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("comics", schema=None) as batch_op:
+        batch_op.drop_column("file_path")
+
+    with op.batch_alter_table("libraries", schema=None) as batch_op:
+        batch_op.drop_column("path")
+
+
+def downgrade() -> None:
+    # Values are gone for good -- this only restores the column shape (nullable,
+    # since we have no data to backfill them with), not the data that once lived there.
+    with op.batch_alter_table("libraries", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("path", sa.String(), nullable=True))
+
+    with op.batch_alter_table("comics", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("file_path", sa.String(), nullable=True))

--- a/app/api/comics.py
+++ b/app/api/comics.py
@@ -121,6 +121,7 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
     comic = db.query(Comic).options(
         # Parents: Join them (1 row)
         joinedload(Comic.volume).joinedload(Volume.series).joinedload(Series.library),
+        joinedload(Comic.library_root),
 
         # Children/Lists: Select them separately to avoid 10x10x10 row explosion
         selectinload(Comic.credits).joinedload(ComicCredit.person),  # Keep person joined to credit
@@ -199,7 +200,7 @@ async def get_comic(comic_id: int, db: SessionDep, current_user: CurrentUser):
     return {
         "id": comic.id,
         "filename": comic.filename,
-        "file_path": comic.file_path,
+        "file_path": comic.absolute_path,
         "file_size": comic.file_size,
         "thumbnail_hash": get_thumbnail_hash(comic.updated_at),
 

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -115,9 +115,11 @@ async def get_current_user(
     except (JWTError, ValidationError):
         raise credentials_exception
 
-    # Eager load accessible libraries relation
+    # Eager load accessible libraries relation (and their roots, since callers
+    # commonly need library.active_root and this User object can outlive the
+    # session that loaded it -- e.g. cached across requests)
     user = db.query(User).options(
-                selectinload(User.accessible_libraries)
+                selectinload(User.accessible_libraries).selectinload(Library.roots)
             ).filter(User.username == username).first()
 
     if user is None:

--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Annotated, Optional
 from pydantic import BaseModel
 from sqlalchemy import func, case
+from sqlalchemy.orm import selectinload
 from datetime import datetime, timezone
 from pathlib import Path as FsPath
 import logging
@@ -9,6 +10,7 @@ import os
 
 from app.config import settings
 from app.core.comic_helpers import get_thumbnail_url, NON_PLAIN_FORMATS, REVERSE_NUMBERING_SERIES, get_series_age_restriction
+from app.core.path_utils import paths_overlap
 from app.models.library import Library
 from app.models.library_root import LibraryRoot
 from app.models.series import Series
@@ -23,35 +25,19 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-def _normalize_library_path(path: str) -> str:
-    return os.path.normcase(os.path.normpath(path.strip()))
-
-
-def _paths_overlap(first_path: str, second_path: str) -> bool:
-    first = _normalize_library_path(first_path)
-    second = _normalize_library_path(second_path)
-
-    try:
-        common = os.path.commonpath([first, second])
-    except ValueError:
-        return False
-
-    return common == first or common == second
-
-
 def _find_overlapping_library(
         db,
         candidate_path: str,
         *,
         exclude_library_id: Optional[int] = None,
 ) -> Optional[Library]:
-    query = db.query(Library)
+    query = db.query(LibraryRoot).join(Library)
     if exclude_library_id is not None:
-        query = query.filter(Library.id != exclude_library_id)
+        query = query.filter(LibraryRoot.library_id != exclude_library_id)
 
-    for existing in query.all():
-        if _paths_overlap(candidate_path, existing.path):
-            return existing
+    for root in query.all():
+        if paths_overlap(candidate_path, root.path):
+            return root.library
 
     return None
 
@@ -69,10 +55,11 @@ def _has_library_access(library_id: int, current_user: CurrentUser) -> bool:
 
 
 def _library_payload(lib: Library, *, pinned: bool = False, stats: Optional[dict] = None) -> dict:
+    active_root = lib.active_root
     payload = {
         "id": lib.id,
         "name": lib.name,
-        "path": lib.path,
+        "path": active_root.path if active_root else None,
         "scan_on_startup": lib.scan_on_startup,
         "watch_mode": lib.watch_mode,
         "parse_reading_lists": lib.parse_reading_lists,
@@ -114,7 +101,7 @@ async def list_libraries(db: SessionDep,
 
     # Fetch the libraries based on permissions
     if current_user.is_superuser:
-        query = db.query(Library).order_by(Library.name)
+        query = db.query(Library).options(selectinload(Library.roots)).order_by(Library.name)
         if limit:
             query = query.limit(limit)
         libs = query.all()
@@ -461,25 +448,29 @@ async def create_library(lib_in: LibraryCreate,
 
     library = Library(
         name=lib_in.name,
-        path=lib_in.path,
         watch_mode=lib_in.watch_mode,
         parse_reading_lists=lib_in.parse_reading_lists,
         parse_collections=lib_in.parse_collections,
         parse_story_arcs=lib_in.parse_story_arcs,
     )
 
-    db.add(library)
-    db.commit()
-    db.refresh(library)
+    try:
+        db.add(library)
+        db.flush()
 
-    db.add(LibraryRoot(library_id=library.id, path=library.path, is_active=True))
-    db.commit()
+        db.add(LibraryRoot(library_id=library.id, path=lib_in.path, is_active=True))
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(library)
 
     # Notify Watcher
     if library.watch_mode:
         library_watcher.refresh_watches()
 
-    return library
+    return _library_payload(library)
 
 # Schema for updates
 class LibraryUpdate(BaseModel):
@@ -509,7 +500,9 @@ async def update_library(
             raise HTTPException(status_code=400, detail="Library name already exists")
         library.name = updates.name
 
-    if updates.path and updates.path != library.path:
+    active_root = library.active_root
+    current_path = active_root.path if active_root else None
+    if updates.path and updates.path != current_path:
         raise HTTPException(
             status_code=400,
             detail="Changing a library's path is temporarily disabled. Library relocation is "
@@ -550,7 +543,7 @@ async def update_library(
     response = {
         "id": library.id,
         "name": library.name,
-        "path": library.path,
+        "path": current_path,
         "scan_on_startup": library.scan_on_startup,
         "watch_mode": library.watch_mode,
         "parse_reading_lists": library.parse_reading_lists,

--- a/app/api/reader.py
+++ b/app/api/reader.py
@@ -9,10 +9,12 @@ import logging
 
 from app.core.comic_helpers import (get_age_rating_config, get_comic_age_restriction)
 from app.core.comic_helpers import get_format_sort_index, get_format_weight, REVERSE_NUMBERING_SERIES
+from app.core.path_utils import resolve_absolute_path
 from app.api.deps import SessionDep, CurrentUser
 from app.models.comic import Comic, Volume
 from app.models.series import Series
 from app.models.library import Library
+from app.models.library_root import LibraryRoot
 
 from app.services.images import ImageService
 from app.models.reading_progress import ReadingProgress
@@ -62,7 +64,8 @@ async def get_comic_reader_init(comic_id: int,
     """
     # 1. Fetch Comic with Series/Volume loaded (Avoids N+1 later)
     comic = db.query(Comic).options(
-        joinedload(Comic.volume).joinedload(Volume.series)
+        joinedload(Comic.volume).joinedload(Volume.series),
+        joinedload(Comic.library_root),
     ).filter(Comic.id == comic_id).first()
 
     if not comic:
@@ -351,7 +354,7 @@ async def get_comic_reader_init(comic_id: int,
         # Fallback to Physical (Slow but accurate)
         # This handles legacy scans or edge cases
         image_service = ImageService()
-        page_count = image_service.get_page_count(str(comic.file_path))
+        page_count = image_service.get_page_count(comic.absolute_path)
 
         # No Self-heal the DB record here
         # GET requests shouldn't write to DB to avoid locks.
@@ -387,17 +390,24 @@ def get_comic_page(
 ):
     """
     Get a specific page image.
-    OPTIMIZED: Fetches only the file_path string, not the full Comic object.
+    OPTIMIZED: Fetches only the root path + relative path, not the full Comic object.
     """
-    # 1. Fetch Path Only (Scalar Query = <1ms)
-    file_path = db.query(Comic.file_path).filter(Comic.id == comic_id).scalar()
+    # 1. Fetch Path Only (Lean joined query = <1ms, no full ORM object)
+    row = (
+        db.query(LibraryRoot.path, Comic.relative_path)
+        .join(Comic, Comic.library_root_id == LibraryRoot.id)
+        .filter(Comic.id == comic_id)
+        .first()
+    )
 
-    if not file_path:
+    if not row:
         raise HTTPException(status_code=404, detail="Comic not found")
+
+    file_path = resolve_absolute_path(row[0], row[1])
 
     image_service = ImageService()
     image_bytes, is_correct_format, mime_type = image_service.get_page_image(
-        str(file_path),
+        file_path,
         page_index,
         sharpen=sharpen,
         grayscale=grayscale,

--- a/app/api/reports.py
+++ b/app/api/reports.py
@@ -334,7 +334,8 @@ async def get_duplicate_report(
         .options(
             contains_eager(Comic.volume)
             .contains_eager(Volume.series)
-            .contains_eager(Series.library)
+            .contains_eager(Series.library),
+            joinedload(Comic.library_root),
         )
         .filter(
             tuple_(Comic.volume_id, Comic.number, Comic.format).in_(dupe_keys)
@@ -364,7 +365,7 @@ async def get_duplicate_report(
         grouped_report[key]["files"].append({
             "id": c.id,
             "filename": c.filename,
-            "path": c.file_path,
+            "path": c.absolute_path,
             "size_bytes": c.file_size,
             "created_at": c.created_at
         })
@@ -408,7 +409,8 @@ async def get_corrupt_files_report(
         .options(
             contains_eager(Comic.volume)
             .contains_eager(Volume.series)
-            .contains_eager(Series.library)
+            .contains_eager(Series.library),
+            joinedload(Comic.library_root),
         )
         .filter(criteria)
         .order_by(Comic.page_count, Comic.file_size)  # Smallest/Emptyest first
@@ -429,7 +431,7 @@ async def get_corrupt_files_report(
             "title": c.title,
             "page_count": c.page_count,
             "file_size": c.file_size,
-            "path": c.file_path,
+            "path": c.absolute_path,
             "filename": c.filename
         })
 

--- a/app/core/path_utils.py
+++ b/app/core/path_utils.py
@@ -1,5 +1,10 @@
-import os
-from typing import Optional
+import posixpath
+from typing import List, Optional
+
+
+def _segments(path: str) -> List[str]:
+    normalized = posixpath.normpath(path.strip().replace("\\", "/"))
+    return [part for part in normalized.split("/") if part not in ("", ".")]
 
 
 def compute_relative_path(root_path: str, file_path: str) -> Optional[str]:
@@ -8,18 +13,27 @@ def compute_relative_path(root_path: str, file_path: str) -> Optional[str]:
     normalization differences (e.g. mixed '/' vs '\\', or case-insensitive filesystems).
     Returns None if file_path is not under root_path.
 
-    The result always uses '/' as the separator, regardless of host OS — this repo
-    primarily ships via a Linux Docker image but is also run loose on Windows, and a
+    Comparisons are done per path segment rather than via os.sep/os.path.normpath/
+    os.path.normcase, which reflect the *current* platform, not necessarily the one
+    that produced the stored path string — this repo primarily ships via a Linux
+    Docker image but is also run loose on Windows, and a path recorded under one
+    needs to still resolve correctly when read back under the other. Segment-based
+    comparison also sidesteps the fact that lowercasing a string for case-insensitive
+    comparison can change its length for a handful of Unicode code points, which would
+    otherwise corrupt a length-based slice of the original (case-preserved) string.
+
+    The result always uses '/' as the separator, regardless of host OS, since a
     stored '\\'-separated path would be unusable (treated as a literal filename, not
     a subdirectory) if ever read back on the other platform.
     """
-    match_root = os.path.normcase(os.path.normpath(root_path.strip()))
-    match_file = os.path.normcase(os.path.normpath(file_path.strip()))
-    case_root = os.path.normpath(root_path.strip())
-    case_file = os.path.normpath(file_path.strip())
+    root_segments = _segments(root_path)
+    file_segments = _segments(file_path)
 
-    if match_file == match_root:
-        return ""
-    if match_file.startswith(match_root + os.sep):
-        return case_file[len(case_root):].lstrip("/\\").replace("\\", "/")
-    return None
+    if len(file_segments) < len(root_segments):
+        return None
+
+    prefix = file_segments[:len(root_segments)]
+    if [part.lower() for part in prefix] != [part.lower() for part in root_segments]:
+        return None
+
+    return "/".join(file_segments[len(root_segments):])

--- a/app/core/path_utils.py
+++ b/app/core/path_utils.py
@@ -1,3 +1,4 @@
+import os
 import posixpath
 from typing import List, Optional
 
@@ -37,3 +38,30 @@ def compute_relative_path(root_path: str, file_path: str) -> Optional[str]:
         return None
 
     return "/".join(file_segments[len(root_segments):])
+
+
+def resolve_absolute_path(root_path: str, relative_path: str) -> str:
+    """Reverse of compute_relative_path: rebuild an absolute path from a root and
+    the relative path stored under it."""
+    if not relative_path:
+        return root_path
+    return os.path.join(root_path, relative_path)
+
+
+def paths_overlap(first_path: str, second_path: str) -> bool:
+    """
+    True if one of the two paths is an ancestor of (or equal to) the other,
+    compared per path segment rather than via os.path.commonpath/os.sep — see
+    compute_relative_path for why that matters across platforms.
+    """
+    first_segments = _segments(first_path)
+    second_segments = _segments(second_path)
+
+    shorter, longer = (
+        (first_segments, second_segments)
+        if len(first_segments) <= len(second_segments)
+        else (second_segments, first_segments)
+    )
+
+    prefix = longer[:len(shorter)]
+    return [part.lower() for part in prefix] == [part.lower() for part in shorter]

--- a/app/models/activity_log.py
+++ b/app/models/activity_log.py
@@ -24,5 +24,5 @@ class ActivityLog(Base):
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), nullable=False, index=True)
 
     # Relationships
-    comic = relationship("Comic")
+    comic = relationship("Comic", back_populates="activity_logs")
     user = relationship("User", back_populates="activity_logs")

--- a/app/models/comic.py
+++ b/app/models/comic.py
@@ -1,6 +1,7 @@
 from sqlalchemy import Column, Integer, String, ForeignKey, Text, DateTime, Float, JSON, Index, Boolean
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
+from app.core.path_utils import resolve_absolute_path
 from app.database import Base
 
 # Import the junction tables
@@ -24,20 +25,19 @@ class Comic(Base):
 
     __table_args__ = (
         Index('idx_comic_volume_age_rating', 'volume_id', 'age_rating'),
-        Index('idx_comic_library_root_relative_path', 'library_root_id', 'relative_path'),
+        Index('idx_comic_library_root_relative_path', 'library_root_id', 'relative_path', unique=True),
     )
 
     id = Column(Integer, primary_key=True, index=True)
     volume_id = Column(Integer, ForeignKey("volumes.id"))
 
     filename = Column(String, nullable=False)
-    file_path = Column(String, unique=True, nullable=False)
     # Physical location only (which root this file was scanned under) — must stay within
     # the same library as volume.series.library_id. Not a substitute for that field: logical
     # library membership always flows through Series. Comics never move between libraries
     # in place; a library change means delete + re-import, which assigns a fresh root.
-    library_root_id = Column(Integer, ForeignKey("library_roots.id"), nullable=True, index=True)
-    relative_path = Column(String, nullable=True)
+    library_root_id = Column(Integer, ForeignKey("library_roots.id"), nullable=False, index=True)
+    relative_path = Column(String, nullable=False)
     file_modified_at = Column(Float)
     file_size = Column(Integer)
     thumbnail_path = Column(String, nullable=True)  # Path to cached thumbnail
@@ -104,7 +104,12 @@ class Comic(Base):
     reading_progress = relationship("ReadingProgress", back_populates="comic", cascade="all, delete-orphan")
     bookmarks = relationship("Bookmark", back_populates="comic", cascade="all, delete-orphan")
     pull_list_items = relationship("PullListItem", back_populates="comic", cascade="all, delete-orphan")
+    user_ratings = relationship("UserComicRating", back_populates="comic", cascade="all, delete-orphan")
+    activity_logs = relationship("ActivityLog", back_populates="comic", cascade="all, delete-orphan")
 
+    @property
+    def absolute_path(self) -> str:
+        return resolve_absolute_path(self.library_root.path, self.relative_path)
 
     # Helper methods to get credits by role
     def get_credits_by_role(self, role: str) -> list:

--- a/app/models/interactions.py
+++ b/app/models/interactions.py
@@ -83,4 +83,4 @@ class UserComicRating(Base):
 
     # Relationships
     user = relationship("User", backref="comic_ratings")
-    comic = relationship("Comic", backref="user_ratings")
+    comic = relationship("Comic", back_populates="user_ratings")

--- a/app/models/library.py
+++ b/app/models/library.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from sqlalchemy import Column, Integer, String, DateTime, Boolean
 from sqlalchemy.orm import relationship
 from datetime import datetime, timezone
@@ -9,7 +11,6 @@ class Library(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, unique=True, nullable=False)
-    path = Column(String, nullable=False)
     scan_on_startup = Column(Boolean, default=False)
     watch_mode = Column(Boolean, default=False)  # Real-time watching
     parse_reading_lists = Column(Boolean, default=True, nullable=False)
@@ -23,3 +24,7 @@ class Library(Base):
     # Relationships - use string reference to avoid circular import
     series = relationship("Series", back_populates="library", cascade="all, delete-orphan")
     roots = relationship("LibraryRoot", back_populates="library", cascade="all, delete-orphan")
+
+    @property
+    def active_root(self) -> Optional["LibraryRoot"]:
+        return next((r for r in self.roots if r.is_active), None)

--- a/app/routers/opds.py
+++ b/app/routers/opds.py
@@ -62,8 +62,7 @@ def format_opds_issued(year: int | None, month: int | None, day: int | None) -> 
 
 def get_comic_archive_suffix(comic: Comic) -> str:
     """Return the normalized archive suffix for OPDS/download metadata."""
-    filename = comic.filename or str(comic.file_path or "")
-    return Path(filename).suffix.lower()
+    return Path(comic.filename).suffix.lower()
 
 
 def get_opds_acquisition_type(comic: Comic) -> str:
@@ -108,7 +107,14 @@ def get_opds_thumbnail_href(request: Request, comic: Comic) -> str:
 
 def get_authorized_opds_comic(comic_id: int, user: OPDSUser, db: SessionDep) -> Comic:
     """Return a comic if the OPDS user can access it, otherwise raise."""
-    comic = db.query(Comic).join(Volume).join(Series).filter(Comic.id == comic_id).first()
+    comic = (
+        db.query(Comic)
+        .join(Volume)
+        .join(Series)
+        .options(joinedload(Comic.library_root))
+        .filter(Comic.id == comic_id)
+        .first()
+    )
 
     if not comic:
         raise HTTPException(status_code=404)
@@ -421,7 +427,7 @@ async def opds_download(comic_id: int, user: OPDSUser, db: SessionDep, filename:
     export_name = get_opds_download_filename(comic)
 
     return FileResponse(
-        path=str(comic.file_path),
+        path=comic.absolute_path,
         filename=export_name,
         media_type=get_opds_acquisition_type(comic),
         headers={"Content-Disposition": f'attachment; filename="{export_name}"'}

--- a/app/services/kavita_migration.py
+++ b/app/services/kavita_migration.py
@@ -11,9 +11,11 @@ from typing import Dict, Optional
 from sqlalchemy.orm import Session
 
 from app.core.comic_helpers import NON_PLAIN_FORMATS
+from app.core.path_utils import resolve_absolute_path
 from app.core.security import get_password_hash
 from app.models.comic import Comic, Volume
 from app.models.library import Library
+from app.models.library_root import LibraryRoot
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.user import User
@@ -270,7 +272,8 @@ class KavitaMigrationService:
         parker_comics = (
             self.db.query(
                 Comic.id,
-                Comic.file_path,
+                LibraryRoot.path.label("root_path"),
+                Comic.relative_path,
                 Comic.number,
                 Comic.format,
                 Series.name.label("series_name"),
@@ -278,6 +281,7 @@ class KavitaMigrationService:
             .select_from(Comic)
             .join(Comic.volume)
             .join(Volume.series)
+            .join(LibraryRoot, LibraryRoot.id == Comic.library_root_id)
             .all()
         )
 
@@ -286,7 +290,8 @@ class KavitaMigrationService:
         meta_index: dict[str, set[int]] = {}
 
         for comic in parker_comics:
-            normalized = self._normalize_path(str(comic.file_path))
+            absolute_path = resolve_absolute_path(comic.root_path, comic.relative_path)
+            normalized = self._normalize_path(absolute_path)
             if normalized:
                 path_index.setdefault(normalized, set()).add(comic.id)
 

--- a/app/services/maintenance.py
+++ b/app/services/maintenance.py
@@ -4,9 +4,11 @@ import logging
 import os
 
 from app.config import settings
+from app.core.path_utils import resolve_absolute_path
 from app.models.tags import Character, Team, Location
 from app.models.credits import Person
 from app.models.comic import Comic, Volume
+from app.models.library_root import LibraryRoot
 from app.models.series import Series
 from app.models.reading_list import ReadingList
 from app.models.collection import Collection
@@ -109,9 +111,19 @@ class MaintenanceService:
         comics = query.all()
         deleted_ids = []
 
+        # Cache root paths since many comics typically share the same root(s).
+        root_paths: dict[int, str] = {}
+
         for comic in comics:
-            if not os.path.exists(comic.file_path):
-                self.logger.info(f"Janitor: Removing missing file: {comic.file_path}")
+            if comic.library_root_id not in root_paths:
+                root = self.db.get(LibraryRoot, comic.library_root_id)
+                root_paths[comic.library_root_id] = root.path if root else None
+
+            root_path = root_paths[comic.library_root_id]
+            path_to_check = resolve_absolute_path(root_path, comic.relative_path) if root_path else None
+
+            if not path_to_check or not os.path.exists(path_to_check):
+                self.logger.info(f"Janitor: Removing missing file: {comic.filename} ({path_to_check})")
                 deleted_ids.append(comic.id)
                 self.db.delete(comic)
 

--- a/app/services/scanner.py
+++ b/app/services/scanner.py
@@ -11,7 +11,9 @@ from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
 from app.core.settings_loader import get_cached_setting
+from app.core.path_utils import compute_relative_path
 from app.models.library import Library
+from app.models.library_root import LibraryRoot
 from app.models.comic import Comic
 from app.models.comic import Volume
 from app.models.series import Series
@@ -43,10 +45,18 @@ class LibraryScanner:
         """
         Parallel metadata extraction + single-writer DB updates.
         """
-        library_path = Path(self.library.path)
+        library_root = (
+            self.db.query(LibraryRoot)
+            .filter(LibraryRoot.library_id == self.library.id, LibraryRoot.is_active == True)
+            .first()
+        )
+        if library_root is None:
+            raise FileNotFoundError(f"Library '{self.library.name}' has no active root configured")
+
+        library_path = Path(library_root.path)
 
         if not library_path.exists():
-            raise FileNotFoundError(f"Library path does not exist: {self.library.path}")
+            raise FileNotFoundError(f"Library path does not exist: {library_root.path}")
 
         self.reconciled_folders.clear()
         self.reconciled_volumes.clear()
@@ -64,27 +74,32 @@ class LibraryScanner:
             .all()
         )
 
-        existing_map = {c.file_path: c for c in db_comics}
+        existing_by_key = {(c.library_root_id, c.relative_path): c for c in db_comics}
 
         # --- Phase 1: Build task list with skip/import/update logic ---
         tasks = []
-        scanned_paths_on_disk = set()
+        scanned_keys = set()
         skipped = 0
 
         for file_path in library_path.rglob("*"):
             if file_path.suffix.lower() not in self.supported_extensions:
                 continue
 
+            file_path_str = str(file_path)
+            # Always resolves: file_path_str is necessarily a child of library_path,
+            # since rglob() only yields files physically nested under it.
+            relative_path = compute_relative_path(library_root.path, file_path_str)
+            key = (library_root.id, relative_path)
+            existing = existing_by_key.get(key)
+
             # --- CONTAINER RECONCILIATION ---
             # This runs for EVERY file, but the logic inside ensures it only
             # performs the disk-check once per folder.
-            self._reconcile_sidecars(file_path, existing_map)
+            self._reconcile_sidecars(file_path, existing, library_root.path)
 
-            file_path_str = str(file_path)
-            scanned_paths_on_disk.add(file_path_str)
+            scanned_keys.add(key)
 
             file_mtime = os.path.getmtime(file_path)
-            existing = existing_map.get(file_path_str)
 
             if existing:
                 # unchanged file -> skip unless force=True
@@ -194,7 +209,7 @@ class LibraryScanner:
                     writer_proc.join(timeout=5)
 
         # --- Phase 3: Cleanup missing files ---
-        deleted = self._cleanup_missing_files(scanned_paths_on_disk, existing_map)
+        deleted = self._cleanup_missing_files(scanned_keys, existing_by_key)
 
         # Cleanup empty containers
         self.reading_list_service.cleanup_empty_lists()
@@ -216,13 +231,12 @@ class LibraryScanner:
             "elapsed": elapsed,
         }
 
-    def _cleanup_missing_files(self, scanned_paths_on_disk: set, existing_map: dict) -> int:
+    def _cleanup_missing_files(self, scanned_keys: set, existing_by_key: dict) -> int:
         """Remove comics from DB whose files no longer exist"""
         deleted = 0
 
-        # Iterate over the map of comics we knew about at start
-        for file_path, comic in existing_map.items():
-            if file_path not in scanned_paths_on_disk:
+        for key, comic in existing_by_key.items():
+            if key not in scanned_keys:
                 self.logger.info(f"Removing deleted comic: {comic.filename}")
                 self.db.delete(comic)
                 deleted += 1
@@ -260,14 +274,14 @@ class LibraryScanner:
 
             current = parent
 
-    def _reconcile_sidecars(self, file_path: Path, existing_map: dict):
+    def _reconcile_sidecars(self, file_path: Path, existing_comic: Optional[Comic], library_root_path: str):
         """
         Sync folder-level sidecars with Series/Volume models.
         Works even if individual comics are skipped.
         """
         folder_path = file_path.parent
         folder_str = str(folder_path)
-        lib_path = Path(self.library.path)
+        lib_path = Path(library_root_path)
 
         # If the comic is in the root, there is no 'Series' or 'Volume' folder to reconcile
         if folder_path == lib_path:
@@ -279,9 +293,6 @@ class LibraryScanner:
         if folder_str in self.reconciled_folders:
             return
 
-        # Identify which Series/Volume this folder belongs to using pre-fetched data
-        # We look at the first comic we know about in this folder
-        existing_comic = existing_map.get(str(file_path))
         if not existing_comic:
             self.logger.debug(
                 "Skipping sidecar reconciliation for unknown comic path; "

--- a/app/services/startup_diagnostics.py
+++ b/app/services/startup_diagnostics.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from sqlalchemy import text
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.models.comic import Comic
 from app.models.library import Library
@@ -205,14 +205,21 @@ def collect_startup_diagnostics(
         User.is_superuser == True,
     ).first() is not None
 
-    library_sample = [
-        {
+    library_sample = []
+    for library in (
+        db.query(Library)
+        .options(selectinload(Library.roots))
+        .order_by(Library.name)
+        .limit(5)
+        .all()
+    ):
+        active_root = library.active_root
+        root_path = active_root.path if active_root else None
+        library_sample.append({
             "name": library.name,
-            "path": library.path,
-            "path_exists": _safe_path_exists(library.path),
-        }
-        for library in db.query(Library).order_by(Library.name).limit(5).all()
-    ]
+            "path": root_path,
+            "path_exists": _safe_path_exists(root_path),
+        })
 
     comics_root_exists = comics_root.exists()
     comics_root_sample = _sample_directory(comics_root)

--- a/app/services/thumbnailer.py
+++ b/app/services/thumbnailer.py
@@ -6,7 +6,7 @@ from multiprocessing import Queue
 from queue import Empty
 from typing import Tuple, Dict, Any, List
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.core.settings_loader import get_cached_setting
 from app.database import SessionLocal, engine
@@ -253,6 +253,7 @@ class ThumbnailService:
             .query(Comic)
             .join(Comic.volume)
             .join(Series)
+            .options(joinedload(Comic.library_root))
             .filter(Series.library_id == self.library_id)
         )
 
@@ -274,6 +275,7 @@ class ThumbnailService:
             #self.logger.info(f"Processing Series {series_id}")
             comics = (self.db.query(Comic)
                       .join(Volume)
+                      .options(joinedload(Comic.library_root))
                       .filter(Volume.series_id == series_id)
                       .all())
         elif self.library_id:
@@ -300,7 +302,7 @@ class ThumbnailService:
                 stats["skipped"] += 1
                 continue
 
-            tasks.append((comic.id, str(comic.file_path)))
+            tasks.append((comic.id, comic.absolute_path))
 
         if not tasks:
             return stats

--- a/app/services/watcher.py
+++ b/app/services/watcher.py
@@ -2,6 +2,7 @@ import time
 import logging
 import threading
 from pathlib import Path
+from sqlalchemy.orm import selectinload
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 from app.database import SessionLocal
@@ -128,7 +129,12 @@ class LibraryWatcher:
         db = SessionLocal()
         try:
             # 1. Get all libraries that should be watched
-            libraries = db.query(Library).filter(Library.watch_mode == True).all()
+            libraries = (
+                db.query(Library)
+                .options(selectinload(Library.roots))
+                .filter(Library.watch_mode == True)
+                .all()
+            )
             active_ids = {lib.id for lib in libraries}
             current_ids = set(self.watches.keys())
 
@@ -140,15 +146,20 @@ class LibraryWatcher:
             # 2. Add new watches
             for lib in libraries:
                 if lib.id not in self.watches:
+                    active_root = lib.active_root
+                    if active_root is None:
+                        self.logger.error(f"Library {lib.id} ('{lib.name}') has no active root; skipping watch")
+                        continue
+
                     try:
-                        self.logger.info(f"Starting watch for: {lib.path}")
+                        self.logger.info(f"Starting watch for: {active_root.path}")
                         handler = LibraryEventHandler(lib.id, int(batch_window))
-                        watch = self.observer.schedule(handler, lib.path, recursive=True)
+                        watch = self.observer.schedule(handler, active_root.path, recursive=True)
 
                         # Store both so we can cancel the handler later
                         self.watches[lib.id] = (watch, handler)
                     except Exception as e:
-                        self.logger.error(f"Failed to watch {lib.path}: {e}")
+                        self.logger.error(f"Failed to watch {active_root.path}: {e}")
 
             # 3. Remove old watches (if disabled in DB)
             for lib_id in current_ids:

--- a/app/services/workers/metadata_writer.py
+++ b/app/services/workers/metadata_writer.py
@@ -1,18 +1,18 @@
 def _apply_metadata_batch(
     db,
     batch,
-    existing_map,
+    existing_by_key,
     get_or_create_series,
     get_or_create_volume,
     tag_service,
     credit_service,
     reading_list_service,
     collection_service,
+    library_root_id,
+    library_root_path,
     parse_reading_lists=True,
     parse_collections=True,
     parse_story_arcs=True,
-    library_root_id=None,
-    library_root_path=None,
 ):
 
     from pathlib import Path
@@ -67,14 +67,17 @@ def _apply_metadata_batch(
         size = item["size"]
         updated_at = datetime.now(timezone.utc)
 
-        existing = existing_map.get(file_path)
+        # Always resolves: the scanner only ever sends paths physically nested
+        # under the library's active root.
+        relative_path = compute_relative_path(library_root_path, file_path)
+        existing = existing_by_key.get((library_root_id, relative_path))
 
         # --- Determine Import vs Update ---
         if existing:
             comic = existing
             action = "update"
         else:
-            comic = Comic(file_path=file_path)
+            comic = Comic()
             action = "import"
 
         # Get or create series (Uses Cache)
@@ -88,11 +91,8 @@ def _apply_metadata_batch(
         volume = get_or_create_volume(series, volume_num, file_path)
         comic.volume_id = volume.id
 
-        if library_root_path is not None:
-            relative_path = compute_relative_path(library_root_path, file_path)
-            if relative_path is not None:
-                comic.library_root_id = library_root_id
-                comic.relative_path = relative_path
+        comic.library_root_id = library_root_id
+        comic.relative_path = relative_path
 
         # --- Basic fields ---
         comic.file_modified_at = mtime
@@ -175,7 +175,7 @@ def _apply_metadata_batch(
         if action == "import":
             comic.is_dirty = True
             imported += 1
-            existing_map[file_path] = comic
+            existing_by_key[(library_root_id, relative_path)] = comic
 
         elif action == "update":
             # If the scanner sent it, we *know* it changed (or force=True)
@@ -222,25 +222,28 @@ def metadata_writer(
 
         # Get library path for sidecars
         library = db.get(Library, library_id)
-        lib_path = Path(library.path)
 
         library_root = (
             db.query(LibraryRoot)
             .filter(LibraryRoot.library_id == library_id, LibraryRoot.is_active == True)
             .first()
         )
-        library_root_id = library_root.id if library_root else None
-        library_root_path = library_root.path if library_root else None
+        if library_root is None:
+            raise ValueError(f"Library '{library.name}' has no active root configured")
+
+        library_root_id = library_root.id
+        library_root_path = library_root.path
+        lib_path = Path(library_root.path)
 
         # Preload existing comics
-        existing = {
-            c.file_path: c
-            for c in db.query(Comic)
-                .join(Volume)
-                .join(Series)
-                .filter(Series.library_id == library_id)
-                .all()
-        }
+        existing_comics = (
+            db.query(Comic)
+            .join(Volume)
+            .join(Series)
+            .filter(Series.library_id == library_id)
+            .all()
+        )
+        existing_by_key = {(c.library_root_id, c.relative_path): c for c in existing_comics}
 
         # Local caches to reduce DB reads during the scan loop
         series_cache = {}
@@ -321,7 +324,7 @@ def metadata_writer(
 
             if len(batch) >= batch_size:
                 stats = _apply_metadata_batch(
-                    db, batch, existing,
+                    db, batch, existing_by_key,
                     get_or_create_series, get_or_create_volume,
                     tag_service, credit_service,
                     reading_list_service, collection_service,
@@ -340,7 +343,7 @@ def metadata_writer(
 
         # Commit remaining
         if batch:
-            stats = _apply_metadata_batch(db, batch, existing,
+            stats = _apply_metadata_batch(db, batch, existing_by_key,
                     get_or_create_series, get_or_create_volume,
                     tag_service, credit_service,
                     reading_list_service, collection_service,

--- a/docs/library-relocation-scope.md
+++ b/docs/library-relocation-scope.md
@@ -1,6 +1,6 @@
 # Library Relocation Scope
 
-Status: Phase 1 implemented (schema + guardrail); relocation flow not yet built
+Status: Phase 1 (schema + guardrail) and the full Compatibility Field Removal Plan are implemented; relocation flow itself not yet built
 
 This note captures a future enhancement for safely changing the filesystem path of an existing Parker library without losing comic identity.
 
@@ -10,9 +10,16 @@ Phase 1 (schema + guardrail) is done:
 
 - `library_roots` table added; `Comic.library_root_id` and `Comic.relative_path` added (migration `d4a1f6e8b3c2`).
 - Migration backfills one root per existing library and each comic's relative path (see `app/core/path_utils.py:compute_relative_path`).
-- `create_library` now creates a matching `LibraryRoot`, and the metadata writer populates `library_root_id`/`relative_path` for every newly scanned or updated comic going forward — not just the historical backfill.
+- `create_library` now creates a matching `LibraryRoot`.
 - Editing a library's path is hard-blocked in the API and admin UI (400 on change) until the relocation flow below exists.
-- `library_root_id`/`relative_path` are written but not yet read by anything — `LibraryScanner` still matches on `Comic.file_path`, unchanged. See Compatibility Field Removal Plan for what's still ahead.
+
+The full Compatibility Field Removal Plan (all four stages) is also done, landing together in one release (`0.1.25`) rather than staged over time — see the plan section below for why:
+
+- `LibraryScanner`, the metadata writer, and the maintenance janitor all match/dedupe purely on `(library_root_id, relative_path)`.
+- `compute_relative_path` compares paths per-segment instead of via `os.sep`/`os.path.normcase`/`os.path.normpath`, so matching doesn't depend on which OS produced the stored path vs. which OS is currently running — this also fixed a bug where a root path of `/` or `C:\` could never match anything.
+- Migration `71464b56eb8a` retried the original backfill with the corrected matching logic; migration `7e3ba96ed6dc` retried once more, deleted any comic still unresolved (logging id/filename/path), and made `library_root_id`/`relative_path` `NOT NULL` with a unique constraint. Migration `9def8df8ed7c` dropped `Comic.file_path` and `Library.path` outright.
+- Every remaining reader (comic reader, thumbnailer, comics API, admin reports, OPDS, Kavita migration, the library API, watcher, and startup diagnostics) reconstructs the absolute path on demand from `library_root.path` + `relative_path` via `Comic.absolute_path`/`Library.active_root`, instead of reading a cached column.
+- `Comic.file_path` and `Library.path` no longer exist. See `docs/releases/0.1.25.md` for the upgrade caveat this required.
 
 The immediate user problem is simple: admins can edit a library path today, either by typing a new path or by using the admin folder browser. Parker accepts the change, but the next scan can treat all old files as deleted and all files under the new path as new imports.
 
@@ -149,15 +156,16 @@ During scanning:
 
 Cleanup should operate within the relevant root identity, not by comparing old absolute paths against new absolute paths.
 
-## Compatibility Field Removal Plan
+## Compatibility Field Removal Plan — done
 
-`Library.path` and `Comic.file_path` are not meant to be permanent. The end state is both columns removed once nothing depends on them. Getting there is three stages, not one:
+`Library.path` and `Comic.file_path` were never meant to be permanent, and as of `0.1.25` they're gone. This originally shipped as a planned four-stage sequence (identity cutover, close the fallback, read-path cutover, column removal), but staging it across multiple releases would have meant carrying a `file_path`-keyed fallback for an indefinite, unmeasurable window — every release in between would be one more chance for someone to edit a library path and never rescan, exactly the hazard this whole doc exists to close off. All four stages landed together in one release instead:
 
-1. **Identity cutover.** `LibraryScanner`, the metadata writer's existing-comic lookup, and the maintenance janitor's missing-file cleanup switch from keying on `Comic.file_path` to `(library_root_id, relative_path)`. This is the stage that actually fixes the data-loss bug described at the top of this doc — everything after it is cleanup, not correctness.
-2. **Read-path cutover.** Every remaining reader of `file_path`/`Library.path` — the comic reader/page-count lookup, thumbnail generation, comic detail/report API responses, OPDS feed entries, and their templates — switches to reconstructing the absolute path on demand from `library_root.path + relative_path` instead of reading the cached column. Needs a small companion helper to `compute_relative_path` for the reverse operation.
-3. **Column removal.** Once nothing reads either field, a final migration drops `Comic.file_path` and `Library.path` for good.
+1. **Identity cutover.** `LibraryScanner`, the metadata writer, and the maintenance janitor switched from keying on `Comic.file_path` to `(library_root_id, relative_path)`. This is the stage that actually fixes the data-loss bug described at the top of this doc.
+2. **Close the fallback.** Migration `7e3ba96ed6dc` forced the invariant directly instead of waiting to observe it: retry matching once more, delete anything still unresolved (logged for traceability), then make `library_root_id`/`relative_path` `NOT NULL` with a unique constraint. No fallback code shipped at all in the final state — see `docs/releases/0.1.25.md` for the upgrade caveat this required.
+3. **Read-path cutover.** Every reader of `file_path`/`Library.path` — the comic reader, thumbnail generation, comics/reports API responses, OPDS, the Kavita migration tool, the library API, watcher, and startup diagnostics — reconstructs the absolute path on demand via `Comic.absolute_path` / `Library.active_root`, backed by `resolve_absolute_path` in `app/core/path_utils.py`.
+4. **Column removal.** Migration `9def8df8ed7c` dropped `Comic.file_path` and `Library.path` for good.
 
-Stage 1 is required before relocation can be considered safe. Stages 2 and 3 should be scheduled explicitly rather than left open-ended — a "temporary" compatibility field that nothing forces out tends to become permanent.
+Stage 1 remains a prerequisite for the relocation flow below to be considered safe — that flow is still unbuilt.
 
 ## Admin UI Guardrails
 

--- a/docs/releases/0.1.25.md
+++ b/docs/releases/0.1.25.md
@@ -1,0 +1,41 @@
+# Parker 0.1.25 Release Notes
+
+Status: Draft
+
+This file tracks the work landing in `0.1.25` so release notes can be built incrementally instead of reconstructed at release time.
+
+`0.1.25` completes the library-root identity work described in `docs/library-relocation-scope.md`: comics are now identified by `(library_root_id, relative_path)` everywhere, and the legacy `Comic.file_path`/`Library.path` columns are gone.
+
+## Added
+
+- Added durable library-root identity as the canonical storage model: comics are now identified by `(library_root_id, relative_path)` under a configured `LibraryRoot`.
+- Added migration `71464b56eb8a`, which retries the original Phase 1 root-identity backfill using corrected OS-independent matching logic.
+- Added migration `7e3ba96ed6dc`, which finalizes root identity by retrying matching once more, deleting comics that still cannot be resolved to a root, making `library_root_id`/`relative_path` `NOT NULL`, and upgrading their index to a unique constraint. When it deletes an unresolvable comic, it also explicitly deletes that comic's rows in every dependent table (bookmarks, reading progress, ratings, collection/reading-list/pull-list membership, credits, and tag associations) so nothing orphaned is left behind — this connection (like the rest of the app) never enables `PRAGMA foreign_keys`, so SQLite won't enforce the tables' `ON DELETE CASCADE` for this raw SQL delete. Deletes are batched at 500 ids per statement to stay under SQLite's bound-parameter limit for large unresolved sets.
+- Added migration `9def8df8ed7c`, which drops `Comic.file_path` and `Library.path`.
+
+## Changed
+
+- Upgrade note: if you changed a library's folder path and have not rescanned that library since, scan it before upgrading. This release permanently removes the legacy path-tracking columns. On upgrade, any comic that cannot be matched to its library's root will be deleted; it will be re-imported automatically on the next scan, but reading progress, bookmarks, ratings, and list membership for that comic will not carry over. Comics that were never affected by a path change are unaffected and require no action.
+- Upgrade note: if you use network storage such as a NAS or mounted volume, make sure all library paths are reachable before upgrading. The upgrade migration cannot distinguish "mount not attached yet" from "file genuinely gone."
+- `LibraryScanner`, the metadata writer, and the maintenance janitor now match and deduplicate comics purely on `(library_root_id, relative_path)` instead of the cached absolute `file_path`.
+- The admin library API's path-overlap check (`app/api/libraries.py`) now compares against every configured `LibraryRoot`, with the same OS-independent comparison.
+- The comic reader, thumbnailer, comics API, admin reports, OPDS feed/download, and the Kavita migration tool all now reconstruct absolute paths on demand from `library_root.path` + `relative_path` instead of reading a cached column.
+- The library API, filesystem watcher, and startup diagnostics now source a library's path from its active `LibraryRoot` instead of a `Library.path` column.
+- Dropped `Comic.file_path` and `Library.path`. `Comic.library_root_id`/`Comic.relative_path` are now `NOT NULL` with a unique constraint on `(library_root_id, relative_path)`.
+
+## Fixed
+
+- Fixed `compute_relative_path` (`app/core/path_utils.py`) so it compares paths per segment instead of via `os.sep`/`os.path.normcase`/`os.path.normpath`; matching no longer depends on which OS wrote the stored path versus which OS is currently running.
+- Fixed root-path matching for libraries configured at filesystem roots such as `/` or `C:\`.
+- Fixed `UserComicRating` and `ActivityLog` silently losing their ORM-level delete cascade from `Comic` (`app/models/comic.py`, `app/models/interactions.py`, `app/models/activity_log.py`) — both relationships previously had no cascade declared on either side, so any `db.delete(comic)` (scanner cleanup, maintenance janitor) left orphaned rating/activity-log rows behind. Pre-existing gap, unrelated to the library-root work but caught while auditing comic deletion paths for it.
+- Fixed `create_library` (`app/api/libraries.py`) committing the new `Library` row and its `LibraryRoot` row as two separate transactions — a failure between them could persist a library with no active root, which the scanner and watcher treat as an error state. Both inserts now share one transaction (`flush()` then a single `commit()`, with `rollback()` on failure).
+
+## Validation
+
+- Verified the full pytest suite: `586 passed, 1 skipped`.
+- Verified the full Playwright browser suite: `64 passed`.
+- Verified all three migrations against scratch SQLite databases in both directions, including a seeded scenario with a resolvable comic, an unresolvable comic, and a library with no active root, confirming the resolvable comic survives with the correct `relative_path`, the unresolvable comic is deleted and logged, and the columns are actually gone from the schema afterward (`PRAGMA table_info`).
+- Verified the finalize migration's dependent-row cleanup directly: seeded a scratch DB with an unresolvable comic plus a bookmark, reading-progress row, pull-list item, and rating all referencing it, ran the migration, and confirmed all four dependent rows were deleted along with the comic (not left orphaned).
+- Verified the finalize migration's batched deletes across a batch boundary: seeded 1200 unresolvable comics plus bookmarks positioned at comic 1, 500, 501, 1000, 1001, and 1200, ran the migration, and confirmed all 1200 comics and all 6 bookmarks were deleted.
+- Verified `db.delete(comic)` (the ORM path used by the scanner and maintenance janitor) now cascades to `UserComicRating` and `ActivityLog` as well, via a regression test in `tests/services/test_maintenance_service.py`.
+- Verified `alembic check` reports no drift attributable to this change (remaining drift is pre-existing FTS/index/nullable-flag noise unrelated to library roots).

--- a/tests/api/test_age_ratings.py
+++ b/tests/api/test_age_ratings.py
@@ -3,12 +3,13 @@ import pytest
 from unittest.mock import patch
 
 from app.models.comic import Comic, Volume
-from app.models.series import Series
 from app.models.library import Library
+from app.models.series import Series
 from app.core.security import get_password_hash, verify_password
 from app.models.user import User
 from app.models.reading_progress import ReadingProgress
 from app.services.settings_service import SettingsService
+from tests.factories import create_comic, create_library_with_root
 
 # --- HELPERS ---
 
@@ -20,9 +21,8 @@ def setup_mixed_environment(db):
     3. Series B (Poisoned): 1 Comic (Teen), 1 Comic (Mature)
     """
     # 1. Library
-    lib = Library(name="Test Lib", path="/tmp")
-    db.add(lib)
-    db.commit()
+    lib = create_library_with_root(db, "Test Lib", "/tmp")
+    root = lib.active_root
 
     # 2. Series A (Safe)
     series_safe = Series(name="Safe Series", library_id=lib.id)
@@ -33,15 +33,13 @@ def setup_mixed_environment(db):
     db.add(vol_safe)
     db.commit()
 
-    c1 = Comic(
-        volume_id=vol_safe.id,
+    c1 = create_comic(
+        db, vol_safe, root, "safe.cbz",
         title="Safe Book",
         number="1",
         age_rating="Teen",
         filename="safe.cbz",
-        file_path="/tmp/safe.cbz"
     )
-    db.add(c1)
 
     # 3. Series B (Poisoned/Mixed)
     series_mixed = Series(name="Poisoned Series", library_id=lib.id)
@@ -53,25 +51,21 @@ def setup_mixed_environment(db):
     db.commit()
 
     # This comic is SAFE, but lives in a dangerous neighborhood
-    c2 = Comic(
-        volume_id=vol_mixed.id,
+    c2 = create_comic(
+        db, vol_mixed, root, "mixed_safe.cbz",
         title="Safe Book in Bad Series",
         number="1",
         age_rating="Teen",
         filename="mixed_safe.cbz",
-        file_path="/tmp/mixed_safe.cbz"
     )
     # This comic is the POISON PILL
-    c3 = Comic(
-        volume_id=vol_mixed.id,
+    c3 = create_comic(
+        db, vol_mixed, root, "mixed_mature.cbz",
         title="Mature Book",
         number="2",
         age_rating="Mature 17+",
         filename="mixed_mature.cbz",
-        file_path="/tmp/mixed_mature.cbz"
     )
-    db.add(c2)
-    db.add(c3)
     db.commit()
 
     return {

--- a/tests/api/test_batch.py
+++ b/tests/api/test_batch.py
@@ -1,11 +1,12 @@
-from app.models.comic import Comic, Volume
-from app.models.library import Library
+from app.models.comic import Volume
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
+from tests.factories import create_comic, create_library_with_root
 
 
 def _seed_batch_graph(db, *, prefix: str):
-    library = Library(name=f"{prefix}-lib", path=f"/tmp/{prefix}-lib")
+    library = create_library_with_root(db, f"{prefix}-lib", f"/tmp/{prefix}-lib")
+    root = library.active_root
     series_a = Series(name=f"{prefix}-series-a", library=library)
     series_b = Series(name=f"{prefix}-series-b", library=library)
 
@@ -13,43 +14,38 @@ def _seed_batch_graph(db, *, prefix: str):
     vol_a2 = Volume(series=series_a, volume_number=2)
     vol_b1 = Volume(series=series_b, volume_number=1)
 
-    db.add_all([library, series_a, series_b, vol_a1, vol_a2, vol_b1])
+    db.add_all([series_a, series_b, vol_a1, vol_a2, vol_b1])
     db.flush()
 
-    c1 = Comic(
-        volume_id=vol_a1.id,
+    c1 = create_comic(
+        db, vol_a1, root, f"{prefix}-a1-1.cbz",
         number="1",
         title=f"{prefix}-a1-1",
         filename=f"{prefix}-a1-1.cbz",
-        file_path=f"/tmp/{prefix}-a1-1.cbz",
         page_count=10,
     )
-    c2 = Comic(
-        volume_id=vol_a1.id,
+    c2 = create_comic(
+        db, vol_a1, root, f"{prefix}-a1-2.cbz",
         number="2",
         title=f"{prefix}-a1-2",
         filename=f"{prefix}-a1-2.cbz",
-        file_path=f"/tmp/{prefix}-a1-2.cbz",
         page_count=0,
     )
-    c3 = Comic(
-        volume_id=vol_a2.id,
+    c3 = create_comic(
+        db, vol_a2, root, f"{prefix}-a2-1.cbz",
         number="1",
         title=f"{prefix}-a2-1",
         filename=f"{prefix}-a2-1.cbz",
-        file_path=f"/tmp/{prefix}-a2-1.cbz",
         page_count=5,
     )
-    c4 = Comic(
-        volume_id=vol_b1.id,
+    c4 = create_comic(
+        db, vol_b1, root, f"{prefix}-b1-1.cbz",
         number="1",
         title=f"{prefix}-b1-1",
         filename=f"{prefix}-b1-1.cbz",
-        file_path=f"/tmp/{prefix}-b1-1.cbz",
         page_count=7,
     )
 
-    db.add_all([c1, c2, c3, c4])
     db.commit()
 
     for obj in (library, series_a, series_b, vol_a1, vol_a2, vol_b1, c1, c2, c3, c4):

--- a/tests/api/test_bookmarks.py
+++ b/tests/api/test_bookmarks.py
@@ -1,12 +1,13 @@
 from app.models.bookmark import Bookmark
 from app.models.comic import Comic, Volume
-from app.models.library import Library
 from app.models.series import Series
 from app.models.user import User
+from tests.factories import create_library_with_root
 
 
 def _seed_bookmark_data(db, normal_user, *, lib_name: str = "bookmark-lib", series_name: str = "Bookmark Series"):
-    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    library = create_library_with_root(db, lib_name, f"/tmp/{lib_name}")
+    root = library.active_root
     series = Series(name=series_name, library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -14,11 +15,12 @@ def _seed_bookmark_data(db, normal_user, *, lib_name: str = "bookmark-lib", seri
         number="1",
         title=f"{series_name} #1",
         filename=f"{series_name}-1.cbz",
-        file_path=f"/tmp/{series_name}-{lib_name}.cbz",
+        library_root_id=root.id,
+        relative_path=f"{series_name}-1.cbz",
         page_count=10,
     )
 
-    db.add_all([library, series, volume, comic])
+    db.add_all([series, volume, comic])
     db.flush()
 
     normal_user.accessible_libraries.append(library)

--- a/tests/api/test_collections.py
+++ b/tests/api/test_collections.py
@@ -1,32 +1,31 @@
 from app.models.collection import Collection, CollectionItem
-from app.models.comic import Comic, Volume
-from app.models.library import Library
+from app.models.comic import Volume
 from app.models.series import Series
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_series_graph(db, *, lib_name: str, series_name: str, prefix: str):
-    library = Library(name=lib_name, path=f"/tmp/{prefix}-lib")
+    library = create_library_with_root(db, lib_name, f"/tmp/{prefix}-lib")
     series = Series(name=series_name, library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
     return library, series, volume
 
 
 def _create_comic(db, *, volume_id: int, prefix: str, number: str, year: int, age_rating=None, title=None):
-    comic = Comic(
-        volume_id=volume_id,
+    volume = db.get(Volume, volume_id)
+    root = volume.series.library.active_root
+    comic = create_comic(
+        db, volume, root, f"{prefix}-{number}.cbz",
         number=number,
         year=year,
         title=title or f"{prefix}-{number}",
         filename=f"{prefix}-{number}.cbz",
-        file_path=f"/tmp/{prefix}-{number}.cbz",
         page_count=20,
         file_size=100,
         age_rating=age_rating,
     )
-    db.add(comic)
-    db.flush()
     return comic
 
 

--- a/tests/api/test_comics.py
+++ b/tests/api/test_comics.py
@@ -7,20 +7,20 @@ from app.models.bookmark import Bookmark
 from app.models.comic import Comic, Volume
 from app.models.credits import ComicCredit, Person
 from app.models.interactions import UserComicRating
-from app.models.library import Library
 from app.models.pull_list import PullList, PullListItem
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.tags import Character, Genre, Location, Team
 from app.models.user import User
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_graph(db, *, lib_name: str, series_name: str):
-    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    library = create_library_with_root(db, lib_name, f"/tmp/{lib_name}")
     series = Series(name=series_name, library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
     return library, series, volume
 
@@ -29,21 +29,18 @@ def test_filter_by_user_access_and_natural_sort_key(db, admin_user, normal_user)
     lib_a, _, vol_a = _create_graph(db, lib_name="comic-access-a", series_name="Access A")
     lib_b, _, vol_b = _create_graph(db, lib_name="comic-access-b", series_name="Access B")
 
-    comic_a = Comic(
-        volume_id=vol_a.id,
+    comic_a = create_comic(
+        db, vol_a, lib_a.active_root, "a-1.cbz",
         number="1",
         title="A #1",
         filename="a-1.cbz",
-        file_path="/tmp/access-a-1.cbz",
     )
-    comic_b = Comic(
-        volume_id=vol_b.id,
+    comic_b = create_comic(
+        db, vol_b, lib_b.active_root, "b-1.cbz",
         number="1",
         title="B #1",
         filename="b-1.cbz",
-        file_path="/tmp/access-b-1.cbz",
     )
-    db.add_all([comic_a, comic_b])
 
     normal_user.accessible_libraries.append(lib_a)
     db.commit()
@@ -109,21 +106,19 @@ def test_search_comics_delegates_to_search_service(auth_client):
 def test_search_comics_can_sort_and_filter_by_parker_rating(auth_client, db, normal_user):
     library, _, volume = _create_graph(db, lib_name="comic-search-rating", series_name="Search Rating Saga")
 
-    top_rated = Comic(
-        volume_id=volume.id,
+    top_rated = create_comic(
+        db, volume, library.active_root, "top-rated.cbz",
         number="1",
         title="Top Rated",
         community_rating=4.8,
         filename="top-rated.cbz",
-        file_path="/tmp/top-rated.cbz",
     )
-    lower_rated = Comic(
-        volume_id=volume.id,
+    lower_rated = create_comic(
+        db, volume, library.active_root, "lower-rated.cbz",
         number="2",
         title="Lower Rated",
         community_rating=4.9,
         filename="lower-rated.cbz",
-        file_path="/tmp/lower-rated.cbz",
     )
     second_user = User(
         username="search-second-rater",
@@ -171,8 +166,8 @@ def test_search_comics_can_sort_and_filter_by_parker_rating(auth_client, db, nor
 def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, db, normal_user):
     library, series, volume = _create_graph(db, lib_name="comic-detail", series_name="Detail Saga")
 
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, library.active_root, "detail-7.cbz",
         number="7",
         title="Detail Issue",
         summary="Issue summary",
@@ -184,10 +179,7 @@ def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, d
         language_iso="en",
         community_rating=3.8,
         filename="detail-7.cbz",
-        file_path="/tmp/detail-7.cbz",
     )
-    db.add(comic)
-    db.flush()
 
     writer = Person(name="Detail Writer")
     penciller = Person(name="Detail Penciller")
@@ -260,15 +252,13 @@ def test_get_comic_detail_returns_metadata_and_in_progress_status(auth_client, d
 def test_get_comic_detail_returns_completed_read_status(auth_client, db, normal_user):
     library, _, volume = _create_graph(db, lib_name="comic-detail-completed", series_name="Completed Detail Saga")
 
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, library.active_root, "completed-4.cbz",
         number="4",
         title="Completed Issue",
         page_count=18,
         filename="completed-4.cbz",
-        file_path="/tmp/completed-4.cbz",
     )
-    db.add(comic)
     normal_user.accessible_libraries.append(library)
     db.flush()
 
@@ -294,15 +284,12 @@ def test_get_comic_detail_returns_completed_read_status(auth_client, db, normal_
 def test_get_comic_detail_sorts_tag_metadata_alphabetically(auth_client, db, normal_user):
     library, _, volume = _create_graph(db, lib_name="comic-detail-tags", series_name="Sorted Detail Saga")
 
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, library.active_root, "sorted-tags-12.cbz",
         number="12",
         title="Sorted Tags Issue",
         filename="sorted-tags-12.cbz",
-        file_path="/tmp/sorted-tags-12.cbz",
     )
-    db.add(comic)
-    db.flush()
 
     hero_z = Character(name="Zeta Hero")
     hero_a = Character(name="Alpha Hero")
@@ -336,15 +323,13 @@ def test_get_comic_detail_sorts_tag_metadata_alphabetically(auth_client, db, nor
 def test_get_comic_detail_uses_generic_label_for_non_comicvine_web_links(auth_client, db, normal_user):
     library, _, volume = _create_graph(db, lib_name="comic-web-link", series_name="Alt Link Saga")
 
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, library.active_root, "alt-link-11.cbz",
         number="11",
         title="Alt Link Issue",
         web="https://leagueofcomicgeeks.com/comic/123456/alt-link-issue",
         filename="alt-link-11.cbz",
-        file_path="/tmp/alt-link-11.cbz",
     )
-    db.add(comic)
 
     normal_user.accessible_libraries.append(library)
     db.commit()
@@ -361,16 +346,13 @@ def test_get_comic_detail_uses_generic_label_for_non_comicvine_web_links(auth_cl
 def test_get_comic_detail_exposes_opted_in_completed_reader_count(auth_client, db, normal_user):
     library, _, volume = _create_graph(db, lib_name="comic-social", series_name="Social Saga")
 
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, library.active_root, "social-3.cbz",
         number="3",
         title="Social Issue",
         filename="social-3.cbz",
-        file_path="/tmp/social-3.cbz",
         page_count=24,
     )
-    db.add(comic)
-    db.flush()
 
     reader_a = User(
         username="social-reader-a",
@@ -420,14 +402,12 @@ def test_get_comic_detail_exposes_opted_in_completed_reader_count(auth_client, d
 
 def test_set_comic_rating_creates_and_updates_single_user_row(auth_client, db, normal_user):
     library, _, volume = _create_graph(db, lib_name="comic-rate", series_name="Rate Saga")
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, library.active_root, "rate-me.cbz",
         number="1",
         title="Rate Me",
         filename="rate-me.cbz",
-        file_path="/tmp/rate-me.cbz",
     )
-    db.add(comic)
 
     other_user = User(
         username="other-rater",
@@ -473,14 +453,12 @@ def test_set_comic_rating_creates_and_updates_single_user_row(auth_client, db, n
 
 def test_delete_comic_rating_updates_aggregate(auth_client, db, normal_user):
     library, _, volume = _create_graph(db, lib_name="comic-unrate", series_name="Unrate Saga")
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, library.active_root, "unrate-me.cbz",
         number="1",
         title="Unrate Me",
         filename="unrate-me.cbz",
-        file_path="/tmp/unrate-me.cbz",
     )
-    db.add(comic)
 
     other_user = User(
         username="other-unrater",
@@ -516,25 +494,22 @@ def test_delete_comic_rating_updates_aggregate(auth_client, db, normal_user):
 
 def test_rating_endpoints_respect_hidden_and_age_restricted_comics(auth_client, db, normal_user):
     hidden_library, _, hidden_volume = _create_graph(db, lib_name="comic-rate-hidden", series_name="Hidden Rate Saga")
-    hidden_comic = Comic(
-        volume_id=hidden_volume.id,
+    hidden_comic = create_comic(
+        db, hidden_volume, hidden_library.active_root, "hidden-rate.cbz",
         number="1",
         title="Hidden Rate",
         filename="hidden-rate.cbz",
-        file_path="/tmp/hidden-rate.cbz",
     )
 
     safe_library, _, safe_volume = _create_graph(db, lib_name="comic-rate-safe", series_name="Safe Rate Saga")
-    mature_comic = Comic(
-        volume_id=safe_volume.id,
+    mature_comic = create_comic(
+        db, safe_volume, safe_library.active_root, "mature-rate.cbz",
         number="2",
         title="Mature Rate",
         age_rating="Mature 17+",
         filename="mature-rate.cbz",
-        file_path="/tmp/mature-rate.cbz",
     )
 
-    db.add_all([hidden_comic, mature_comic])
     normal_user.accessible_libraries.append(safe_library)
     normal_user.max_age_rating = "Teen"
     normal_user.allow_unknown_age_ratings = False
@@ -555,14 +530,12 @@ def test_get_comic_detail_missing_or_hidden_returns_404(auth_client, db):
     assert response.json() == {"detail": "Comic not found"}
 
     library, _, volume = _create_graph(db, lib_name="comic-hidden", series_name="Hidden Saga")
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, library.active_root, "hidden.cbz",
         number="1",
         title="Hidden",
         filename="hidden.cbz",
-        file_path="/tmp/hidden.cbz",
     )
-    db.add_all([library, comic])
     db.commit()
 
     hidden = auth_client.get(f"/api/comics/{comic.id}")
@@ -576,31 +549,27 @@ def test_get_comic_thumbnail_db_path_and_fallback_and_missing(client, db, tmp_pa
     db_thumb = tmp_path / "db-thumb.webp"
     db_thumb.write_bytes(b"db-thumb")
 
-    comic_db = Comic(
-        volume_id=volume.id,
+    comic_db = create_comic(
+        db, volume, library.active_root, "db-thumb.cbz",
         number="1",
         title="DB Thumb",
         thumbnail_path=str(db_thumb),
         filename="db-thumb.cbz",
-        file_path="/tmp/db-thumb.cbz",
     )
-    comic_std = Comic(
-        volume_id=volume.id,
+    comic_std = create_comic(
+        db, volume, library.active_root, "std-thumb.cbz",
         number="2",
         title="Std Thumb",
         thumbnail_path=None,
         filename="std-thumb.cbz",
-        file_path="/tmp/std-thumb.cbz",
     )
-    comic_missing = Comic(
-        volume_id=volume.id,
+    comic_missing = create_comic(
+        db, volume, library.active_root, "no-thumb.cbz",
         number="3",
         title="No Thumb",
         thumbnail_path=None,
         filename="no-thumb.cbz",
-        file_path="/tmp/no-thumb.cbz",
     )
-    db.add_all([library, comic_db, comic_std, comic_missing])
     db.commit()
 
     db_resp = client.get(f"/api/comics/{comic_db.id}/thumbnail")
@@ -645,10 +614,10 @@ def test_random_backgrounds_handles_empty_and_limit(client, db):
     assert empty.json() == []
 
     library, _, volume = _create_graph(db, lib_name="comic-random", series_name="Random Saga")
-    c1 = Comic(volume_id=volume.id, number="1", title="R1", thumbnail_path="/tmp/r1.webp", filename="r1.cbz", file_path="/tmp/r1.cbz")
-    c2 = Comic(volume_id=volume.id, number="2", title="R2", thumbnail_path="/tmp/r2.webp", filename="r2.cbz", file_path="/tmp/r2.cbz")
-    c3 = Comic(volume_id=volume.id, number="3", title="R3", thumbnail_path="/tmp/r3.webp", filename="r3.cbz", file_path="/tmp/r3.cbz")
-    db.add_all([library, c1, c2, c3])
+    root = library.active_root
+    c1 = create_comic(db, volume, root, "r1.cbz", number="1", title="R1", thumbnail_path="/tmp/r1.webp", filename="r1.cbz")
+    c2 = create_comic(db, volume, root, "r2.cbz", number="2", title="R2", thumbnail_path="/tmp/r2.webp", filename="r2.cbz")
+    c3 = create_comic(db, volume, root, "r3.cbz", number="3", title="R3", thumbnail_path="/tmp/r3.webp", filename="r3.cbz")
     db.commit()
 
     with patch("app.api.comics.random.sample", side_effect=lambda rows, size: rows[:size]):
@@ -664,25 +633,22 @@ def test_random_backgrounds_handles_empty_and_limit(client, db):
 def test_cover_manifest_volume_and_series_reverse_sort(auth_client, db, normal_user):
     library, series, volume = _create_graph(db, lib_name="comic-manifest-rev", series_name="Countdown")
 
-    issue_one = Comic(
-        volume_id=volume.id,
+    issue_one = create_comic(
+        db, volume, library.active_root, "cd-1.cbz",
         number="1",
         year=2020,
         title="Countdown #1",
         thumbnail_path="/tmp/cd-1.webp",
         filename="cd-1.cbz",
-        file_path="/tmp/cd-1.cbz",
     )
-    issue_four = Comic(
-        volume_id=volume.id,
+    issue_four = create_comic(
+        db, volume, library.active_root, "cd-4.cbz",
         number="4",
         year=2020,
         title="Countdown #4",
         thumbnail_path="/tmp/cd-4.webp",
         filename="cd-4.cbz",
-        file_path="/tmp/cd-4.cbz",
     )
-    db.add_all([issue_one, issue_four])
 
     normal_user.accessible_libraries.append(library)
     db.commit()
@@ -699,35 +665,30 @@ def test_cover_manifest_volume_and_series_reverse_sort(auth_client, db, normal_u
 def test_cover_manifest_reading_list_pull_list_and_collection_ordering(auth_client, db, normal_user):
     library, series, volume = _create_graph(db, lib_name="comic-manifest-order", series_name="Manifest Order")
 
-    c1 = Comic(
-        volume_id=volume.id,
+    c1 = create_comic(
+        db, volume, library.active_root, "order-2.cbz",
         number="2",
         year=2022,
         title="Order #2",
         thumbnail_path="/tmp/order-2.webp",
         filename="order-2.cbz",
-        file_path="/tmp/order-2.cbz",
     )
-    c2 = Comic(
-        volume_id=volume.id,
+    c2 = create_comic(
+        db, volume, library.active_root, "order-1.cbz",
         number="1",
         year=2020,
         title="Order #1",
         thumbnail_path="/tmp/order-1.webp",
         filename="order-1.cbz",
-        file_path="/tmp/order-1.cbz",
     )
-    c3 = Comic(
-        volume_id=volume.id,
+    c3 = create_comic(
+        db, volume, library.active_root, "order-3.cbz",
         number="3",
         year=2021,
         title="Order #3",
         thumbnail_path="/tmp/order-3.webp",
         filename="order-3.cbz",
-        file_path="/tmp/order-3.cbz",
     )
-    db.add_all([c1, c2, c3])
-    db.flush()
 
     reading_list = ReadingList(name="Manifest Reading", description="")
     pull_list = PullList(user_id=normal_user.id, name="Manifest Pull")
@@ -769,16 +730,14 @@ def test_cover_manifest_reading_list_pull_list_and_collection_ordering(auth_clie
 
 def test_cover_manifest_hides_items_outside_user_library(auth_client, db):
     library, _, volume = _create_graph(db, lib_name="comic-manifest-hidden", series_name="Hidden Manifest")
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, library.active_root, "hm-1.cbz",
         number="1",
         title="Hidden Manifest #1",
         year=2024,
         thumbnail_path="/tmp/hm-1.webp",
         filename="hm-1.cbz",
-        file_path="/tmp/hm-1.cbz",
     )
-    db.add_all([library, comic])
     db.commit()
 
     response = auth_client.get(f"/api/comics/covers/manifest?context_type=volume&context_id={volume.id}")

--- a/tests/api/test_deps.py
+++ b/tests/api/test_deps.py
@@ -9,9 +9,9 @@ from app.api import deps
 from app.config import settings
 from app.core.security import get_password_hash
 from app.models.comic import Comic, Volume
-from app.models.library import Library
 from app.models.series import Series
 from app.models.user import User
+from tests.factories import create_library_with_root
 
 
 def _make_request(cookie_header: str | None = None) -> Request:
@@ -35,7 +35,8 @@ def _make_request(cookie_header: str | None = None) -> Request:
 
 
 def _seed_graph(db):
-    library = Library(name="deps-lib", path="/tmp/deps-lib")
+    library = create_library_with_root(db, "deps-lib", "/tmp/deps-lib")
+    root = library.active_root
     series = Series(name="Deps Series", library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -43,9 +44,10 @@ def _seed_graph(db):
         number="1",
         title="Deps Comic",
         filename="deps-comic.cbz",
-        file_path="/tmp/deps-comic.cbz",
+        library_root_id=root.id,
+        relative_path="deps-comic.cbz",
     )
-    db.add_all([library, series, volume, comic])
+    db.add_all([series, volume, comic])
     db.commit()
     db.refresh(library)
     db.refresh(series)

--- a/tests/api/test_home.py
+++ b/tests/api/test_home.py
@@ -5,32 +5,30 @@ from unittest.mock import patch
 from app.api.home import _pick_best_cover, format_home_item
 from app.models.comic import Comic, Volume
 from app.models.interactions import UserComicRating, UserLibraryPin, UserVolumeFollow
-from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.user import User
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_series_graph(db, *, lib_name: str, series_name: str):
-    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    library = create_library_with_root(db, lib_name, f"/tmp/{lib_name}")
     series = Series(name=series_name, library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
     return library, series, volume
 
 
 def _add_comic(db, volume: Volume, *, number: str, title: str, **kwargs):
-    comic = Comic(
-        volume_id=volume.id,
+    root = volume.series.library.active_root
+    comic = create_comic(
+        db, volume, root, f"{title.replace(' ', '-')}-{volume.id}-{number}.cbz",
         number=number,
         title=title,
         filename=f"{title.replace(' ', '-')}.cbz",
-        file_path=f"/tmp/{title.replace(' ', '-')}-{volume.id}-{number}.cbz",
         **kwargs,
     )
-    db.add(comic)
-    db.flush()
     return comic
 
 
@@ -612,12 +610,10 @@ def test_home_following_arrivals_respects_baseline_formats_and_progress(auth_cli
 
 
 def test_home_pinned_libraries_returns_recently_updated_series_by_pin_order(auth_client, db, normal_user):
-    first_library = Library(name="Pinned First", path="/tmp/pinned-first")
-    second_library = Library(name="Pinned Second", path="/tmp/pinned-second")
-    empty_library = Library(name="Pinned Empty", path="/tmp/pinned-empty")
-    hidden_library = Library(name="Pinned Hidden", path="/tmp/pinned-hidden")
-    db.add_all([first_library, second_library, empty_library, hidden_library])
-    db.flush()
+    first_library = create_library_with_root(db, "Pinned First", "/tmp/pinned-first")
+    second_library = create_library_with_root(db, "Pinned Second", "/tmp/pinned-second")
+    empty_library = create_library_with_root(db, "Pinned Empty", "/tmp/pinned-empty")
+    hidden_library = create_library_with_root(db, "Pinned Hidden", "/tmp/pinned-hidden")
 
     normal_user.accessible_libraries.extend([first_library, second_library, empty_library])
     pinned_at = datetime(2026, 7, 20, tzinfo=timezone.utc)

--- a/tests/api/test_insights.py
+++ b/tests/api/test_insights.py
@@ -1,15 +1,15 @@
-from app.models.comic import Comic, Volume
+from app.models.comic import Volume
 from app.models.credits import ComicCredit, Person
-from app.models.library import Library
 from app.models.series import Series
 from app.models.tags import Character
+from tests.factories import create_comic, create_library_with_root
 
 
 def _seed_creator_collab_fixture(db, normal_user):
-    visible_lib = Library(name="Insights Visible", path="/tmp/insights-visible")
-    hidden_lib = Library(name="Insights Hidden", path="/tmp/insights-hidden")
-    db.add_all([visible_lib, hidden_lib])
-    db.flush()
+    visible_lib = create_library_with_root(db, "Insights Visible", "/tmp/insights-visible")
+    hidden_lib = create_library_with_root(db, "Insights Hidden", "/tmp/insights-hidden")
+    visible_root = visible_lib.active_root
+    hidden_root = hidden_lib.active_root
 
     safe_series = Series(name="Insights Safe Series", library_id=visible_lib.id)
     banned_series = Series(name="Insights Banned Series", library_id=visible_lib.id)
@@ -24,69 +24,39 @@ def _seed_creator_collab_fixture(db, normal_user):
     db.flush()
 
     safe_comics = [
-        Comic(
-            volume_id=safe_volume.id,
-            number="1",
-            title="Safe #1",
-            age_rating="Teen",
-            filename="safe-1.cbz",
-            file_path="/tmp/safe-1.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "safe-1.cbz",
+            number="1", title="Safe #1", age_rating="Teen", filename="safe-1.cbz",
         ),
-        Comic(
-            volume_id=safe_volume.id,
-            number="2",
-            title="Safe #2",
-            age_rating="Teen",
-            filename="safe-2.cbz",
-            file_path="/tmp/safe-2.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "safe-2.cbz",
+            number="2", title="Safe #2", age_rating="Teen", filename="safe-2.cbz",
         ),
-        Comic(
-            volume_id=safe_volume.id,
-            number="3",
-            title="Safe #3",
-            age_rating="Teen",
-            filename="safe-3.cbz",
-            file_path="/tmp/safe-3.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "safe-3.cbz",
+            number="3", title="Safe #3", age_rating="Teen", filename="safe-3.cbz",
         ),
     ]
     banned_comics = [
-        Comic(
-            volume_id=banned_volume.id,
-            number="1",
-            title="Banned #1",
-            age_rating="Mature 17+",
-            filename="banned-1.cbz",
-            file_path="/tmp/banned-1.cbz",
+        create_comic(
+            db, banned_volume, visible_root, "banned-1.cbz",
+            number="1", title="Banned #1", age_rating="Mature 17+", filename="banned-1.cbz",
         ),
-        Comic(
-            volume_id=banned_volume.id,
-            number="2",
-            title="Banned #2",
-            age_rating="Mature 17+",
-            filename="banned-2.cbz",
-            file_path="/tmp/banned-2.cbz",
+        create_comic(
+            db, banned_volume, visible_root, "banned-2.cbz",
+            number="2", title="Banned #2", age_rating="Mature 17+", filename="banned-2.cbz",
         ),
     ]
     hidden_comics = [
-        Comic(
-            volume_id=hidden_volume.id,
-            number="1",
-            title="Hidden #1",
-            age_rating="Teen",
-            filename="hidden-1.cbz",
-            file_path="/tmp/hidden-1.cbz",
+        create_comic(
+            db, hidden_volume, hidden_root, "hidden-1.cbz",
+            number="1", title="Hidden #1", age_rating="Teen", filename="hidden-1.cbz",
         ),
-        Comic(
-            volume_id=hidden_volume.id,
-            number="2",
-            title="Hidden #2",
-            age_rating="Teen",
-            filename="hidden-2.cbz",
-            file_path="/tmp/hidden-2.cbz",
+        create_comic(
+            db, hidden_volume, hidden_root, "hidden-2.cbz",
+            number="2", title="Hidden #2", age_rating="Teen", filename="hidden-2.cbz",
         ),
     ]
-    db.add_all(safe_comics + banned_comics + hidden_comics)
-    db.flush()
 
     writer_a = Person(name="Insight Writer A")
     writer_b = Person(name="Insight Writer B")
@@ -128,10 +98,10 @@ def _seed_creator_collab_fixture(db, normal_user):
 
 
 def _seed_character_collab_fixture(db, normal_user):
-    visible_lib = Library(name="Character Insights Visible", path="/tmp/character-insights-visible")
-    hidden_lib = Library(name="Character Insights Hidden", path="/tmp/character-insights-hidden")
-    db.add_all([visible_lib, hidden_lib])
-    db.flush()
+    visible_lib = create_library_with_root(db, "Character Insights Visible", "/tmp/character-insights-visible")
+    hidden_lib = create_library_with_root(db, "Character Insights Hidden", "/tmp/character-insights-hidden")
+    visible_root = visible_lib.active_root
+    hidden_root = hidden_lib.active_root
 
     safe_series = Series(name="Character Insights Safe Series", library_id=visible_lib.id)
     banned_series = Series(name="Character Insights Banned Series", library_id=visible_lib.id)
@@ -146,69 +116,39 @@ def _seed_character_collab_fixture(db, normal_user):
     db.flush()
 
     safe_comics = [
-        Comic(
-            volume_id=safe_volume.id,
-            number="1",
-            title="Character Safe #1",
-            age_rating="Teen",
-            filename="character-safe-1.cbz",
-            file_path="/tmp/character-safe-1.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "character-safe-1.cbz",
+            number="1", title="Character Safe #1", age_rating="Teen", filename="character-safe-1.cbz",
         ),
-        Comic(
-            volume_id=safe_volume.id,
-            number="2",
-            title="Character Safe #2",
-            age_rating="Teen",
-            filename="character-safe-2.cbz",
-            file_path="/tmp/character-safe-2.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "character-safe-2.cbz",
+            number="2", title="Character Safe #2", age_rating="Teen", filename="character-safe-2.cbz",
         ),
-        Comic(
-            volume_id=safe_volume.id,
-            number="3",
-            title="Character Safe #3",
-            age_rating="Teen",
-            filename="character-safe-3.cbz",
-            file_path="/tmp/character-safe-3.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "character-safe-3.cbz",
+            number="3", title="Character Safe #3", age_rating="Teen", filename="character-safe-3.cbz",
         ),
     ]
     banned_comics = [
-        Comic(
-            volume_id=banned_volume.id,
-            number="1",
-            title="Character Banned #1",
-            age_rating="Mature 17+",
-            filename="character-banned-1.cbz",
-            file_path="/tmp/character-banned-1.cbz",
+        create_comic(
+            db, banned_volume, visible_root, "character-banned-1.cbz",
+            number="1", title="Character Banned #1", age_rating="Mature 17+", filename="character-banned-1.cbz",
         ),
-        Comic(
-            volume_id=banned_volume.id,
-            number="2",
-            title="Character Banned #2",
-            age_rating="Mature 17+",
-            filename="character-banned-2.cbz",
-            file_path="/tmp/character-banned-2.cbz",
+        create_comic(
+            db, banned_volume, visible_root, "character-banned-2.cbz",
+            number="2", title="Character Banned #2", age_rating="Mature 17+", filename="character-banned-2.cbz",
         ),
     ]
     hidden_comics = [
-        Comic(
-            volume_id=hidden_volume.id,
-            number="1",
-            title="Character Hidden #1",
-            age_rating="Teen",
-            filename="character-hidden-1.cbz",
-            file_path="/tmp/character-hidden-1.cbz",
+        create_comic(
+            db, hidden_volume, hidden_root, "character-hidden-1.cbz",
+            number="1", title="Character Hidden #1", age_rating="Teen", filename="character-hidden-1.cbz",
         ),
-        Comic(
-            volume_id=hidden_volume.id,
-            number="2",
-            title="Character Hidden #2",
-            age_rating="Teen",
-            filename="character-hidden-2.cbz",
-            file_path="/tmp/character-hidden-2.cbz",
+        create_comic(
+            db, hidden_volume, hidden_root, "character-hidden-2.cbz",
+            number="2", title="Character Hidden #2", age_rating="Teen", filename="character-hidden-2.cbz",
         ),
     ]
-    db.add_all(safe_comics + banned_comics + hidden_comics)
-    db.flush()
 
     hero_alpha = Character(name="Hero Alpha")
     hero_beta = Character(name="Hero Beta")
@@ -238,10 +178,10 @@ def _seed_character_collab_fixture(db, normal_user):
 
 
 def _seed_writer_character_fixture(db, normal_user):
-    visible_lib = Library(name="Writer Character Visible", path="/tmp/writer-character-visible")
-    hidden_lib = Library(name="Writer Character Hidden", path="/tmp/writer-character-hidden")
-    db.add_all([visible_lib, hidden_lib])
-    db.flush()
+    visible_lib = create_library_with_root(db, "Writer Character Visible", "/tmp/writer-character-visible")
+    hidden_lib = create_library_with_root(db, "Writer Character Hidden", "/tmp/writer-character-hidden")
+    visible_root = visible_lib.active_root
+    hidden_root = hidden_lib.active_root
 
     safe_series = Series(name="Writer Character Safe Series", library_id=visible_lib.id)
     banned_series = Series(name="Writer Character Banned Series", library_id=visible_lib.id)
@@ -256,69 +196,39 @@ def _seed_writer_character_fixture(db, normal_user):
     db.flush()
 
     safe_comics = [
-        Comic(
-            volume_id=safe_volume.id,
-            number="1",
-            title="Writer Character Safe #1",
-            age_rating="Teen",
-            filename="writer-character-safe-1.cbz",
-            file_path="/tmp/writer-character-safe-1.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "writer-character-safe-1.cbz",
+            number="1", title="Writer Character Safe #1", age_rating="Teen", filename="writer-character-safe-1.cbz",
         ),
-        Comic(
-            volume_id=safe_volume.id,
-            number="2",
-            title="Writer Character Safe #2",
-            age_rating="Teen",
-            filename="writer-character-safe-2.cbz",
-            file_path="/tmp/writer-character-safe-2.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "writer-character-safe-2.cbz",
+            number="2", title="Writer Character Safe #2", age_rating="Teen", filename="writer-character-safe-2.cbz",
         ),
-        Comic(
-            volume_id=safe_volume.id,
-            number="3",
-            title="Writer Character Safe #3",
-            age_rating="Teen",
-            filename="writer-character-safe-3.cbz",
-            file_path="/tmp/writer-character-safe-3.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "writer-character-safe-3.cbz",
+            number="3", title="Writer Character Safe #3", age_rating="Teen", filename="writer-character-safe-3.cbz",
         ),
     ]
     banned_comics = [
-        Comic(
-            volume_id=banned_volume.id,
-            number="1",
-            title="Writer Character Banned #1",
-            age_rating="Mature 17+",
-            filename="writer-character-banned-1.cbz",
-            file_path="/tmp/writer-character-banned-1.cbz",
+        create_comic(
+            db, banned_volume, visible_root, "writer-character-banned-1.cbz",
+            number="1", title="Writer Character Banned #1", age_rating="Mature 17+", filename="writer-character-banned-1.cbz",
         ),
-        Comic(
-            volume_id=banned_volume.id,
-            number="2",
-            title="Writer Character Banned #2",
-            age_rating="Mature 17+",
-            filename="writer-character-banned-2.cbz",
-            file_path="/tmp/writer-character-banned-2.cbz",
+        create_comic(
+            db, banned_volume, visible_root, "writer-character-banned-2.cbz",
+            number="2", title="Writer Character Banned #2", age_rating="Mature 17+", filename="writer-character-banned-2.cbz",
         ),
     ]
     hidden_comics = [
-        Comic(
-            volume_id=hidden_volume.id,
-            number="1",
-            title="Writer Character Hidden #1",
-            age_rating="Teen",
-            filename="writer-character-hidden-1.cbz",
-            file_path="/tmp/writer-character-hidden-1.cbz",
+        create_comic(
+            db, hidden_volume, hidden_root, "writer-character-hidden-1.cbz",
+            number="1", title="Writer Character Hidden #1", age_rating="Teen", filename="writer-character-hidden-1.cbz",
         ),
-        Comic(
-            volume_id=hidden_volume.id,
-            number="2",
-            title="Writer Character Hidden #2",
-            age_rating="Teen",
-            filename="writer-character-hidden-2.cbz",
-            file_path="/tmp/writer-character-hidden-2.cbz",
+        create_comic(
+            db, hidden_volume, hidden_root, "writer-character-hidden-2.cbz",
+            number="2", title="Writer Character Hidden #2", age_rating="Teen", filename="writer-character-hidden-2.cbz",
         ),
     ]
-    db.add_all(safe_comics + banned_comics + hidden_comics)
-    db.flush()
 
     writer_a = Person(name="Writer Character A")
     writer_b = Person(name="Writer Character B")
@@ -362,10 +272,10 @@ def _seed_writer_character_fixture(db, normal_user):
 
 
 def _seed_artist_character_fixture(db, normal_user):
-    visible_lib = Library(name="Artist Character Visible", path="/tmp/artist-character-visible")
-    hidden_lib = Library(name="Artist Character Hidden", path="/tmp/artist-character-hidden")
-    db.add_all([visible_lib, hidden_lib])
-    db.flush()
+    visible_lib = create_library_with_root(db, "Artist Character Visible", "/tmp/artist-character-visible")
+    hidden_lib = create_library_with_root(db, "Artist Character Hidden", "/tmp/artist-character-hidden")
+    visible_root = visible_lib.active_root
+    hidden_root = hidden_lib.active_root
 
     safe_series = Series(name="Artist Character Safe Series", library_id=visible_lib.id)
     banned_series = Series(name="Artist Character Banned Series", library_id=visible_lib.id)
@@ -380,69 +290,39 @@ def _seed_artist_character_fixture(db, normal_user):
     db.flush()
 
     safe_comics = [
-        Comic(
-            volume_id=safe_volume.id,
-            number="1",
-            title="Artist Character Safe #1",
-            age_rating="Teen",
-            filename="artist-character-safe-1.cbz",
-            file_path="/tmp/artist-character-safe-1.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "artist-character-safe-1.cbz",
+            number="1", title="Artist Character Safe #1", age_rating="Teen", filename="artist-character-safe-1.cbz",
         ),
-        Comic(
-            volume_id=safe_volume.id,
-            number="2",
-            title="Artist Character Safe #2",
-            age_rating="Teen",
-            filename="artist-character-safe-2.cbz",
-            file_path="/tmp/artist-character-safe-2.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "artist-character-safe-2.cbz",
+            number="2", title="Artist Character Safe #2", age_rating="Teen", filename="artist-character-safe-2.cbz",
         ),
-        Comic(
-            volume_id=safe_volume.id,
-            number="3",
-            title="Artist Character Safe #3",
-            age_rating="Teen",
-            filename="artist-character-safe-3.cbz",
-            file_path="/tmp/artist-character-safe-3.cbz",
+        create_comic(
+            db, safe_volume, visible_root, "artist-character-safe-3.cbz",
+            number="3", title="Artist Character Safe #3", age_rating="Teen", filename="artist-character-safe-3.cbz",
         ),
     ]
     banned_comics = [
-        Comic(
-            volume_id=banned_volume.id,
-            number="1",
-            title="Artist Character Banned #1",
-            age_rating="Mature 17+",
-            filename="artist-character-banned-1.cbz",
-            file_path="/tmp/artist-character-banned-1.cbz",
+        create_comic(
+            db, banned_volume, visible_root, "artist-character-banned-1.cbz",
+            number="1", title="Artist Character Banned #1", age_rating="Mature 17+", filename="artist-character-banned-1.cbz",
         ),
-        Comic(
-            volume_id=banned_volume.id,
-            number="2",
-            title="Artist Character Banned #2",
-            age_rating="Mature 17+",
-            filename="artist-character-banned-2.cbz",
-            file_path="/tmp/artist-character-banned-2.cbz",
+        create_comic(
+            db, banned_volume, visible_root, "artist-character-banned-2.cbz",
+            number="2", title="Artist Character Banned #2", age_rating="Mature 17+", filename="artist-character-banned-2.cbz",
         ),
     ]
     hidden_comics = [
-        Comic(
-            volume_id=hidden_volume.id,
-            number="1",
-            title="Artist Character Hidden #1",
-            age_rating="Teen",
-            filename="artist-character-hidden-1.cbz",
-            file_path="/tmp/artist-character-hidden-1.cbz",
+        create_comic(
+            db, hidden_volume, hidden_root, "artist-character-hidden-1.cbz",
+            number="1", title="Artist Character Hidden #1", age_rating="Teen", filename="artist-character-hidden-1.cbz",
         ),
-        Comic(
-            volume_id=hidden_volume.id,
-            number="2",
-            title="Artist Character Hidden #2",
-            age_rating="Teen",
-            filename="artist-character-hidden-2.cbz",
-            file_path="/tmp/artist-character-hidden-2.cbz",
+        create_comic(
+            db, hidden_volume, hidden_root, "artist-character-hidden-2.cbz",
+            number="2", title="Artist Character Hidden #2", age_rating="Teen", filename="artist-character-hidden-2.cbz",
         ),
     ]
-    db.add_all(safe_comics + banned_comics + hidden_comics)
-    db.flush()
 
     artist_a = Person(name="Artist Character A")
     artist_b = Person(name="Artist Character B")
@@ -574,9 +454,8 @@ def test_creator_collaborations_include_identity_fields_for_matrix_alignment(aut
 
 
 def test_creator_collaboration_header_totals_match_visible_matrix(auth_client, db, normal_user):
-    visible_lib = Library(name="Visible Matrix Totals", path="/tmp/visible-matrix-totals")
-    db.add(visible_lib)
-    db.flush()
+    visible_lib = create_library_with_root(db, "Visible Matrix Totals", "/tmp/visible-matrix-totals")
+    root = visible_lib.active_root
 
     series = Series(name="Visible Matrix Totals Series", library_id=visible_lib.id)
     db.add(series)
@@ -587,49 +466,27 @@ def test_creator_collaboration_header_totals_match_visible_matrix(auth_client, d
     db.flush()
 
     comics = [
-        Comic(
-            volume_id=volume.id,
-            number="1",
-            title="Visible #1",
-            age_rating="Teen",
-            filename="visible-1.cbz",
-            file_path="/tmp/visible-1.cbz",
+        create_comic(
+            db, volume, root, "visible-1.cbz",
+            number="1", title="Visible #1", age_rating="Teen", filename="visible-1.cbz",
         ),
-        Comic(
-            volume_id=volume.id,
-            number="2",
-            title="Visible #2",
-            age_rating="Teen",
-            filename="visible-2.cbz",
-            file_path="/tmp/visible-2.cbz",
+        create_comic(
+            db, volume, root, "visible-2.cbz",
+            number="2", title="Visible #2", age_rating="Teen", filename="visible-2.cbz",
         ),
-        Comic(
-            volume_id=volume.id,
-            number="3",
-            title="Visible #3",
-            age_rating="Teen",
-            filename="visible-3.cbz",
-            file_path="/tmp/visible-3.cbz",
+        create_comic(
+            db, volume, root, "visible-3.cbz",
+            number="3", title="Visible #3", age_rating="Teen", filename="visible-3.cbz",
         ),
-        Comic(
-            volume_id=volume.id,
-            number="4",
-            title="Visible #4",
-            age_rating="Teen",
-            filename="visible-4.cbz",
-            file_path="/tmp/visible-4.cbz",
+        create_comic(
+            db, volume, root, "visible-4.cbz",
+            number="4", title="Visible #4", age_rating="Teen", filename="visible-4.cbz",
         ),
-        Comic(
-            volume_id=volume.id,
-            number="5",
-            title="Visible #5",
-            age_rating="Teen",
-            filename="visible-5.cbz",
-            file_path="/tmp/visible-5.cbz",
+        create_comic(
+            db, volume, root, "visible-5.cbz",
+            number="5", title="Visible #5", age_rating="Teen", filename="visible-5.cbz",
         ),
     ]
-    db.add_all(comics)
-    db.flush()
 
     writer_a = Person(name="Visible Writer A")
     writer_b = Person(name="Visible Writer B")

--- a/tests/api/test_jobs.py
+++ b/tests/api/test_jobs.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 from app.models.job import JobStatus, JobType, ScanJob
-from app.models.library import Library
+from tests.factories import create_library_with_root
 
 
 def test_active_job_returns_inactive_when_none(client):
@@ -35,9 +35,7 @@ def test_active_job_returns_cleanup_placeholder_library_name(client, db):
 
 
 def test_list_jobs_applies_filters_and_parses_summary(admin_client, db):
-    library = Library(name="Jobs-Lib", path="/tmp/jobs-lib")
-    db.add(library)
-    db.flush()
+    library = create_library_with_root(db, "Jobs-Lib", "/tmp/jobs-lib")
 
     base_time = datetime.now(timezone.utc)
     completed = ScanJob(
@@ -80,9 +78,7 @@ def test_list_jobs_applies_filters_and_parses_summary(admin_client, db):
 
 
 def test_get_job_status_success_and_not_found(admin_client, db):
-    library = Library(name="Status-Lib", path="/tmp/status-lib")
-    db.add(library)
-    db.flush()
+    library = create_library_with_root(db, "Status-Lib", "/tmp/status-lib")
 
     job = ScanJob(
         library_id=library.id,

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -1,6 +1,8 @@
 import json
 from unittest.mock import patch
 
+import pytest
+
 from app.main import app
 from app.api.deps import get_current_user
 from app.models.comic import Comic, Volume
@@ -11,10 +13,12 @@ from app.models.interactions import UserLibraryPin
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_library_series_fixture(db, *, lib_name: str):
-    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    library = create_library_with_root(db, lib_name, f"/tmp/{lib_name}")
+    root = library.active_root
     series_alpha = Series(name="The Alpha", library=library)
     series_beta = Series(name="Beta", library=library)
     series_reverse = Series(name="Countdown", library=library)
@@ -23,69 +27,36 @@ def _create_library_series_fixture(db, *, lib_name: str):
     vol_beta = Volume(series=series_beta, volume_number=1)
     vol_reverse = Volume(series=series_reverse, volume_number=1)
 
-    db.add_all([library, series_alpha, series_beta, series_reverse, vol_alpha, vol_beta, vol_reverse])
+    db.add_all([series_alpha, series_beta, series_reverse, vol_alpha, vol_beta, vol_reverse])
     db.flush()
 
-    alpha_two = Comic(
-        volume_id=vol_alpha.id,
-        number="2",
-        title="The Alpha #2",
-        year=2002,
-        filename="alpha-2.cbz",
-        file_path=f"/tmp/{lib_name}-alpha-2.cbz",
-        page_count=20,
+    alpha_two = create_comic(
+        db, vol_alpha, root, "alpha-2.cbz",
+        number="2", title="The Alpha #2", year=2002, filename="alpha-2.cbz", page_count=20,
     )
-    alpha_one = Comic(
-        volume_id=vol_alpha.id,
-        number="1",
-        title="The Alpha #1",
-        year=2001,
-        filename="alpha-1.cbz",
-        file_path=f"/tmp/{lib_name}-alpha-1.cbz",
-        page_count=20,
+    alpha_one = create_comic(
+        db, vol_alpha, root, "alpha-1.cbz",
+        number="1", title="The Alpha #1", year=2001, filename="alpha-1.cbz", page_count=20,
     )
 
-    beta_five = Comic(
-        volume_id=vol_beta.id,
-        number="5",
-        title="Beta Annual",
-        year=2005,
-        format="annual",
-        filename="beta-5.cbz",
-        file_path=f"/tmp/{lib_name}-beta-5.cbz",
-        page_count=20,
+    beta_five = create_comic(
+        db, vol_beta, root, "beta-5.cbz",
+        number="5", title="Beta Annual", year=2005, format="annual", filename="beta-5.cbz", page_count=20,
     )
-    beta_three = Comic(
-        volume_id=vol_beta.id,
-        number="3",
-        title="Beta Special",
-        year=2003,
-        format="one-shot",
-        filename="beta-3.cbz",
-        file_path=f"/tmp/{lib_name}-beta-3.cbz",
-        page_count=20,
+    beta_three = create_comic(
+        db, vol_beta, root, "beta-3.cbz",
+        number="3", title="Beta Special", year=2003, format="one-shot", filename="beta-3.cbz", page_count=20,
     )
 
-    reverse_one = Comic(
-        volume_id=vol_reverse.id,
-        number="1",
-        title="Countdown #1",
-        year=2001,
-        filename="countdown-1.cbz",
-        file_path=f"/tmp/{lib_name}-countdown-1.cbz",
-        page_count=20,
+    reverse_one = create_comic(
+        db, vol_reverse, root, "countdown-1.cbz",
+        number="1", title="Countdown #1", year=2001, filename="countdown-1.cbz", page_count=20,
     )
-    reverse_four = Comic(
-        volume_id=vol_reverse.id,
-        number="4",
-        title="Countdown #4",
-        year=2004,
-        filename="countdown-4.cbz",
-        file_path=f"/tmp/{lib_name}-countdown-4.cbz",
-        page_count=20,
+    reverse_four = create_comic(
+        db, vol_reverse, root, "countdown-4.cbz",
+        number="4", title="Countdown #4", year=2004, filename="countdown-4.cbz", page_count=20,
     )
 
-    db.add_all([alpha_two, alpha_one, beta_five, beta_three, reverse_one, reverse_four])
     db.commit()
 
     return {
@@ -125,9 +96,22 @@ def test_admin_can_create_library(admin_client, db):
     assert root.is_active is True
 
 
+def test_create_library_rolls_back_if_root_creation_fails(admin_client, db, monkeypatch):
+    import app.api.libraries as libraries_module
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(libraries_module, "LibraryRoot", _boom)
+
+    with pytest.raises(RuntimeError):
+        admin_client.post("/api/libraries/", json={"name": "Atomic Test", "path": "/tmp/atomic"})
+
+    assert db.query(Library).filter_by(name="Atomic Test").first() is None
+
+
 def test_create_library_duplicate_name_returns_400(admin_client, db):
-    db.add(Library(name="Duplicate", path="/tmp/dup"))
-    db.commit()
+    create_library_with_root(db, "Duplicate", "/tmp/dup")
 
     response = admin_client.post("/api/libraries/", json={"name": "Duplicate", "path": "/tmp/other"})
 
@@ -136,8 +120,7 @@ def test_create_library_duplicate_name_returns_400(admin_client, db):
 
 
 def test_create_library_rejects_overlapping_child_path(admin_client, db):
-    db.add(Library(name="Main Library", path="/tmp/comics"))
-    db.commit()
+    create_library_with_root(db, "Main Library", "/tmp/comics")
 
     response = admin_client.post(
         "/api/libraries/",
@@ -151,8 +134,7 @@ def test_create_library_rejects_overlapping_child_path(admin_client, db):
 
 
 def test_create_library_rejects_overlapping_parent_path(admin_client, db):
-    db.add(Library(name="Marvel", path="/tmp/comics/Marvel"))
-    db.commit()
+    create_library_with_root(db, "Marvel", "/tmp/comics/Marvel")
 
     response = admin_client.post(
         "/api/libraries/",
@@ -166,9 +148,7 @@ def test_create_library_rejects_overlapping_parent_path(admin_client, db):
 
 
 def test_user_rls_security(client, db, admin_user, normal_user):
-    lib = Library(name="Secret Library", path="/tmp")
-    db.add(lib)
-    db.commit()
+    lib = create_library_with_root(db, "Secret Library", "/tmp")
 
     app.dependency_overrides[get_current_user] = lambda: admin_user
 
@@ -184,9 +164,7 @@ def test_user_rls_security(client, db, admin_user, normal_user):
 
 
 def test_get_library_detail_requires_access(auth_client, db):
-    library = Library(name="Hidden", path="/tmp/hidden")
-    db.add(library)
-    db.commit()
+    library = create_library_with_root(db, "Hidden", "/tmp/hidden")
 
     response = auth_client.get(f"/api/libraries/{library.id}")
 
@@ -195,9 +173,7 @@ def test_get_library_detail_requires_access(auth_client, db):
 
 
 def test_get_library_detail_as_admin(admin_client, db):
-    library = Library(name="Visible", path="/tmp/visible")
-    db.add(library)
-    db.commit()
+    library = create_library_with_root(db, "Visible", "/tmp/visible")
 
     response = admin_client.get(f"/api/libraries/{library.id}")
 
@@ -279,9 +255,7 @@ def test_library_path_browser_reports_missing_root(admin_client, monkeypatch, tm
 
 
 def test_user_can_pin_and_unpin_accessible_library_idempotently(auth_client, db, normal_user):
-    library = Library(name="Pinned Access", path="/tmp/pinned-access")
-    db.add(library)
-    db.commit()
+    library = create_library_with_root(db, "Pinned Access", "/tmp/pinned-access")
     normal_user.accessible_libraries.append(library)
     db.commit()
 
@@ -311,9 +285,7 @@ def test_user_can_pin_and_unpin_accessible_library_idempotently(auth_client, db,
 
 
 def test_user_cannot_pin_inaccessible_library(auth_client, db):
-    library = Library(name="Pinned Hidden", path="/tmp/pinned-hidden")
-    db.add(library)
-    db.commit()
+    library = create_library_with_root(db, "Pinned Hidden", "/tmp/pinned-hidden")
 
     pin_response = auth_client.post(f"/api/libraries/{library.id}/pin")
     unpin_response = auth_client.delete(f"/api/libraries/{library.id}/pin")
@@ -369,9 +341,7 @@ def test_get_library_series_sorts_and_computes_cover_and_read_state(auth_client,
 
 
 def test_get_library_series_empty_page_returns_empty_items(auth_client, db, normal_user):
-    library = Library(name="No-Series", path="/tmp/no-series")
-    db.add(library)
-    db.commit()
+    library = create_library_with_root(db, "No-Series", "/tmp/no-series")
 
     normal_user.accessible_libraries.append(library)
     db.commit()
@@ -383,16 +353,15 @@ def test_get_library_series_empty_page_returns_empty_items(auth_client, db, norm
 
 
 def test_update_library_applies_fields_and_refreshes_watches(admin_client, db):
-    library = Library(
-        name="UpdateMe",
-        path="/tmp/update-me",
+    library = create_library_with_root(
+        db,
+        "UpdateMe",
+        "/tmp/update-me",
         watch_mode=False,
         parse_reading_lists=True,
         parse_collections=True,
         parse_story_arcs=True,
     )
-    db.add(library)
-    db.commit()
 
     with patch("app.api.libraries.library_watcher.refresh_watches") as mock_refresh:
         response = admin_client.patch(
@@ -419,13 +388,15 @@ def test_update_library_applies_fields_and_refreshes_watches(admin_client, db):
 
 
 def test_update_library_disabling_metadata_flags_preserves_existing_metadata_rows(admin_client, db):
-    library = Library(
-        name="Cleanup Metadata",
-        path="/tmp/cleanup-metadata",
+    library = create_library_with_root(
+        db,
+        "Cleanup Metadata",
+        "/tmp/cleanup-metadata",
         parse_reading_lists=True,
         parse_collections=True,
         parse_story_arcs=True,
     )
+    root = library.active_root
     series = Series(name="Cleanup Series", library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -433,7 +404,8 @@ def test_update_library_disabling_metadata_flags_preserves_existing_metadata_row
         number="1",
         title="Cleanup Issue",
         filename="cleanup.cbz",
-        file_path="/tmp/cleanup.cbz",
+        library_root_id=root.id,
+        relative_path="cleanup.cbz",
         alternate_series="Event Alpha",
         alternate_number="1",
         series_group="Group Alpha",
@@ -442,7 +414,7 @@ def test_update_library_disabling_metadata_flags_preserves_existing_metadata_row
 
     reading_list = ReadingList(name="Event Alpha")
     collection = Collection(name="Group Alpha")
-    db.add_all([library, series, volume, comic, reading_list, collection])
+    db.add_all([series, volume, comic, reading_list, collection])
     db.flush()
 
     reading_list_item = ReadingListItem(reading_list_id=reading_list.id, comic_id=comic.id, position=1.0)
@@ -479,13 +451,15 @@ def test_update_library_disabling_metadata_flags_preserves_existing_metadata_row
 
 
 def test_update_library_reenabling_metadata_flags_queues_rehydrate_job(admin_client, db):
-    library = Library(
-        name="Rehydrate Metadata",
-        path="/tmp/rehydrate-metadata",
+    library = create_library_with_root(
+        db,
+        "Rehydrate Metadata",
+        "/tmp/rehydrate-metadata",
         parse_reading_lists=False,
         parse_collections=False,
         parse_story_arcs=False,
     )
+    root = library.active_root
 
     series = Series(name="Rehydrate Series", library=library)
     volume = Volume(series=series, volume_number=1)
@@ -495,7 +469,8 @@ def test_update_library_reenabling_metadata_flags_queues_rehydrate_job(admin_cli
         number="1",
         title="Restorable Issue",
         filename="restorable.cbz",
-        file_path="/tmp/restorable.cbz",
+        library_root_id=root.id,
+        relative_path="restorable.cbz",
         metadata_json=json.dumps(
             {
                 "alternate_series": "Event Beta",
@@ -511,11 +486,12 @@ def test_update_library_reenabling_metadata_flags_queues_rehydrate_job(admin_cli
         number="2",
         title="Missing Source",
         filename="missing-source.cbz",
-        file_path="/tmp/missing-source.cbz",
+        library_root_id=root.id,
+        relative_path="missing-source.cbz",
         metadata_json=None,
     )
 
-    db.add_all([library, series, volume, restorable, missing_source])
+    db.add_all([series, volume, restorable, missing_source])
     db.commit()
 
     with (
@@ -563,10 +539,8 @@ def test_update_library_reenabling_metadata_flags_queues_rehydrate_job(admin_cli
 
 
 def test_update_library_rejects_duplicate_name(admin_client, db):
-    original = Library(name="Original", path="/tmp/original")
-    duplicate = Library(name="Taken", path="/tmp/taken")
-    db.add_all([original, duplicate])
-    db.commit()
+    original = create_library_with_root(db, "Original", "/tmp/original")
+    create_library_with_root(db, "Taken", "/tmp/taken")
 
     response = admin_client.patch(f"/api/libraries/{original.id}", json={"name": "Taken"})
 
@@ -575,9 +549,7 @@ def test_update_library_rejects_duplicate_name(admin_client, db):
 
 
 def test_update_library_rejects_changed_path(admin_client, db):
-    original = Library(name="Original", path="/tmp/original")
-    db.add(original)
-    db.commit()
+    original = create_library_with_root(db, "Original", "/tmp/original")
 
     response = admin_client.patch(
         f"/api/libraries/{original.id}",
@@ -588,13 +560,11 @@ def test_update_library_rejects_changed_path(admin_client, db):
     assert "temporarily disabled" in response.json()["detail"]
 
     db.refresh(original)
-    assert original.path == "/tmp/original"
+    assert original.active_root.path == "/tmp/original"
 
 
 def test_update_library_allows_unchanged_path(admin_client, db):
-    original = Library(name="Original", path="/tmp/original")
-    db.add(original)
-    db.commit()
+    original = create_library_with_root(db, "Original", "/tmp/original")
 
     response = admin_client.patch(
         f"/api/libraries/{original.id}",
@@ -614,9 +584,7 @@ def test_update_library_returns_404_for_missing_library(admin_client):
 
 
 def test_delete_library_success_and_not_found(admin_client, db):
-    library = Library(name="DeleteMe", path="/tmp/delete-me")
-    db.add(library)
-    db.commit()
+    library = create_library_with_root(db, "DeleteMe", "/tmp/delete-me")
 
     success = admin_client.delete(f"/api/libraries/{library.id}")
     assert success.status_code == 200
@@ -629,9 +597,7 @@ def test_delete_library_success_and_not_found(admin_client, db):
 
 
 def test_scan_library_passes_force_flag_to_scan_manager(admin_client, db):
-    library = Library(name="ScanMe", path="/tmp/scan-me")
-    db.add(library)
-    db.commit()
+    library = create_library_with_root(db, "ScanMe", "/tmp/scan-me")
 
     expected = {"status": "queued", "job_id": 55, "message": "Queued"}
     with patch("app.api.libraries.scan_manager.add_task", return_value=expected) as mock_add_task:
@@ -652,10 +618,8 @@ def test_scan_library_returns_404_for_missing_library(admin_client):
 def test_has_library_access_helper_paths(db, normal_user, admin_user):
     from app.api.libraries import _has_library_access
 
-    allowed_library = Library(name="Helper Allowed", path="/tmp/helper-allowed")
-    denied_library = Library(name="Helper Denied", path="/tmp/helper-denied")
-    db.add_all([allowed_library, denied_library])
-    db.commit()
+    allowed_library = create_library_with_root(db, "Helper Allowed", "/tmp/helper-allowed")
+    denied_library = create_library_with_root(db, "Helper Denied", "/tmp/helper-denied")
 
     normal_user.accessible_libraries.append(allowed_library)
     db.commit()
@@ -666,12 +630,9 @@ def test_has_library_access_helper_paths(db, normal_user, admin_user):
 
 
 def test_list_libraries_applies_limit_for_superuser(admin_client, db):
-    db.add_all([
-        Library(name="A Library", path="/tmp/a"),
-        Library(name="B Library", path="/tmp/b"),
-        Library(name="C Library", path="/tmp/c"),
-    ])
-    db.commit()
+    create_library_with_root(db, "A Library", "/tmp/a")
+    create_library_with_root(db, "B Library", "/tmp/b")
+    create_library_with_root(db, "C Library", "/tmp/c")
 
     response = admin_client.get("/api/libraries/?limit=2")
 
@@ -682,11 +643,9 @@ def test_list_libraries_applies_limit_for_superuser(admin_client, db):
 
 
 def test_list_libraries_applies_limit_for_normal_user(auth_client, db, normal_user):
-    lib_a = Library(name="Limit User A", path="/tmp/limit-user-a")
-    lib_b = Library(name="Limit User B", path="/tmp/limit-user-b")
-    lib_c = Library(name="Limit User C", path="/tmp/limit-user-c")
-    db.add_all([lib_a, lib_b, lib_c])
-    db.commit()
+    lib_a = create_library_with_root(db, "Limit User A", "/tmp/limit-user-a")
+    lib_b = create_library_with_root(db, "Limit User B", "/tmp/limit-user-b")
+    lib_c = create_library_with_root(db, "Limit User C", "/tmp/limit-user-c")
 
     normal_user.accessible_libraries.extend([lib_b, lib_a, lib_c])
     db.commit()
@@ -700,7 +659,8 @@ def test_list_libraries_applies_limit_for_normal_user(auth_client, db, normal_us
 
 
 def test_list_libraries_filters_stats_by_age_restriction(auth_client, db, normal_user):
-    library = Library(name="Age Stats Library", path="/tmp/age-stats-library")
+    library = create_library_with_root(db, "Age Stats Library", "/tmp/age-stats-library")
+    root = library.active_root
 
     safe_series = Series(name="Safe Stats Series", library=library)
     safe_volume = Volume(series=safe_series, volume_number=1)
@@ -710,7 +670,8 @@ def test_list_libraries_filters_stats_by_age_restriction(auth_client, db, normal
         title="Safe Stats Comic",
         age_rating="Teen",
         filename="safe-stats.cbz",
-        file_path="/tmp/safe-stats.cbz",
+        library_root_id=root.id,
+        relative_path="safe-stats.cbz",
     )
 
     banned_series = Series(name="Banned Stats Series", library=library)
@@ -721,10 +682,11 @@ def test_list_libraries_filters_stats_by_age_restriction(auth_client, db, normal
         title="Banned Stats Comic",
         age_rating="Mature 17+",
         filename="banned-stats.cbz",
-        file_path="/tmp/banned-stats.cbz",
+        library_root_id=root.id,
+        relative_path="banned-stats.cbz",
     )
 
-    db.add_all([library, safe_series, safe_volume, safe_comic, banned_series, banned_volume, banned_comic])
+    db.add_all([safe_series, safe_volume, safe_comic, banned_series, banned_volume, banned_comic])
     normal_user.accessible_libraries.append(library)
     normal_user.max_age_rating = "Teen"
     normal_user.allow_unknown_age_ratings = False
@@ -739,7 +701,8 @@ def test_list_libraries_filters_stats_by_age_restriction(auth_client, db, normal
 
 
 def test_get_library_series_filters_by_age_restriction(auth_client, db, normal_user):
-    library = Library(name="Age Series Library", path="/tmp/age-series-library")
+    library = create_library_with_root(db, "Age Series Library", "/tmp/age-series-library")
+    root = library.active_root
 
     safe_series = Series(name="Safe Series", library=library)
     safe_volume = Volume(series=safe_series, volume_number=1)
@@ -749,7 +712,8 @@ def test_get_library_series_filters_by_age_restriction(auth_client, db, normal_u
         title="Safe Comic",
         age_rating="Teen",
         filename="safe-series.cbz",
-        file_path="/tmp/safe-series.cbz",
+        library_root_id=root.id,
+        relative_path="safe-series.cbz",
     )
 
     banned_series = Series(name="Banned Series", library=library)
@@ -760,10 +724,11 @@ def test_get_library_series_filters_by_age_restriction(auth_client, db, normal_u
         title="Banned Comic",
         age_rating="Mature 17+",
         filename="banned-series.cbz",
-        file_path="/tmp/banned-series.cbz",
+        library_root_id=root.id,
+        relative_path="banned-series.cbz",
     )
 
-    db.add_all([library, safe_series, safe_volume, safe_comic, banned_series, banned_volume, banned_comic])
+    db.add_all([safe_series, safe_volume, safe_comic, banned_series, banned_volume, banned_comic])
     normal_user.accessible_libraries.append(library)
     normal_user.max_age_rating = "Teen"
     normal_user.allow_unknown_age_ratings = False
@@ -779,29 +744,21 @@ def test_get_library_series_filters_by_age_restriction(auth_client, db, normal_u
 
 
 def test_get_library_series_cover_fallback_handles_non_numeric_numbers(auth_client, db, normal_user):
-    library = Library(name="Library Non Numeric", path="/tmp/library-non-numeric")
+    library = create_library_with_root(db, "Library Non Numeric", "/tmp/library-non-numeric")
+    root = library.active_root
     series = Series(name="Non Numeric Series", library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    comic_alpha = Comic(
-        volume_id=volume.id,
-        number="A",
-        title="Non Numeric A",
-        year=2024,
-        filename="non-numeric-a.cbz",
-        file_path="/tmp/non-numeric-a.cbz",
+    comic_alpha = create_comic(
+        db, volume, root, "non-numeric-a.cbz",
+        number="A", title="Non Numeric A", year=2024, filename="non-numeric-a.cbz",
     )
-    comic_two = Comic(
-        volume_id=volume.id,
-        number="2",
-        title="Non Numeric #2",
-        year=2023,
-        filename="non-numeric-2.cbz",
-        file_path="/tmp/non-numeric-2.cbz",
+    comic_two = create_comic(
+        db, volume, root, "non-numeric-2.cbz",
+        number="2", title="Non Numeric #2", year=2023, filename="non-numeric-2.cbz",
     )
-    db.add_all([comic_alpha, comic_two])
 
     normal_user.accessible_libraries.append(library)
     db.commit()

--- a/tests/api/test_opds.py
+++ b/tests/api/test_opds.py
@@ -4,9 +4,9 @@ import xml.etree.ElementTree as ET
 from PIL import Image
 from app.services.settings_service import SettingsService
 from app.models.setting import SystemSetting
-from app.models.library import Library
 from app.models.series import Series
 from app.models.comic import Comic, Volume
+from tests.factories import create_library_with_root
 
 
 def test_opds_disabled_by_default(client, normal_user):
@@ -144,7 +144,8 @@ def _enable_opds(db):
 def test_opds_library_feed_renders_series_entries(client, db, normal_user):
     _enable_opds(db)
 
-    library = Library(name="OPDS Library", path="/tmp/opds-library")
+    library = create_library_with_root(db, "OPDS Library", "/tmp/opds-library")
+    root = library.active_root
     series = Series(name="Alpha Flight", library=library, summary_override="Team book")
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -152,10 +153,11 @@ def test_opds_library_feed_renders_series_entries(client, db, normal_user):
         number="1",
         title="First Issue",
         filename="alpha-flight-001.cbz",
-        file_path="/tmp/alpha-flight-001.cbz",
+        library_root_id=root.id,
+        relative_path="alpha-flight-001.cbz",
         updated_at=series.updated_at,
     )
-    db.add_all([library, series, volume, comic])
+    db.add_all([series, volume, comic])
     normal_user.accessible_libraries.append(library)
     db.commit()
 
@@ -182,20 +184,22 @@ def test_opds_library_feed_renders_series_entries(client, db, normal_user):
 def test_opds_library_feed_paginates_series_entries(client, db, normal_user):
     _enable_opds(db)
 
-    library = Library(name="Paged Library", path="/tmp/opds-paged-library")
+    library = create_library_with_root(db, "Paged Library", "/tmp/opds-paged-library")
+    root = library.active_root
     series_names = ["Alpha", "Beta", "Gamma"]
     for name in series_names:
         series = Series(name=name, library=library)
         volume = Volume(series=series, volume_number=1)
-        Comic(
+        comic = Comic(
             volume=volume,
             number="1",
             title=f"{name} One",
             filename=f"{name.lower()}-001.cbz",
-            file_path=f"/tmp/{name.lower()}-001.cbz",
+            library_root_id=root.id,
+            relative_path=f"{name.lower()}-001.cbz",
         )
+        db.add_all([series, volume, comic])
 
-    db.add(library)
     normal_user.accessible_libraries.append(library)
     db.commit()
 
@@ -224,7 +228,8 @@ def test_opds_library_feed_paginates_series_entries(client, db, normal_user):
 def test_opds_series_feed_handles_missing_month_and_day(client, db, normal_user):
     _enable_opds(db)
 
-    library = Library(name="Series Library", path="/tmp/opds-series-library")
+    library = create_library_with_root(db, "Series Library", "/tmp/opds-series-library")
+    root = library.active_root
     series = Series(name="Beta Ray", library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -232,13 +237,14 @@ def test_opds_series_feed_handles_missing_month_and_day(client, db, normal_user)
         number="7",
         title="Stormbreaker",
         filename="beta-ray-007.cbz",
-        file_path="/tmp/beta-ray-007.cbz",
+        library_root_id=root.id,
+        relative_path="beta-ray-007.cbz",
         year=2024,
         month=None,
         day=None,
         file_size=12345,
     )
-    db.add_all([library, series, volume, comic])
+    db.add_all([series, volume, comic])
     normal_user.accessible_libraries.append(library)
     db.commit()
 
@@ -268,20 +274,23 @@ def test_opds_series_feed_handles_missing_month_and_day(client, db, normal_user)
 def test_opds_series_feed_paginates_issue_entries(client, db, normal_user):
     _enable_opds(db)
 
-    library = Library(name="Paged Series Library", path="/tmp/opds-paged-series-library")
+    library = create_library_with_root(db, "Paged Series Library", "/tmp/opds-paged-series-library")
+    root = library.active_root
     series = Series(name="Paged Issues", library=library)
     volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
     for number in ("1", "2", "3"):
-        Comic(
+        comic = Comic(
             volume=volume,
             number=number,
             title=f"Issue {number}",
             filename=f"paged-issues-{number}.cbz",
-            file_path=f"/tmp/paged-issues-{number}.cbz",
+            library_root_id=root.id,
+            relative_path=f"paged-issues-{number}.cbz",
             file_size=123,
         )
+        db.add(comic)
 
-    db.add(library)
     normal_user.accessible_libraries.append(library)
     db.commit()
 
@@ -313,7 +322,8 @@ def test_opds_thumbnail_links_use_jpeg_endpoint(client, db, normal_user, tmp_pat
     thumbnail_path = tmp_path / "cover.webp"
     Image.new("RGB", (24, 36), color=(120, 20, 40)).save(thumbnail_path, format="WEBP")
 
-    library = Library(name="Thumbnail Library", path=str(tmp_path / "thumbnail-library"))
+    library = create_library_with_root(db, "Thumbnail Library", str(tmp_path))
+    root = library.active_root
     series = Series(name="Cover Test", library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -321,10 +331,11 @@ def test_opds_thumbnail_links_use_jpeg_endpoint(client, db, normal_user, tmp_pat
         number="1",
         title="Cover Story",
         filename="cover-test-001.cbz",
-        file_path=str(tmp_path / "cover-test-001.cbz"),
+        library_root_id=root.id,
+        relative_path="cover-test-001.cbz",
         thumbnail_path=str(thumbnail_path),
     )
-    db.add_all([library, series, volume, comic])
+    db.add_all([series, volume, comic])
     normal_user.accessible_libraries.append(library)
     db.commit()
 
@@ -357,7 +368,8 @@ def test_opds_download_uses_real_archive_type_and_extension(client, db, normal_u
     archive_path = tmp_path / "gamma-ray-001.cbr"
     archive_path.write_bytes(b"fake-rar")
 
-    library = Library(name="Download Library", path=str(tmp_path / "download-library"))
+    library = create_library_with_root(db, "Download Library", str(tmp_path))
+    root = library.active_root
     series = Series(name="Gamma Ray", library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -365,9 +377,10 @@ def test_opds_download_uses_real_archive_type_and_extension(client, db, normal_u
         number="1",
         title="First Blast",
         filename="gamma-ray-001.cbr",
-        file_path=str(archive_path),
+        library_root_id=root.id,
+        relative_path=archive_path.name,
     )
-    db.add_all([library, series, volume, comic])
+    db.add_all([series, volume, comic])
     normal_user.accessible_libraries.append(library)
     db.commit()
 
@@ -390,7 +403,8 @@ def test_opds_download_uses_filename_stem_when_title_missing(client, db, normal_
     archive_path = tmp_path / "titleless-special.cbz"
     archive_path.write_bytes(b"fake-zip")
 
-    library = Library(name="Titleless Library", path=str(tmp_path / "titleless-library"))
+    library = create_library_with_root(db, "Titleless Library", str(tmp_path))
+    root = library.active_root
     series = Series(name="Titleless Series", library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -398,9 +412,10 @@ def test_opds_download_uses_filename_stem_when_title_missing(client, db, normal_
         number="2",
         title=None,
         filename="titleless-special.cbz",
-        file_path=str(archive_path),
+        library_root_id=root.id,
+        relative_path=archive_path.name,
     )
-    db.add_all([library, series, volume, comic])
+    db.add_all([series, volume, comic])
     normal_user.accessible_libraries.append(library)
     db.commit()
 

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -1,11 +1,12 @@
 from app.core.templates import templates
 from app.models.comic import Comic, Volume
-from app.models.library import Library
 from app.models.series import Series
+from tests.factories import create_library_with_root
 
 
 def _seed_series_page_data(db, volume_count=1):
-    library = Library(name=f"Page Test Library {volume_count}", path=f"/tmp/page-test-library-{volume_count}")
+    library = create_library_with_root(db, f"Page Test Library {volume_count}", f"/tmp/page-test-library-{volume_count}")
+    root = library.active_root
     series = Series(name=f"Page Test Series {volume_count}", library=library)
     db.add(series)
 
@@ -18,7 +19,8 @@ def _seed_series_page_data(db, volume_count=1):
                 volume=volume,
                 number="1",
                 filename=f"page-test-{volume_count}-{index}.cbz",
-                file_path=f"/tmp/page-test-{volume_count}-{index}.cbz",
+                library_root_id=root.id,
+                relative_path=f"page-test-{volume_count}-{index}.cbz",
                 page_count=10,
             )
         )

--- a/tests/api/test_progress.py
+++ b/tests/api/test_progress.py
@@ -1,39 +1,29 @@
 from datetime import datetime, timezone, timedelta
 
 from app.models.comic import Comic, Volume
-from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
+from tests.factories import create_comic, create_library_with_root
 
 
 def _seed_progress_data(db, *, lib_name: str, series_name: str):
-    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    library = create_library_with_root(db, lib_name, f"/tmp/{lib_name}")
+    root = library.active_root
     series = Series(name=series_name, library=library)
     volume = Volume(series=series, volume_number=1)
 
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    first = Comic(
-        volume_id=volume.id,
-        number="1",
-        title=f"{series_name} #1",
-        year=2024,
-        filename=f"{series_name}-1.cbz",
-        file_path=f"/tmp/{series_name}-1-{lib_name}.cbz",
-        page_count=10,
+    first = create_comic(
+        db, volume, root, f"{series_name}-1.cbz",
+        number="1", title=f"{series_name} #1", year=2024, filename=f"{series_name}-1.cbz", page_count=10,
     )
-    second = Comic(
-        volume_id=volume.id,
-        number="2",
-        title=f"{series_name} #2",
-        year=2025,
-        filename=f"{series_name}-2.cbz",
-        file_path=f"/tmp/{series_name}-2-{lib_name}.cbz",
-        page_count=12,
+    second = create_comic(
+        db, volume, root, f"{series_name}-2.cbz",
+        number="2", title=f"{series_name} #2", year=2025, filename=f"{series_name}-2.cbz", page_count=12,
     )
 
-    db.add_all([first, second])
     db.commit()
 
     for obj in (library, series, volume, first, second):
@@ -49,7 +39,8 @@ def _seed_progress_data(db, *, lib_name: str, series_name: str):
 
 
 def _seed_age_filtered_progress_data(db, normal_user):
-    library = Library(name="progress-age-lib", path="/tmp/progress-age-lib")
+    library = create_library_with_root(db, "progress-age-lib", "/tmp/progress-age-lib")
+    root = library.active_root
 
     safe_series = Series(name="Safe Progress Series", library=library)
     safe_volume = Volume(series=safe_series, volume_number=1)
@@ -59,7 +50,8 @@ def _seed_age_filtered_progress_data(db, normal_user):
         title="Safe Progress Comic",
         age_rating="Teen",
         filename="safe-progress.cbz",
-        file_path="/tmp/safe-progress.cbz",
+        library_root_id=root.id,
+        relative_path="safe-progress.cbz",
         page_count=10,
     )
 
@@ -71,11 +63,12 @@ def _seed_age_filtered_progress_data(db, normal_user):
         title="Banned Progress Comic",
         age_rating="Mature 17+",
         filename="banned-progress.cbz",
-        file_path="/tmp/banned-progress.cbz",
+        library_root_id=root.id,
+        relative_path="banned-progress.cbz",
         page_count=10,
     )
 
-    db.add_all([library, safe_series, safe_volume, safe_comic, banned_series, banned_volume, banned_comic])
+    db.add_all([safe_series, safe_volume, safe_comic, banned_series, banned_volume, banned_comic])
     db.flush()
 
     db.add_all([
@@ -294,17 +287,10 @@ def test_recent_progress_filters_completed_and_in_progress(auth_client, db, norm
 def test_recent_progress_paginates_results(auth_client, db, normal_user):
     data = _seed_progress_data(db, lib_name="progress-pagination", series_name="Pagination Progress")
 
-    third = Comic(
-        volume_id=data["volume"].id,
-        number="3",
-        title="Pagination Progress #3",
-        year=2026,
-        filename="Pagination-3.cbz",
-        file_path="/tmp/Pagination-3-progress-pagination.cbz",
-        page_count=14,
+    third = create_comic(
+        db, data["volume"], data["library"].active_root, "Pagination-3.cbz",
+        number="3", title="Pagination Progress #3", year=2026, filename="Pagination-3.cbz", page_count=14,
     )
-    db.add(third)
-    db.flush()
 
     now = datetime.now(timezone.utc)
     db.add_all([

--- a/tests/api/test_pull_lists.py
+++ b/tests/api/test_pull_lists.py
@@ -1,44 +1,35 @@
 from app.core.security import get_password_hash
-from app.models.comic import Comic, Volume
-from app.models.library import Library
+from app.models.comic import Volume
 from app.models.pull_list import PullList, PullListItem
 from app.models.series import Series
 from app.models.user import User
+from tests.factories import create_comic, create_library_with_root
 
 
 def _seed_comics(db, prefix="pull"):
-    lib = Library(name=f"{prefix}-lib", path=f"/tmp/{prefix}-lib")
+    lib = create_library_with_root(db, f"{prefix}-lib", f"/tmp/{prefix}-lib")
+    root = lib.active_root
     series = Series(name=f"{prefix}-series", library=lib)
     volume = Volume(series=series, volume_number=1)
 
-    db.add_all([lib, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
     comics = [
-        Comic(
-            volume_id=volume.id,
-            number="1",
-            title=f"{prefix}-one",
-            filename=f"{prefix}-1.cbz",
-            file_path=f"/tmp/{prefix}-1.cbz",
+        create_comic(
+            db, volume, root, f"{prefix}-1.cbz",
+            number="1", title=f"{prefix}-one", filename=f"{prefix}-1.cbz",
         ),
-        Comic(
-            volume_id=volume.id,
-            number="2",
-            title=f"{prefix}-two",
-            filename=f"{prefix}-2.cbz",
-            file_path=f"/tmp/{prefix}-2.cbz",
+        create_comic(
+            db, volume, root, f"{prefix}-2.cbz",
+            number="2", title=f"{prefix}-two", filename=f"{prefix}-2.cbz",
         ),
-        Comic(
-            volume_id=volume.id,
-            number="3",
-            title=f"{prefix}-three",
-            filename=f"{prefix}-3.cbz",
-            file_path=f"/tmp/{prefix}-3.cbz",
+        create_comic(
+            db, volume, root, f"{prefix}-3.cbz",
+            number="3", title=f"{prefix}-three", filename=f"{prefix}-3.cbz",
         ),
     ]
 
-    db.add_all(comics)
     db.commit()
 
     for c in comics:

--- a/tests/api/test_reader.py
+++ b/tests/api/test_reader.py
@@ -7,34 +7,36 @@ from PIL import Image, ImageDraw
 
 from app.api.reader import natural_sort_key
 from app.models.collection import Collection, CollectionItem
-from app.models.comic import Comic, Volume
-from app.models.library import Library
+from app.models.comic import Volume
 from app.models.pull_list import PullList, PullListItem
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.series import Series
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_graph(db, *, lib_name: str, series_name: str, volume_number: int = 1):
-    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    library = create_library_with_root(db, lib_name, f"/tmp/{lib_name}")
     series = Series(name=series_name, library=library)
     volume = Volume(series=series, volume_number=volume_number)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
     return library, series, volume
 
 
 def _add_comic(db, volume: Volume, *, number: str, title: str, **kwargs):
     kwargs.setdefault("filename", f"{title.replace(' ', '-')}.cbz")
-    kwargs.setdefault("file_path", f"/tmp/{title.replace(' ', '-')}-{volume.id}-{number}.cbz")
-    comic = Comic(
-        volume_id=volume.id,
-        number=number,
-        title=title,
-        **kwargs,
-    )
-    db.add(comic)
-    db.flush()
-    return comic
+    file_path = kwargs.pop("file_path", None)
+    root = volume.series.library.active_root
+    if file_path is not None:
+        # Real archive on disk: point the root at its containing directory
+        # so relative_path + root.path reconstructs the real absolute path.
+        archive = Path(file_path)
+        root.path = str(archive.parent)
+        db.flush()
+        relative_path = archive.name
+    else:
+        relative_path = kwargs["filename"]
+    return create_comic(db, volume, root, relative_path, number=number, title=title, **kwargs)
 
 
 def _write_jxl_page(path: Path, accent: tuple[int, int, int]) -> None:
@@ -350,7 +352,7 @@ def test_reader_page_endpoint_headers_and_errors(client, db):
     assert jpeg.headers["content-disposition"] == 'inline; filename="page_1.jpg"'
     assert jpeg.headers["cache-control"] == "public, max-age=31536000"
     mock_page.assert_called_once_with(
-        str(comic.file_path),
+        str(comic.absolute_path),
         1,
         sharpen=True,
         grayscale=True,
@@ -408,7 +410,6 @@ def test_reader_page_endpoint_serves_real_jxl_archive_page(client, db, tmp_path)
         title="JXL Archive Comic",
         file_path=str(archive_path),
     )
-    db.add(library)
     db.commit()
 
     response = client.get(f"/api/reader/{comic.id}/page/0")
@@ -429,7 +430,6 @@ def test_reader_page_endpoint_serves_real_avif_archive_page(client, db, tmp_path
         title="AVIF Archive Comic",
         file_path=str(archive_path),
     )
-    db.add(library)
     db.commit()
 
     response = client.get(f"/api/reader/{comic.id}/page/0")

--- a/tests/api/test_reading_lists.py
+++ b/tests/api/test_reading_lists.py
@@ -1,32 +1,34 @@
-from app.models.comic import Comic, Volume
-from app.models.library import Library
+from app.models.comic import Volume
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.series import Series
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_series_graph(db, *, lib_name: str, series_name: str, prefix: str):
-    library = Library(name=lib_name, path=f"/tmp/{prefix}-lib")
+    library = create_library_with_root(db, lib_name, f"/tmp/{prefix}-lib")
     series = Series(name=series_name, library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
     return library, series, volume
 
 
 def _create_comic(db, *, volume_id: int, prefix: str, number: str, year: int, age_rating=None, title=None):
-    comic = Comic(
-        volume_id=volume_id,
+    volume = db.get(Volume, volume_id)
+    root = volume.series.library.active_root
+    comic = create_comic(
+        db,
+        volume,
+        root,
+        f"{prefix}-{number}.cbz",
         number=number,
         year=year,
         title=title or f"{prefix}-{number}",
         filename=f"{prefix}-{number}.cbz",
-        file_path=f"/tmp/{prefix}-{number}.cbz",
         page_count=20,
         file_size=100,
         age_rating=age_rating,
     )
-    db.add(comic)
-    db.flush()
     return comic
 
 

--- a/tests/api/test_reports.py
+++ b/tests/api/test_reports.py
@@ -1,71 +1,49 @@
-from app.models.comic import Comic, Volume
-from app.models.library import Library
+from app.models.comic import Volume
 from app.models.series import Series
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_library_series_volume(db, *, lib_name: str, series_name: str, volume_number: int = 1):
-    lib = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    lib = create_library_with_root(db, lib_name, f"/tmp/{lib_name}")
     series = Series(name=series_name, library=lib)
     volume = Volume(series=series, volume_number=volume_number)
-    db.add_all([lib, series, volume])
+    db.add_all([series, volume])
     db.flush()
     return lib, series, volume
 
 
 def test_missing_issues_report_detects_gaps_and_skips_standalone(admin_client, db):
-    _, _, volume_missing = _create_library_series_volume(
+    missing_lib, _, volume_missing = _create_library_series_volume(
         db,
         lib_name="reports-missing-lib",
         series_name="Reports Missing Series",
     )
+    missing_root = missing_lib.active_root
 
-    db.add_all([
-        Comic(
-            volume_id=volume_missing.id,
-            number="1",
-            filename="missing-1.cbz",
-            file_path="/tmp/reports-missing-1.cbz",
-            file_size=100,
-            page_count=20,
-            count=5,
-        ),
-        Comic(
-            volume_id=volume_missing.id,
-            number="2",
-            filename="missing-2.cbz",
-            file_path="/tmp/reports-missing-2.cbz",
-            file_size=120,
-            page_count=22,
-            count=5,
-        ),
-        Comic(
-            volume_id=volume_missing.id,
-            number="4",
-            filename="missing-4.cbz",
-            file_path="/tmp/reports-missing-4.cbz",
-            file_size=140,
-            page_count=24,
-            count=5,
-        ),
-    ])
+    create_comic(
+        db, volume_missing, missing_root, "missing-1.cbz",
+        number="1", filename="missing-1.cbz", file_size=100, page_count=20, count=5,
+    )
+    create_comic(
+        db, volume_missing, missing_root, "missing-2.cbz",
+        number="2", filename="missing-2.cbz", file_size=120, page_count=22, count=5,
+    )
+    create_comic(
+        db, volume_missing, missing_root, "missing-4.cbz",
+        number="4", filename="missing-4.cbz", file_size=140, page_count=24, count=5,
+    )
 
-    _, _, standalone_volume = _create_library_series_volume(
+    standalone_lib, _, standalone_volume = _create_library_series_volume(
         db,
         lib_name="reports-standalone-lib",
         series_name="Reports Standalone Series",
     )
+    standalone_root = standalone_lib.active_root
 
-    db.add(
-        Comic(
-            volume_id=standalone_volume.id,
-            number="1",
-            format="annual",
-            filename="standalone-annual.cbz",
-            file_path="/tmp/reports-standalone-annual.cbz",
-            file_size=200,
-            page_count=30,
-            count=1,
-        )
+    create_comic(
+        db, standalone_volume, standalone_root, "standalone-annual.cbz",
+        number="1", format="annual", filename="standalone-annual.cbz",
+        file_size=200, page_count=30, count=1,
     )
     db.commit()
 
@@ -79,43 +57,31 @@ def test_missing_issues_report_detects_gaps_and_skips_standalone(admin_client, d
 
 
 def test_storage_reports_for_libraries_and_series(admin_client, db):
-    _, series_a, volume_a = _create_library_series_volume(
+    lib_a, series_a, volume_a = _create_library_series_volume(
         db,
         lib_name="reports-storage-lib-a",
         series_name="Reports Storage Series A",
     )
-    _, series_b, volume_b = _create_library_series_volume(
+    lib_b, series_b, volume_b = _create_library_series_volume(
         db,
         lib_name="reports-storage-lib-b",
         series_name="Reports Storage Series B",
     )
+    root_a = lib_a.active_root
+    root_b = lib_b.active_root
 
-    db.add_all([
-        Comic(
-            volume_id=volume_a.id,
-            number="1",
-            filename="storage-a-1.cbz",
-            file_path="/tmp/reports-storage-a-1.cbz",
-            file_size=900,
-            page_count=20,
-        ),
-        Comic(
-            volume_id=volume_a.id,
-            number="2",
-            filename="storage-a-2.cbz",
-            file_path="/tmp/reports-storage-a-2.cbz",
-            file_size=100,
-            page_count=25,
-        ),
-        Comic(
-            volume_id=volume_b.id,
-            number="1",
-            filename="storage-b-1.cbz",
-            file_path="/tmp/reports-storage-b-1.cbz",
-            file_size=400,
-            page_count=18,
-        ),
-    ])
+    create_comic(
+        db, volume_a, root_a, "storage-a-1.cbz",
+        number="1", filename="storage-a-1.cbz", file_size=900, page_count=20,
+    )
+    create_comic(
+        db, volume_a, root_a, "storage-a-2.cbz",
+        number="2", filename="storage-a-2.cbz", file_size=100, page_count=25,
+    )
+    create_comic(
+        db, volume_b, root_b, "storage-b-1.cbz",
+        number="1", filename="storage-b-1.cbz", file_size=400, page_count=18,
+    )
     db.commit()
 
     by_library = admin_client.get("/api/reports/storage/libraries")
@@ -133,18 +99,17 @@ def test_storage_reports_for_libraries_and_series(admin_client, db):
 
 
 def test_format_report_counts_known_extensions(admin_client, db):
-    _, _, volume = _create_library_series_volume(
+    lib, _, volume = _create_library_series_volume(
         db,
         lib_name="reports-formats-lib",
         series_name="Reports Formats Series",
     )
+    root = lib.active_root
 
-    db.add_all([
-        Comic(volume_id=volume.id, number="1", filename="fmt1.cbz", file_path="/tmp/reports-fmt1.cbz"),
-        Comic(volume_id=volume.id, number="2", filename="fmt2.cbr", file_path="/tmp/reports-fmt2.cbr"),
-        Comic(volume_id=volume.id, number="3", filename="fmt3.pdf", file_path="/tmp/reports-fmt3.pdf"),
-        Comic(volume_id=volume.id, number="4", filename="fmt4.epub", file_path="/tmp/reports-fmt4.epub"),
-    ])
+    create_comic(db, volume, root, "fmt1.cbz", number="1", filename="fmt1.cbz")
+    create_comic(db, volume, root, "fmt2.cbr", number="2", filename="fmt2.cbr")
+    create_comic(db, volume, root, "fmt3.pdf", number="3", filename="fmt3.pdf")
+    create_comic(db, volume, root, "fmt4.epub", number="4", filename="fmt4.epub")
     db.commit()
 
     response = admin_client.get("/api/reports/storage/formats")
@@ -165,25 +130,17 @@ def test_metadata_health_empty_returns_perfect_score(admin_client):
 
 
 def test_metadata_health_populated_returns_issue_details(admin_client, db):
-    _, _, volume = _create_library_series_volume(
+    lib, _, volume = _create_library_series_volume(
         db,
         lib_name="reports-metadata-lib",
         series_name="Unknown Series",
     )
+    root = lib.active_root
 
-    db.add(
-        Comic(
-            volume_id=volume.id,
-            number="1",
-            title="Meta One",
-            filename="meta-1.cbz",
-            file_path="/tmp/reports-meta-1.cbz",
-            page_count=1,
-            summary="",
-            year=None,
-            publisher="",
-            web="",
-        )
+    create_comic(
+        db, volume, root, "meta-1.cbz",
+        number="1", title="Meta One", filename="meta-1.cbz", page_count=1,
+        summary="", year=None, publisher="", web="",
     )
     db.commit()
 
@@ -206,30 +163,21 @@ def test_duplicates_report_empty_and_grouped(admin_client, db):
     assert empty.status_code == 200
     assert empty.json()["total"] == 0
 
-    _, _, volume = _create_library_series_volume(
+    lib, _, volume = _create_library_series_volume(
         db,
         lib_name="reports-dupes-lib",
         series_name="Reports Dupes Series",
     )
+    root = lib.active_root
 
-    db.add_all([
-        Comic(
-            volume_id=volume.id,
-            number="10",
-            format="annual",
-            filename="dupe-a.cbz",
-            file_path="/tmp/reports-dupe-a.cbz",
-            file_size=111,
-        ),
-        Comic(
-            volume_id=volume.id,
-            number="10",
-            format="annual",
-            filename="dupe-b.cbz",
-            file_path="/tmp/reports-dupe-b.cbz",
-            file_size=222,
-        ),
-    ])
+    create_comic(
+        db, volume, root, "dupe-a.cbz",
+        number="10", format="annual", filename="dupe-a.cbz", file_size=111,
+    )
+    create_comic(
+        db, volume, root, "dupe-b.cbz",
+        number="10", format="annual", filename="dupe-b.cbz", file_size=222,
+    )
     db.commit()
 
     grouped = admin_client.get("/api/reports/duplicates?page=1&size=10")
@@ -242,50 +190,29 @@ def test_duplicates_report_empty_and_grouped(admin_client, db):
 
 
 def test_corrupt_files_report_filters_and_paginates(admin_client, db):
-    _, _, volume = _create_library_series_volume(
+    lib, _, volume = _create_library_series_volume(
         db,
         lib_name="reports-corrupt-lib",
         series_name="Reports Corrupt Series",
     )
+    root = lib.active_root
 
-    db.add_all([
-        Comic(
-            volume_id=volume.id,
-            number="1",
-            title="Corrupt One",
-            filename="corrupt-1.cbz",
-            file_path="/tmp/reports-corrupt-1.cbz",
-            file_size=10,
-            page_count=1,
-        ),
-        Comic(
-            volume_id=volume.id,
-            number="2",
-            title="Corrupt Two",
-            filename="corrupt-2.cbz",
-            file_path="/tmp/reports-corrupt-2.cbz",
-            file_size=20,
-            page_count=2,
-        ),
-        Comic(
-            volume_id=volume.id,
-            number="3",
-            title="Healthy Three",
-            filename="healthy-3.cbz",
-            file_path="/tmp/reports-healthy-3.cbz",
-            file_size=30,
-            page_count=3,
-        ),
-        Comic(
-            volume_id=volume.id,
-            number="4",
-            title="Unscanned Four",
-            filename="unscanned-4.cbz",
-            file_path="/tmp/reports-unscanned-4.cbz",
-            file_size=40,
-            page_count=0,
-        ),
-    ])
+    create_comic(
+        db, volume, root, "corrupt-1.cbz",
+        number="1", title="Corrupt One", filename="corrupt-1.cbz", file_size=10, page_count=1,
+    )
+    create_comic(
+        db, volume, root, "corrupt-2.cbz",
+        number="2", title="Corrupt Two", filename="corrupt-2.cbz", file_size=20, page_count=2,
+    )
+    create_comic(
+        db, volume, root, "healthy-3.cbz",
+        number="3", title="Healthy Three", filename="healthy-3.cbz", file_size=30, page_count=3,
+    )
+    create_comic(
+        db, volume, root, "unscanned-4.cbz",
+        number="4", title="Unscanned Four", filename="unscanned-4.cbz", file_size=40, page_count=0,
+    )
     db.commit()
 
     response = admin_client.get("/api/reports/corrupt?page=1&size=1")

--- a/tests/api/test_search_api.py
+++ b/tests/api/test_search_api.py
@@ -1,20 +1,20 @@
 from app.api.search import _get_allowed_library_ids
 from app.models.collection import Collection, CollectionItem
-from app.models.comic import Comic, Volume
+from app.models.comic import Volume
 from app.models.credits import ComicCredit, Person
-from app.models.library import Library
 from app.models.pull_list import PullList, PullListItem
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.series import Series
 from app.models.tags import Character, Location, Team
 from app.models.user import User
+from tests.factories import create_comic, create_library_with_root
 
 
 def _seed_search_fixture(db, normal_user):
-    visible_lib = Library(name="FindMe Visible Library", path="/tmp/findme-visible")
-    hidden_lib = Library(name="FindMe Hidden Library", path="/tmp/findme-hidden")
-    db.add_all([visible_lib, hidden_lib])
-    db.flush()
+    visible_lib = create_library_with_root(db, "FindMe Visible Library", "/tmp/findme-visible")
+    hidden_lib = create_library_with_root(db, "FindMe Hidden Library", "/tmp/findme-hidden")
+    visible_root = visible_lib.active_root
+    hidden_root = hidden_lib.active_root
 
     safe_series = Series(name="FindMe Safe Series", library_id=visible_lib.id)
     poisoned_series = Series(name="FindMe Banned Series", library_id=visible_lib.id)
@@ -28,8 +28,8 @@ def _seed_search_fixture(db, normal_user):
     db.add_all([safe_vol, poisoned_vol, hidden_vol])
     db.flush()
 
-    safe1 = Comic(
-        volume_id=safe_vol.id,
+    safe1 = create_comic(
+        db, safe_vol, visible_root, "findme-safe-1.cbz",
         number="1",
         title="FindMe Safe #1",
         publisher="FindMe Publisher",
@@ -38,10 +38,9 @@ def _seed_search_fixture(db, normal_user):
         age_rating="Teen",
         language_iso="en",
         filename="findme-safe-1.cbz",
-        file_path="/tmp/findme-safe-1.cbz",
     )
-    safe2 = Comic(
-        volume_id=safe_vol.id,
+    safe2 = create_comic(
+        db, safe_vol, visible_root, "findme-safe-2.cbz",
         number="2",
         title="FindMe Safe #2",
         publisher="FindMe Publisher",
@@ -50,10 +49,9 @@ def _seed_search_fixture(db, normal_user):
         age_rating="Teen",
         language_iso="en",
         filename="findme-safe-2.cbz",
-        file_path="/tmp/findme-safe-2.cbz",
     )
-    banned = Comic(
-        volume_id=poisoned_vol.id,
+    banned = create_comic(
+        db, poisoned_vol, visible_root, "findme-banned.cbz",
         number="1",
         title="FindMe Banned",
         publisher="FindMe Banned Publisher",
@@ -62,10 +60,9 @@ def _seed_search_fixture(db, normal_user):
         age_rating="Mature 17+",
         language_iso="jp",
         filename="findme-banned.cbz",
-        file_path="/tmp/findme-banned.cbz",
     )
-    hidden = Comic(
-        volume_id=hidden_vol.id,
+    hidden = create_comic(
+        db, hidden_vol, hidden_root, "findme-hidden.cbz",
         number="1",
         title="FindMe Hidden",
         publisher="FindMe Hidden Publisher",
@@ -74,10 +71,7 @@ def _seed_search_fixture(db, normal_user):
         age_rating="Teen",
         language_iso="fr",
         filename="findme-hidden.cbz",
-        file_path="/tmp/findme-hidden.cbz",
     )
-    db.add_all([safe1, safe2, banned, hidden])
-    db.flush()
 
     safe_character = Character(name="FindMe Hero")
     banned_character = Character(name="FindMe Villain")
@@ -179,9 +173,7 @@ def _seed_search_fixture(db, normal_user):
 
 
 def test_get_allowed_library_ids_helper(db, normal_user, admin_user):
-    lib = Library(name="search-helper-lib", path="/tmp/search-helper")
-    db.add(lib)
-    db.flush()
+    lib = create_library_with_root(db, "search-helper-lib", "/tmp/search-helper")
 
     normal_user.accessible_libraries.append(lib)
     db.commit()

--- a/tests/api/test_series.py
+++ b/tests/api/test_series.py
@@ -4,55 +4,52 @@ from app.models.collection import Collection, CollectionItem
 from app.models.comic import Comic, Volume
 from app.models.credits import ComicCredit, Person
 from app.models.interactions import UserSeries
-from app.models.library import Library
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.tags import Character, Location, Team
 from app.models.user import User
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_series_with_volume(db, *, lib_name: str, series_name: str):
-    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    library = create_library_with_root(db, lib_name, f"/tmp/{lib_name}")
+    root = library.active_root
     series = Series(name=series_name, library=library)
     volume = Volume(series=series, volume_number=1)
 
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
     comics = [
-        Comic(
-            volume_id=volume.id,
+        create_comic(
+            db, volume, root, f"{series_name}-1.cbz",
             number="1",
             title=f"{series_name} #1",
             year=2020,
             filename=f"{series_name}-1.cbz",
-            file_path=f"/tmp/{series_name}-1-{lib_name}.cbz",
             page_count=24,
         ),
-        Comic(
-            volume_id=volume.id,
+        create_comic(
+            db, volume, root, f"{series_name}-2.cbz",
             number="2",
             title=f"{series_name} Annual",
             year=2021,
             format="annual",
             filename=f"{series_name}-2.cbz",
-            file_path=f"/tmp/{series_name}-2-{lib_name}.cbz",
             page_count=30,
         ),
-        Comic(
-            volume_id=volume.id,
+        create_comic(
+            db, volume, root, f"{series_name}-3.cbz",
             number="3",
             title=f"{series_name} Special",
             year=2022,
             format="one-shot",
             filename=f"{series_name}-3.cbz",
-            file_path=f"/tmp/{series_name}-3-{lib_name}.cbz",
             page_count=20,
         ),
     ]
 
-    db.add_all(comics)
     db.commit()
 
     db.refresh(library)
@@ -70,15 +67,16 @@ def _create_series_with_volume(db, *, lib_name: str, series_name: str):
 
 
 def _create_series_detail_fixture(db):
-    library = Library(name="series-detail-lib", path="/tmp/series-detail-lib")
+    library = create_library_with_root(db, "series-detail-lib", "/tmp/series-detail-lib")
+    root = library.active_root
     series = Series(name="Countdown", library=library, summary_override="Series override summary")
     vol1 = Volume(series=series, volume_number=1)
     vol2 = Volume(series=series, volume_number=2)
-    db.add_all([library, series, vol1, vol2])
+    db.add_all([series, vol1, vol2])
     db.flush()
 
-    issue_one = Comic(
-        volume_id=vol1.id,
+    issue_one = create_comic(
+        db, vol1, root, "countdown-1.cbz",
         number="1",
         title="Countdown #1",
         year=2000,
@@ -88,10 +86,9 @@ def _create_series_detail_fixture(db):
         publisher="Series Pub",
         imprint="Series Imprint",
         filename="countdown-1.cbz",
-        file_path="/tmp/series-countdown-1.cbz",
     )
-    issue_four = Comic(
-        volume_id=vol1.id,
+    issue_four = create_comic(
+        db, vol1, root, "countdown-4.cbz",
         number="4",
         title="Countdown #4",
         year=2000,
@@ -102,10 +99,9 @@ def _create_series_detail_fixture(db):
         publisher="Series Pub",
         imprint="Series Imprint",
         filename="countdown-4.cbz",
-        file_path="/tmp/series-countdown-4.cbz",
     )
-    issue_two = Comic(
-        volume_id=vol2.id,
+    issue_two = create_comic(
+        db, vol2, root, "countdown-2.cbz",
         number="2",
         title="Countdown #2",
         year=2000,
@@ -115,10 +111,9 @@ def _create_series_detail_fixture(db):
         publisher="Series Pub",
         imprint="Series Imprint",
         filename="countdown-2.cbz",
-        file_path="/tmp/series-countdown-2.cbz",
     )
-    annual = Comic(
-        volume_id=vol2.id,
+    annual = create_comic(
+        db, vol2, root, "countdown-annual.cbz",
         number="1",
         title="Countdown Annual",
         year=2001,
@@ -129,10 +124,7 @@ def _create_series_detail_fixture(db):
         publisher="Series Pub",
         imprint="Series Imprint",
         filename="countdown-annual.cbz",
-        file_path="/tmp/series-countdown-annual.cbz",
     )
-    db.add_all([issue_one, issue_four, issue_two, annual])
-    db.flush()
 
     writer = Person(name="Series Writer")
     penciller = Person(name="Series Penciller")
@@ -475,9 +467,9 @@ def test_series_detail_hides_story_arcs_and_related_containers_when_parsing_disa
 
 
 def test_series_detail_returns_empty_structure_when_no_volumes(auth_client, db, normal_user):
-    library = Library(name="empty-series-lib", path="/tmp/empty-series-lib")
+    library = create_library_with_root(db, "empty-series-lib", "/tmp/empty-series-lib")
     series = Series(name="Empty Series", library=library)
-    db.add_all([library, series])
+    db.add_all([series])
     db.commit()
 
     normal_user.accessible_libraries.append(library)
@@ -496,21 +488,19 @@ def test_series_detail_returns_empty_structure_when_no_volumes(auth_client, db, 
 
 
 def test_series_detail_blocks_age_restricted_content(auth_client, db, normal_user):
-    library = Library(name="restricted-series-lib", path="/tmp/restricted-series-lib")
+    library = create_library_with_root(db, "restricted-series-lib", "/tmp/restricted-series-lib")
+    root = library.active_root
     series = Series(name="Restricted Series", library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    db.add(
-        Comic(
-            volume_id=volume.id,
-            number="1",
-            title="Restricted Comic",
-            age_rating="Mature 17+",
-            filename="restricted-series.cbz",
-            file_path="/tmp/restricted-series.cbz",
-        )
+    create_comic(
+        db, volume, root, "restricted-series.cbz",
+        number="1",
+        title="Restricted Comic",
+        age_rating="Mature 17+",
+        filename="restricted-series.cbz",
     )
 
     normal_user.accessible_libraries.append(library)
@@ -551,32 +541,29 @@ def test_series_recommendations_returns_empty_when_series_missing(auth_client):
 
 
 def test_series_recommendations_includes_group_lane(auth_client, db, normal_user):
-    library = Library(name="rec-lib", path="/tmp/rec-lib")
+    library = create_library_with_root(db, "rec-lib", "/tmp/rec-lib")
+    root = library.active_root
     source = Series(name="Source Series", library=library)
     other = Series(name="Other Series", library=library)
     source_vol = Volume(series=source, volume_number=1)
     other_vol = Volume(series=other, volume_number=1)
-    db.add_all([library, source, other, source_vol, other_vol])
+    db.add_all([source, other, source_vol, other_vol])
     db.flush()
 
-    db.add_all([
-        Comic(
-            volume_id=source_vol.id,
-            number="1",
-            title="Source #1",
-            series_group="Shared Verse",
-            filename="source-1.cbz",
-            file_path="/tmp/source-1.cbz",
-        ),
-        Comic(
-            volume_id=other_vol.id,
-            number="1",
-            title="Other #1",
-            series_group="Shared Verse",
-            filename="other-1.cbz",
-            file_path="/tmp/other-1.cbz",
-        ),
-    ])
+    create_comic(
+        db, source_vol, root, "source-1.cbz",
+        number="1",
+        title="Source #1",
+        series_group="Shared Verse",
+        filename="source-1.cbz",
+    )
+    create_comic(
+        db, other_vol, root, "other-1.cbz",
+        number="1",
+        title="Other #1",
+        series_group="Shared Verse",
+        filename="other-1.cbz",
+    )
 
     normal_user.accessible_libraries.append(library)
     db.commit()
@@ -607,6 +594,7 @@ def _create_single_issue_series(
     writer=None,
     penciller=None,
 ):
+    root = library.active_root
     series = Series(name=name, library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -618,7 +606,8 @@ def _create_single_issue_series(
         series_group=series_group,
         publisher=publisher,
         filename=f"{name}-{number}.cbz",
-        file_path=f"/tmp/{name}-{number}.cbz",
+        library_root_id=root.id,
+        relative_path=f"{name}-{number}.cbz",
     )
 
     db.add_all([series, volume, comic])
@@ -638,29 +627,27 @@ def _create_single_issue_series(
 
 
 def test_series_list_fallback_cover_handles_non_numeric_issue_numbers(auth_client, db, normal_user):
-    library = Library(name="series-fallback-list-lib", path="/tmp/series-fallback-list-lib")
+    library = create_library_with_root(db, "series-fallback-list-lib", "/tmp/series-fallback-list-lib")
+    root = library.active_root
     series = Series(name="Fallback Sort Series", library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    comic_alpha = Comic(
-        volume_id=volume.id,
+    comic_alpha = create_comic(
+        db, volume, root, "fallback-a.cbz",
         number="A",
         title="Fallback A",
         year=2025,
         filename="fallback-a.cbz",
-        file_path="/tmp/fallback-a.cbz",
     )
-    comic_two = Comic(
-        volume_id=volume.id,
+    comic_two = create_comic(
+        db, volume, root, "fallback-2.cbz",
         number="2",
         title="Fallback 2",
         year=2024,
         filename="fallback-2.cbz",
-        file_path="/tmp/fallback-2.cbz",
     )
-    db.add_all([comic_alpha, comic_two])
 
     normal_user.accessible_libraries.append(library)
     db.commit()
@@ -675,46 +662,42 @@ def test_series_list_fallback_cover_handles_non_numeric_issue_numbers(auth_clien
 
 
 def test_series_detail_non_reverse_cover_logic_and_resume_default(auth_client, db, normal_user):
-    library = Library(name="series-detail-cover-lib", path="/tmp/series-detail-cover-lib")
+    library = create_library_with_root(db, "series-detail-cover-lib", "/tmp/series-detail-cover-lib")
+    root = library.active_root
     series = Series(name="Alpha Line", library=library)
     vol1 = Volume(series=series, volume_number=1)
     vol2 = Volume(series=series, volume_number=2)
-    db.add_all([library, series, vol1, vol2])
+    db.add_all([series, vol1, vol2])
     db.flush()
 
-    v1_issue_alpha = Comic(
-        volume_id=vol1.id,
+    v1_issue_alpha = create_comic(
+        db, vol1, root, "v1-a.cbz",
         number="A",
         title="Vol1 A",
         year=2026,
         filename="v1-a.cbz",
-        file_path="/tmp/v1-a.cbz",
     )
-    v1_issue_two = Comic(
-        volume_id=vol1.id,
+    v1_issue_two = create_comic(
+        db, vol1, root, "v1-2.cbz",
         number="2",
         title="Vol1 #2",
         year=2025,
         filename="v1-2.cbz",
-        file_path="/tmp/v1-2.cbz",
     )
-    v2_issue_one = Comic(
-        volume_id=vol2.id,
+    v2_issue_one = create_comic(
+        db, vol2, root, "v2-1.cbz",
         number="1",
         title="Vol2 #1",
         year=2024,
         filename="v2-1.cbz",
-        file_path="/tmp/v2-1.cbz",
     )
-    v2_issue_three = Comic(
-        volume_id=vol2.id,
+    v2_issue_three = create_comic(
+        db, vol2, root, "v2-3.cbz",
         number="3",
         title="Vol2 #3",
         year=2027,
         filename="v2-3.cbz",
-        file_path="/tmp/v2-3.cbz",
     )
-    db.add_all([v1_issue_alpha, v1_issue_two, v2_issue_one, v2_issue_three])
 
     normal_user.accessible_libraries.append(library)
     db.commit()
@@ -732,34 +715,31 @@ def test_series_detail_non_reverse_cover_logic_and_resume_default(auth_client, d
 
 
 def test_series_detail_advances_to_next_issue_when_latest_progress_is_completed(auth_client, db, normal_user):
-    library = Library(name="series-detail-next-lib", path="/tmp/series-detail-next-lib")
+    library = create_library_with_root(db, "series-detail-next-lib", "/tmp/series-detail-next-lib")
+    root = library.active_root
     series = Series(name="Series Next Logic", library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    issue_one = Comic(
-        volume_id=volume.id,
+    issue_one = create_comic(
+        db, volume, root, "series-next-1.cbz",
         number="1",
         title="Series Next #1",
         filename="series-next-1.cbz",
-        file_path="/tmp/series-next-1.cbz",
     )
-    issue_two = Comic(
-        volume_id=volume.id,
+    issue_two = create_comic(
+        db, volume, root, "series-next-2.cbz",
         number="2",
         title="Series Next #2",
         filename="series-next-2.cbz",
-        file_path="/tmp/series-next-2.cbz",
     )
-    issue_three = Comic(
-        volume_id=volume.id,
+    issue_three = create_comic(
+        db, volume, root, "series-next-3.cbz",
         number="3",
         title="Series Next #3",
         filename="series-next-3.cbz",
-        file_path="/tmp/series-next-3.cbz",
     )
-    db.add_all([issue_one, issue_two, issue_three])
 
     normal_user.accessible_libraries.append(library)
     db.flush()
@@ -792,7 +772,8 @@ def test_series_detail_advances_to_next_issue_when_latest_progress_is_completed(
 
 
 def test_series_detail_filters_related_containers_with_banned_content(auth_client, db, normal_user):
-    library = Library(name="series-detail-ban-lib", path="/tmp/series-detail-ban-lib")
+    library = create_library_with_root(db, "series-detail-ban-lib", "/tmp/series-detail-ban-lib")
+    root = library.active_root
 
     safe_series = Series(name="Safe Detail Series", library=library)
     safe_volume = Volume(series=safe_series, volume_number=1)
@@ -802,7 +783,8 @@ def test_series_detail_filters_related_containers_with_banned_content(auth_clien
         title="Safe Detail",
         age_rating="Teen",
         filename="safe-detail.cbz",
-        file_path="/tmp/safe-detail.cbz",
+        library_root_id=root.id,
+        relative_path="safe-detail.cbz",
     )
 
     banned_series = Series(name="Banned Detail Series", library=library)
@@ -813,14 +795,14 @@ def test_series_detail_filters_related_containers_with_banned_content(auth_clien
         title="Banned Detail",
         age_rating="Mature 17+",
         filename="banned-detail.cbz",
-        file_path="/tmp/banned-detail.cbz",
+        library_root_id=root.id,
+        relative_path="banned-detail.cbz",
     )
 
     collection = Collection(name="Mixed Collection")
     reading_list = ReadingList(name="Mixed Reading List")
 
     db.add_all([
-        library,
         safe_series,
         safe_volume,
         safe_comic,
@@ -853,33 +835,30 @@ def test_series_detail_filters_related_containers_with_banned_content(auth_clien
 
 
 def test_series_list_applies_age_filter_and_created_sort(auth_client, db, normal_user):
-    library = Library(name="series-list-age-lib", path="/tmp/series-list-age-lib")
+    library = create_library_with_root(db, "series-list-age-lib", "/tmp/series-list-age-lib")
+    root = library.active_root
 
     safe_series = Series(name="Safe Created Series", library=library)
     banned_series = Series(name="Banned Created Series", library=library)
     safe_volume = Volume(series=safe_series, volume_number=1)
     banned_volume = Volume(series=banned_series, volume_number=1)
-    db.add_all([library, safe_series, banned_series, safe_volume, banned_volume])
+    db.add_all([safe_series, banned_series, safe_volume, banned_volume])
     db.flush()
 
-    db.add_all([
-        Comic(
-            volume_id=safe_volume.id,
-            number="1",
-            title="Safe Created",
-            age_rating="Teen",
-            filename="safe-created.cbz",
-            file_path="/tmp/safe-created.cbz",
-        ),
-        Comic(
-            volume_id=banned_volume.id,
-            number="1",
-            title="Banned Created",
-            age_rating="Mature 17+",
-            filename="banned-created.cbz",
-            file_path="/tmp/banned-created.cbz",
-        ),
-    ])
+    create_comic(
+        db, safe_volume, root, "safe-created.cbz",
+        number="1",
+        title="Safe Created",
+        age_rating="Teen",
+        filename="safe-created.cbz",
+    )
+    create_comic(
+        db, banned_volume, root, "banned-created.cbz",
+        number="1",
+        title="Banned Created",
+        age_rating="Mature 17+",
+        filename="banned-created.cbz",
+    )
 
     safe_series.created_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
     banned_series.created_at = datetime(2021, 1, 1, tzinfo=timezone.utc)
@@ -904,9 +883,9 @@ def test_series_thumbnails_404_when_series_missing(admin_client):
 
 
 def test_series_thumbnails_background_task_handles_errors(admin_client, db, monkeypatch):
-    library = Library(name="series-thumb-lib", path="/tmp/series-thumb-lib")
+    library = create_library_with_root(db, "series-thumb-lib", "/tmp/series-thumb-lib")
     series = Series(name="Series Thumbs", library=library)
-    db.add_all([library, series])
+    db.add_all([series])
     db.commit()
 
     called = {"value": False}
@@ -929,46 +908,41 @@ def test_series_issues_sort_order_none_uses_reverse_numbering_rule(db, normal_us
     from app.api.deps import PaginationParams
     from app.api.series import get_series_issues
 
-    library = Library(name="series-issues-none-lib", path="/tmp/series-issues-none-lib")
+    library = create_library_with_root(db, "series-issues-none-lib", "/tmp/series-issues-none-lib")
+    root = library.active_root
     reverse_series = Series(name="Countdown", library=library)
     reverse_volume = Volume(series=reverse_series, volume_number=1)
 
     normal_series = Series(name="Regular Sort Series", library=library)
     normal_volume = Volume(series=normal_series, volume_number=1)
 
-    db.add_all([library, reverse_series, reverse_volume, normal_series, normal_volume])
+    db.add_all([reverse_series, reverse_volume, normal_series, normal_volume])
     db.flush()
 
-    db.add_all([
-        Comic(
-            volume_id=reverse_volume.id,
-            number="1",
-            title="Reverse #1",
-            filename="reverse-1.cbz",
-            file_path="/tmp/reverse-1.cbz",
-        ),
-        Comic(
-            volume_id=reverse_volume.id,
-            number="2",
-            title="Reverse #2",
-            filename="reverse-2.cbz",
-            file_path="/tmp/reverse-2.cbz",
-        ),
-        Comic(
-            volume_id=normal_volume.id,
-            number="1",
-            title="Regular #1",
-            filename="regular-1.cbz",
-            file_path="/tmp/regular-1.cbz",
-        ),
-        Comic(
-            volume_id=normal_volume.id,
-            number="2",
-            title="Regular #2",
-            filename="regular-2.cbz",
-            file_path="/tmp/regular-2.cbz",
-        ),
-    ])
+    create_comic(
+        db, reverse_volume, root, "reverse-1.cbz",
+        number="1",
+        title="Reverse #1",
+        filename="reverse-1.cbz",
+    )
+    create_comic(
+        db, reverse_volume, root, "reverse-2.cbz",
+        number="2",
+        title="Reverse #2",
+        filename="reverse-2.cbz",
+    )
+    create_comic(
+        db, normal_volume, root, "regular-1.cbz",
+        number="1",
+        title="Regular #1",
+        filename="regular-1.cbz",
+    )
+    create_comic(
+        db, normal_volume, root, "regular-2.cbz",
+        number="2",
+        title="Regular #2",
+        filename="regular-2.cbz",
+    )
     db.commit()
 
     params = PaginationParams(page=1, size=20)
@@ -1001,9 +975,9 @@ def test_series_issues_sort_order_none_uses_reverse_numbering_rule(db, normal_us
 
 
 def test_series_recommendations_writer_lane(auth_client, db, normal_user):
-    library = Library(name="series-rec-writer-lib", path="/tmp/series-rec-writer-lib")
+    library = create_library_with_root(db, "series-rec-writer-lib", "/tmp/series-rec-writer-lib")
     writer = Person(name="Writer Lane")
-    db.add_all([library, writer])
+    db.add_all([writer])
     db.flush()
 
     source = _create_single_issue_series(db, library, name="Writer Source", writer=writer)
@@ -1025,9 +999,9 @@ def test_series_recommendations_writer_lane(auth_client, db, normal_user):
 
 
 def test_series_recommendations_penciller_lane(auth_client, db, normal_user):
-    library = Library(name="series-rec-pencil-lib", path="/tmp/series-rec-pencil-lib")
+    library = create_library_with_root(db, "series-rec-pencil-lib", "/tmp/series-rec-pencil-lib")
     penciller = Person(name="Penciller Lane")
-    db.add_all([library, penciller])
+    db.add_all([penciller])
     db.flush()
 
     source = _create_single_issue_series(db, library, name="Penciller Source", penciller=penciller)
@@ -1051,9 +1025,9 @@ def test_series_recommendations_penciller_lane(auth_client, db, normal_user):
 def test_series_recommendations_genre_lane(auth_client, db, normal_user):
     from app.models.tags import Genre
 
-    library = Library(name="series-rec-genre-lib", path="/tmp/series-rec-genre-lib")
+    library = create_library_with_root(db, "series-rec-genre-lib", "/tmp/series-rec-genre-lib")
     genre = Genre(name="Mystery")
-    db.add_all([library, genre])
+    db.add_all([genre])
     db.flush()
 
     source = _create_single_issue_series(db, library, name="Genre Source", genre=genre)
@@ -1075,7 +1049,7 @@ def test_series_recommendations_genre_lane(auth_client, db, normal_user):
 
 
 def test_series_recommendations_publisher_lane(auth_client, db, normal_user):
-    library = Library(name="series-rec-publisher-lib", path="/tmp/series-rec-publisher-lib")
+    library = create_library_with_root(db, "series-rec-publisher-lib", "/tmp/series-rec-publisher-lib")
     source = _create_single_issue_series(db, library, name="Publisher Source", publisher="Pub Lane")
     match_ids = []
     for i in range(5):
@@ -1095,9 +1069,7 @@ def test_series_recommendations_publisher_lane(auth_client, db, normal_user):
 
 
 def test_series_recommendations_apply_age_filter_for_restricted_user(auth_client, db, normal_user):
-    library = Library(name="series-rec-age-lib", path="/tmp/series-rec-age-lib")
-    db.add(library)
-    db.flush()
+    library = create_library_with_root(db, "series-rec-age-lib", "/tmp/series-rec-age-lib")
 
     source = _create_single_issue_series(
         db,
@@ -1138,29 +1110,27 @@ def test_series_recommendations_apply_age_filter_for_restricted_user(auth_client
 
 
 def test_series_list_reverse_numbering_fallback_uses_highest_issue(auth_client, db, normal_user):
-    library = Library(name="series-reverse-list-lib", path="/tmp/series-reverse-list-lib")
+    library = create_library_with_root(db, "series-reverse-list-lib", "/tmp/series-reverse-list-lib")
+    root = library.active_root
     series = Series(name="Countdown", library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    issue_two = Comic(
-        volume_id=volume.id,
+    issue_two = create_comic(
+        db, volume, root, "countdown-2.cbz",
         number="2",
         title="Countdown #2",
         year=2008,
         filename="countdown-2.cbz",
-        file_path="/tmp/countdown-2.cbz",
     )
-    issue_four = Comic(
-        volume_id=volume.id,
+    issue_four = create_comic(
+        db, volume, root, "countdown-4.cbz",
         number="4",
         title="Countdown #4",
         year=2007,
         filename="countdown-4.cbz",
-        file_path="/tmp/countdown-4.cbz",
     )
-    db.add_all([issue_two, issue_four])
 
     normal_user.accessible_libraries.append(library)
     db.commit()

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -1,17 +1,17 @@
 from app.core.security import get_password_hash
-from app.models.comic import Comic, Volume
-from app.models.library import Library
+from app.models.comic import Volume
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.tags import Genre
 from app.models.user import User
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_series_volume(db, *, prefix: str, series_suffix: str):
-    library = Library(name=f"{prefix}-lib", path=f"/tmp/{prefix}-lib")
+    library = create_library_with_root(db, f"{prefix}-lib", f"/tmp/{prefix}-lib")
     series = Series(name=f"{prefix}-series-{series_suffix}", library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
     return library, series, volume
 
@@ -81,19 +81,18 @@ def test_startup_support_snapshot_endpoint_returns_structured_snapshot(admin_cli
 
 
 def test_system_stats_aggregates_counts_storage_and_activity(admin_client, db, admin_user):
-    lib = Library(name="stats-lib", path="/tmp/stats-lib")
+    lib = create_library_with_root(db, "stats-lib", "/tmp/stats-lib")
+    root = lib.active_root
     series_a = Series(name="stats-series-a", library=lib)
     series_b = Series(name="stats-series-b", library=lib)
     vol_a = Volume(series=series_a, volume_number=1)
     vol_b = Volume(series=series_b, volume_number=1)
-    db.add_all([lib, series_a, series_b, vol_a, vol_b])
+    db.add_all([series_a, series_b, vol_a, vol_b])
     db.flush()
 
-    c1 = Comic(volume_id=vol_a.id, number="1", filename="stats-1.cbz", file_path="/tmp/stats-1.cbz", file_size=100, page_count=10)
-    c2 = Comic(volume_id=vol_a.id, number="2", filename="stats-2.cbz", file_path="/tmp/stats-2.cbz", file_size=200, page_count=12)
-    c3 = Comic(volume_id=vol_b.id, number="1", filename="stats-3.cbz", file_path="/tmp/stats-3.cbz", file_size=300, page_count=14)
-    db.add_all([c1, c2, c3])
-    db.flush()
+    c1 = create_comic(db, vol_a, root, "stats-1.cbz", number="1", filename="stats-1.cbz", file_size=100, page_count=10)
+    c2 = create_comic(db, vol_a, root, "stats-2.cbz", number="2", filename="stats-2.cbz", file_size=200, page_count=12)
+    c3 = create_comic(db, vol_b, root, "stats-3.cbz", number="1", filename="stats-3.cbz", file_size=300, page_count=14)
 
     other_user = User(
         username="stats-other",
@@ -128,15 +127,16 @@ def test_system_stats_aggregates_counts_storage_and_activity(admin_client, db, a
 
 
 def test_genre_stats_aggregate_inventory_read_percent_and_size(admin_client, db, admin_user):
-    lib = Library(name="stats-genre-lib", path="/tmp/stats-genre-lib")
+    lib = create_library_with_root(db, "stats-genre-lib", "/tmp/stats-genre-lib")
+    root = lib.active_root
     series = Series(name="stats-genre-series", library=lib)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([lib, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    c1 = Comic(volume_id=volume.id, number="1", filename="genre-1.cbz", file_path="/tmp/genre-1.cbz", file_size=100, page_count=10)
-    c2 = Comic(volume_id=volume.id, number="2", filename="genre-2.cbz", file_path="/tmp/genre-2.cbz", file_size=250, page_count=12)
-    c3 = Comic(volume_id=volume.id, number="3", filename="genre-3.cbz", file_path="/tmp/genre-3.cbz", file_size=400, page_count=14)
+    c1 = create_comic(db, volume, root, "genre-1.cbz", number="1", filename="genre-1.cbz", file_size=100, page_count=10)
+    c2 = create_comic(db, volume, root, "genre-2.cbz", number="2", filename="genre-2.cbz", file_size=250, page_count=12)
+    c3 = create_comic(db, volume, root, "genre-3.cbz", number="3", filename="genre-3.cbz", file_size=400, page_count=14)
 
     action = Genre(name="Action")
     sci_fi = Genre(name="Sci-Fi")

--- a/tests/api/test_tasks.py
+++ b/tests/api/test_tasks.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from app.models.library import Library
+from tests.factories import create_library_with_root
 
 
 def test_cleanup_task_queues_job(admin_client):
@@ -34,10 +34,8 @@ def test_refresh_descriptions_task_returns_stats(admin_client):
 
 
 def test_refresh_colorscapes_counts_only_queued_libraries(admin_client, db):
-    db.add_all([
-        Library(name="Colors-1", path="/tmp/colors-1"),
-        Library(name="Colors-2", path="/tmp/colors-2"),
-    ])
+    create_library_with_root(db, "Colors-1", "/tmp/colors-1")
+    create_library_with_root(db, "Colors-2", "/tmp/colors-2")
     db.commit()
 
     with patch("app.api.tasks.scan_manager.add_thumbnail_task", side_effect=[{"status": "queued"}, {"status": "skipped"}]):

--- a/tests/api/test_timelines.py
+++ b/tests/api/test_timelines.py
@@ -1,9 +1,9 @@
 from app.models.collection import Collection, CollectionItem
 from app.models.comic import Comic, Volume
-from app.models.library import Library
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.series import Series
 from app.models.tags import Character, Team
+from tests.factories import create_library_with_root
 
 
 def _comic(
@@ -19,6 +19,7 @@ def _comic(
     age_rating: str | None = None,
 ) -> Comic:
     slug = title.lower().replace(" ", "-").replace("#", "")
+    root = volume.series.library.active_root
     return Comic(
         volume=volume,
         number=number,
@@ -30,16 +31,15 @@ def _comic(
         series_group=series_group,
         age_rating=age_rating,
         filename=f"{slug}.cbz",
-        file_path=f"/tmp/{slug}.cbz",
+        library_root_id=root.id,
+        relative_path=f"{slug}.cbz",
         page_count=22,
     )
 
 
 def _seed_timeline_fixture(db, normal_user):
-    library = Library(name="Timeline Library", path="/tmp/timeline-library")
-    hidden_library = Library(name="Hidden Timeline Library", path="/tmp/hidden-timeline-library")
-    db.add_all([library, hidden_library])
-    db.flush()
+    library = create_library_with_root(db, "Timeline Library", "/tmp/timeline-library")
+    hidden_library = create_library_with_root(db, "Hidden Timeline Library", "/tmp/hidden-timeline-library")
 
     action = Series(name="Action Timeline", library=library)
     adventures = Series(name="Adventures Timeline", library=library)

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -6,15 +6,16 @@ from app.api.users import MAX_AVATAR_SIZE_BYTES, get_stats_service
 from app.core.security import get_password_hash, verify_password
 from app.main import app
 from app.models.comic import Comic, Volume
-from app.models.library import Library
 from app.models.pull_list import PullList, PullListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.user import User
+from tests.factories import create_library_with_root
 
 
 def _seed_user_activity(db, user):
-    library = Library(name="Dash Library", path="/tmp/dash-lib")
+    library = create_library_with_root(db, "Dash Library", "/tmp/dash-lib")
+    root = library.active_root
     series = Series(name="Dashboard Series", library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -22,12 +23,13 @@ def _seed_user_activity(db, user):
         number="1",
         title="Dashboard Issue",
         filename="dashboard.cbz",
-        file_path="/tmp/dashboard.cbz",
+        library_root_id=root.id,
+        relative_path="dashboard.cbz",
         page_count=10,
     )
     pull_list = PullList(user_id=user.id, name="Weekly Pulls")
 
-    db.add_all([library, series, volume, comic, pull_list])
+    db.add_all([series, volume, comic, pull_list])
     db.flush()
 
     pull_item = PullListItem(pull_list_id=pull_list.id, comic_id=comic.id, sort_order=0)
@@ -126,8 +128,7 @@ def test_year_in_review_uses_default_and_explicit_year(auth_client):
 
 
 def test_admin_create_user_and_duplicate_username(admin_client, db):
-    lib = Library(name="Create User Library", path="/tmp/create-user-lib")
-    db.add(lib)
+    lib = create_library_with_root(db, "Create User Library", "/tmp/create-user-lib")
     db.commit()
 
     create_response = admin_client.post(
@@ -181,7 +182,7 @@ def test_admin_create_user_rejects_empty_fields(admin_client):
 
 
 def test_admin_list_users_includes_library_ids(admin_client, db):
-    lib = Library(name="List User Library", path="/tmp/list-user-lib")
+    lib = create_library_with_root(db, "List User Library", "/tmp/list-user-lib")
     user = User(
         username="list-user",
         email="list-user@example.com",
@@ -190,7 +191,7 @@ def test_admin_list_users_includes_library_ids(admin_client, db):
         is_active=True,
         accessible_libraries=[lib],
     )
-    db.add_all([lib, user])
+    db.add(user)
     db.commit()
 
     response = admin_client.get("/api/users/?page=1&size=100")
@@ -204,8 +205,8 @@ def test_admin_list_users_includes_library_ids(admin_client, db):
 
 
 def test_admin_update_user_handles_normal_and_superuser_modes(admin_client, db):
-    lib_a = Library(name="Update Library A", path="/tmp/update-lib-a")
-    lib_b = Library(name="Update Library B", path="/tmp/update-lib-b")
+    lib_a = create_library_with_root(db, "Update Library A", "/tmp/update-lib-a")
+    lib_b = create_library_with_root(db, "Update Library B", "/tmp/update-lib-b")
     user = User(
         username="target-user",
         email="target@example.com",
@@ -213,7 +214,7 @@ def test_admin_update_user_handles_normal_and_superuser_modes(admin_client, db):
         is_superuser=False,
         is_active=True,
     )
-    db.add_all([lib_a, lib_b, user])
+    db.add(user)
     db.commit()
 
     missing = admin_client.patch("/api/users/999999", json={"email": "none@example.com"})

--- a/tests/api/test_volumes.py
+++ b/tests/api/test_volumes.py
@@ -1,54 +1,51 @@
 from datetime import datetime, timezone
 
-from app.models.comic import Comic, Volume
+from app.models.comic import Volume
 from app.models.credits import ComicCredit, Person
 from app.models.interactions import UserVolumeFollow
-from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.tags import Character, Location, Team
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_volume_fixture(db, *, lib_name: str, series_name: str):
-    library = Library(name=lib_name, path=f"/tmp/{lib_name}")
+    library = create_library_with_root(db, lib_name, f"/tmp/{lib_name}")
+    root = library.active_root
     series = Series(name=series_name, library=library)
     volume = Volume(series=series, volume_number=1)
 
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
     comics = [
-        Comic(
-            volume_id=volume.id,
+        create_comic(
+            db, volume, root, f"{series_name}-10.cbz",
             number="10",
             title=f"{series_name} #10",
             year=2024,
             filename=f"{series_name}-10.cbz",
-            file_path=f"/tmp/{series_name}-10-{lib_name}.cbz",
             page_count=20,
         ),
-        Comic(
-            volume_id=volume.id,
+        create_comic(
+            db, volume, root, f"{series_name}-2.cbz",
             number="2",
             title=f"{series_name} #2",
             year=2023,
             filename=f"{series_name}-2.cbz",
-            file_path=f"/tmp/{series_name}-2-{lib_name}.cbz",
             page_count=22,
         ),
-        Comic(
-            volume_id=volume.id,
+        create_comic(
+            db, volume, root, f"{series_name}-annual.cbz",
             number="1",
             title=f"{series_name} Annual",
             format="annual",
             year=2022,
             filename=f"{series_name}-annual.cbz",
-            file_path=f"/tmp/{series_name}-annual-{lib_name}.cbz",
             page_count=30,
         ),
     ]
 
-    db.add_all(comics)
     db.commit()
 
     db.refresh(library)
@@ -68,15 +65,13 @@ def _create_volume_fixture(db, *, lib_name: str, series_name: str):
 def test_volume_detail_blocks_restricted_content(auth_client, db, normal_user):
     data = _create_volume_fixture(db, lib_name="restricted-lib", series_name="Restricted Volume")
 
-    mature = Comic(
-        volume_id=data["volume"].id,
+    create_comic(
+        db, data["volume"], data["library"].active_root, "restricted.cbz",
         number="11",
         title="Restricted Issue",
         age_rating="Mature 17+",
         filename="restricted.cbz",
-        file_path="/tmp/restricted-issue.cbz",
     )
-    db.add(mature)
 
     normal_user.max_age_rating = "Teen"
     normal_user.allow_unknown_age_ratings = False
@@ -124,14 +119,15 @@ def test_volume_issues_filters_sorting_and_read_status(auth_client, db, normal_u
 
 
 def test_volume_detail_reports_missing_zero_index_and_metadata(auth_client, db, normal_user):
-    library = Library(name="vol-detail-lib", path="/tmp/vol-detail-lib")
+    library = create_library_with_root(db, "vol-detail-lib", "/tmp/vol-detail-lib")
+    root = library.active_root
     series = Series(name="Volume Detail Saga", library=library)
     volume = Volume(series=series, volume_number=1, summary_override="Volume override summary")
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    issue_zero = Comic(
-        volume_id=volume.id,
+    issue_zero = create_comic(
+        db, volume, root, "issue-0.cbz",
         number="0",
         title="Issue Zero",
         year=2000,
@@ -142,10 +138,9 @@ def test_volume_detail_reports_missing_zero_index_and_metadata(auth_client, db, 
         publisher="Detail Pub",
         imprint="Detail Imprint",
         filename="issue-0.cbz",
-        file_path="/tmp/vol-detail-0.cbz",
     )
-    issue_one = Comic(
-        volume_id=volume.id,
+    issue_one = create_comic(
+        db, volume, root, "issue-1.cbz",
         number="1",
         title="Issue One",
         year=2001,
@@ -159,10 +154,9 @@ def test_volume_detail_reports_missing_zero_index_and_metadata(auth_client, db, 
         publisher="Detail Pub",
         imprint="Detail Imprint",
         filename="issue-1.cbz",
-        file_path="/tmp/vol-detail-1.cbz",
     )
-    issue_three = Comic(
-        volume_id=volume.id,
+    issue_three = create_comic(
+        db, volume, root, "issue-3.cbz",
         number="3",
         title="Issue Three",
         year=2003,
@@ -173,10 +167,9 @@ def test_volume_detail_reports_missing_zero_index_and_metadata(auth_client, db, 
         publisher="Detail Pub",
         imprint="Detail Imprint",
         filename="issue-3.cbz",
-        file_path="/tmp/vol-detail-3.cbz",
     )
-    annual = Comic(
-        volume_id=volume.id,
+    annual = create_comic(
+        db, volume, root, "annual.cbz",
         number="1",
         title="Annual",
         format="annual",
@@ -185,10 +178,9 @@ def test_volume_detail_reports_missing_zero_index_and_metadata(auth_client, db, 
         page_count=30,
         file_size=140,
         filename="annual.cbz",
-        file_path="/tmp/vol-detail-annual.cbz",
     )
-    special = Comic(
-        volume_id=volume.id,
+    special = create_comic(
+        db, volume, root, "special.cbz",
         number="0.5",
         title="Special",
         format="one-shot",
@@ -197,10 +189,7 @@ def test_volume_detail_reports_missing_zero_index_and_metadata(auth_client, db, 
         page_count=26,
         file_size=90,
         filename="special.cbz",
-        file_path="/tmp/vol-detail-special.cbz",
     )
-    db.add_all([issue_zero, issue_one, issue_three, annual, special])
-    db.flush()
 
     writer = Person(name="Writer A")
     penciller = Person(name="Penciller A")
@@ -266,21 +255,19 @@ def test_volume_detail_reports_missing_zero_index_and_metadata(auth_client, db, 
 
 
 def test_volume_detail_hides_story_arcs_when_parsing_disabled(auth_client, db, normal_user):
-    library = Library(name="vol-story-parse-off-lib", path="/tmp/vol-story-parse-off-lib", parse_story_arcs=False)
+    library = create_library_with_root(db, "vol-story-parse-off-lib", "/tmp/vol-story-parse-off-lib", parse_story_arcs=False)
+    root = library.active_root
     series = Series(name="Volume Story Off", library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    db.add(
-        Comic(
-            volume_id=volume.id,
-            number="1",
-            title="Story Arc Off",
-            story_arc="Hidden Arc",
-            filename="story-off.cbz",
-            file_path="/tmp/story-off.cbz",
-        )
+    create_comic(
+        db, volume, root, "story-off.cbz",
+        number="1",
+        title="Story Arc Off",
+        story_arc="Hidden Arc",
+        filename="story-off.cbz",
     )
 
     normal_user.accessible_libraries.append(library)
@@ -293,14 +280,15 @@ def test_volume_detail_hides_story_arcs_when_parsing_disabled(auth_client, db, n
 
 
 def test_volume_detail_marks_standalone_without_plain_issues(auth_client, db, normal_user):
-    library = Library(name="vol-standalone-lib", path="/tmp/vol-standalone-lib")
+    library = create_library_with_root(db, "vol-standalone-lib", "/tmp/vol-standalone-lib")
+    root = library.active_root
     series = Series(name="Standalone Volume", library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    annual = Comic(
-        volume_id=volume.id,
+    create_comic(
+        db, volume, root, "standalone-annual.cbz",
         number="1",
         title="Standalone Annual",
         format="annual",
@@ -308,10 +296,9 @@ def test_volume_detail_marks_standalone_without_plain_issues(auth_client, db, no
         page_count=40,
         file_size=150,
         filename="standalone-annual.cbz",
-        file_path="/tmp/standalone-annual.cbz",
     )
-    special = Comic(
-        volume_id=volume.id,
+    create_comic(
+        db, volume, root, "standalone-special.cbz",
         number="2",
         title="Standalone Special",
         format="one-shot",
@@ -319,9 +306,7 @@ def test_volume_detail_marks_standalone_without_plain_issues(auth_client, db, no
         page_count=35,
         file_size=130,
         filename="standalone-special.cbz",
-        file_path="/tmp/standalone-special.cbz",
     )
-    db.add_all([annual, special])
 
     normal_user.accessible_libraries.append(library)
     db.commit()
@@ -341,34 +326,31 @@ def test_volume_detail_marks_standalone_without_plain_issues(auth_client, db, no
 
 
 def test_volume_detail_advances_to_next_issue_when_latest_progress_is_completed(auth_client, db, normal_user):
-    library = Library(name="volume-next-lib", path="/tmp/volume-next-lib")
+    library = create_library_with_root(db, "volume-next-lib", "/tmp/volume-next-lib")
+    root = library.active_root
     series = Series(name="Volume Next Logic", library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    issue_one = Comic(
-        volume_id=volume.id,
+    issue_one = create_comic(
+        db, volume, root, "volume-next-1.cbz",
         number="1",
         title="Volume Next #1",
         filename="volume-next-1.cbz",
-        file_path="/tmp/volume-next-1.cbz",
     )
-    issue_two = Comic(
-        volume_id=volume.id,
+    issue_two = create_comic(
+        db, volume, root, "volume-next-2.cbz",
         number="2",
         title="Volume Next #2",
         filename="volume-next-2.cbz",
-        file_path="/tmp/volume-next-2.cbz",
     )
-    issue_three = Comic(
-        volume_id=volume.id,
+    issue_three = create_comic(
+        db, volume, root, "volume-next-3.cbz",
         number="3",
         title="Volume Next #3",
         filename="volume-next-3.cbz",
-        file_path="/tmp/volume-next-3.cbz",
     )
-    db.add_all([issue_one, issue_two, issue_three])
 
     normal_user.accessible_libraries.append(library)
     db.flush()
@@ -458,36 +440,32 @@ def test_following_list_reports_new_arrivals_and_filters_hidden_volumes(auth_cli
     ])
     db.flush()
 
-    new_issue = Comic(
-        volume_id=visible["volume"].id,
+    visible_root = visible["library"].active_root
+    new_issue = create_comic(
+        db, visible["volume"], visible_root, "visible-follow-11.cbz",
         number="11",
         title="Visible Follow #11",
         year=2026,
         created_at=datetime(2026, 7, 2, 12, 0, tzinfo=timezone.utc),
         filename="visible-follow-11.cbz",
-        file_path="/tmp/visible-follow-11.cbz",
     )
-    started_issue = Comic(
-        volume_id=visible["volume"].id,
+    started_issue = create_comic(
+        db, visible["volume"], visible_root, "visible-follow-12.cbz",
         number="12",
         title="Visible Follow #12",
         year=2026,
         created_at=datetime(2026, 7, 3, 12, 0, tzinfo=timezone.utc),
         filename="visible-follow-12.cbz",
-        file_path="/tmp/visible-follow-12.cbz",
     )
-    annual = Comic(
-        volume_id=visible["volume"].id,
+    annual = create_comic(
+        db, visible["volume"], visible_root, "visible-follow-annual.cbz",
         number="1",
         title="Visible Follow Annual",
         format="annual",
         year=2026,
         created_at=datetime(2026, 7, 4, 12, 0, tzinfo=timezone.utc),
         filename="visible-follow-annual.cbz",
-        file_path="/tmp/visible-follow-annual.cbz",
     )
-    db.add_all([new_issue, started_issue, annual])
-    db.flush()
 
     db.add(
         ReadingProgress(

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -30,6 +30,8 @@ from app.models.series import Series
 from app.models.tags import Character
 from app.models.user import User
 
+from tests.factories import create_library_with_root
+
 PNG_PIXEL_BYTES = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9sZVE70AAAAASUVORK5CYII="
 )
@@ -65,33 +67,37 @@ def browser_db_factory(tmp_path_factory):
 @pytest.fixture(scope="session")
 def browser_seed_data(browser_db_factory):
     session = browser_db_factory()
-    library = Library(name="Browser Test Library", path=str(Path("/tmp/browser-test-library")))
+    library = create_library_with_root(session, "Browser Test Library", str(Path("/tmp/browser-test-library")))
+    root = library.active_root
     series = Series(name="Smoke Series", library=library)
     volume = Volume(series=series, volume_number=1)
     completed_comic = Comic(
         volume=volume,
+        library_root_id=root.id,
+        relative_path="smoke-reader.cbz",
         number="1",
         title="Smoke Reader",
         filename="smoke-reader.cbz",
-        file_path="/tmp/smoke-reader.cbz",
         page_count=3,
     )
     active_comic = Comic(
         volume=volume,
+        library_root_id=root.id,
+        relative_path="smoke-encore.cbz",
         number="2",
         title="Smoke Encore",
         filename="smoke-encore.cbz",
-        file_path="/tmp/smoke-encore.cbz",
         page_count=3,
     )
     in_progress_comic = Comic(
         volume=volume,
+        library_root_id=root.id,
+        relative_path="smoke-horizon.cbz",
         number="3",
         title="Smoke Horizon",
         year=2024,
         month=5,
         filename="smoke-horizon.cbz",
-        file_path="/tmp/smoke-horizon.cbz",
         page_count=4,
     )
     reading_list = ReadingList(
@@ -223,7 +229,7 @@ def browser_server(browser_db_factory, browser_seed_data, monkeypatch_session):
         try:
             user = session.scalar(
                 select(User)
-                .options(selectinload(User.accessible_libraries))
+                .options(selectinload(User.accessible_libraries).selectinload(Library.roots))
                 .where(User.id == browser_seed_data["user_id"])
             )
             _ = list(user.accessible_libraries)

--- a/tests/browser/test_navigation_smoke.py
+++ b/tests/browser/test_navigation_smoke.py
@@ -1,8 +1,9 @@
 import pytest
 
 from app.models.collection import Collection, CollectionItem
-from app.models.comic import Comic
+from app.models.comic import Comic, Volume
 from app.models.tags import Character
+from tests.factories import create_comic
 
 
 def _insert_decade_timeline_fixture(browser_server):
@@ -13,18 +14,18 @@ def _insert_decade_timeline_fixture(browser_server):
         session.flush()
 
         volume_id = browser_server["seed"]["volume_id"]
+        volume = session.get(Volume, volume_id)
+        root = volume.series.library.active_root
         for offset, year in enumerate(range(2000, 2013), start=1):
-            comic = Comic(
-                volume_id=volume_id,
+            comic = create_comic(
+                session, volume, root, f"decade-smoke-{year}.cbz",
                 number=str(100 + offset),
                 title=f"Decade Smoke {year}",
                 year=year,
                 filename=f"decade-smoke-{year}.cbz",
-                file_path=f"/tmp/decade-smoke-{year}.cbz",
                 page_count=3,
             )
             comic.characters.append(character)
-            session.add(comic)
 
         session.commit()
     finally:

--- a/tests/browser/test_search_and_series_smoke.py
+++ b/tests/browser/test_search_and_series_smoke.py
@@ -2,8 +2,9 @@ import pytest
 from datetime import timedelta
 from sqlalchemy import select
 
-from app.models.comic import Comic
+from app.models.comic import Volume
 from app.models.interactions import UserVolumeFollow
+from tests.factories import create_comic
 
 
 def _insert_following_arrival(browser_server):
@@ -18,8 +19,10 @@ def _insert_following_arrival(browser_server):
         )
         assert follow is not None
 
-        new_issue = Comic(
-            volume_id=seed["volume_id"],
+        volume = session.get(Volume, seed["volume_id"])
+        root = volume.series.library.active_root
+        new_issue = create_comic(
+            session, volume, root, "smoke-future-shock.cbz",
             number="4",
             title="Smoke Future Shock",
             year=2026,
@@ -27,9 +30,7 @@ def _insert_following_arrival(browser_server):
             created_at=follow.followed_at + timedelta(minutes=1),
             updated_at=follow.followed_at + timedelta(minutes=1),
             filename="smoke-future-shock.cbz",
-            file_path="/tmp/smoke-future-shock.cbz",
         )
-        session.add(new_issue)
         session.commit()
         session.refresh(new_issue)
         return new_issue.id, new_issue.title

--- a/tests/core/test_path_utils.py
+++ b/tests/core/test_path_utils.py
@@ -33,3 +33,19 @@ def test_compute_relative_path_returns_none_when_not_under_root():
 def test_compute_relative_path_returns_none_for_sibling_with_shared_prefix():
     # "DC" should not match "DComics" — must respect the path separator boundary
     assert compute_relative_path("C:\\Comics\\DC", "C:\\Comics\\DComics\\file.cbz") is None
+
+
+def test_compute_relative_path_windows_style_paths_regardless_of_host_os():
+    # Backslash-separated paths must resolve correctly even when this code runs on
+    # a host (e.g. Linux) whose native os.sep is '/' — matching must not depend on
+    # which platform originally wrote the path string.
+    assert compute_relative_path("C:\\Comics\\DC", "C:\\Comics\\DC\\Batman\\Batman 001.cbz") == \
+        "Batman/Batman 001.cbz"
+
+
+def test_compute_relative_path_root_at_filesystem_root():
+    assert compute_relative_path("/", "/comics/dc/Batman 001.cbz") == "comics/dc/Batman 001.cbz"
+
+
+def test_compute_relative_path_windows_drive_root():
+    assert compute_relative_path("C:\\", "C:\\Comics\\DC\\Batman 001.cbz") == "Comics/DC/Batman 001.cbz"

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,35 @@
+"""Shared test factories for creating Library/LibraryRoot/Comic rows.
+
+Comic.library_root_id/relative_path are NOT NULL, so every comic needs a real
+LibraryRoot to attach to -- these helpers exist so tests don't each have to
+repeat that plumbing.
+"""
+from app.models.comic import Comic
+from app.models.library import Library
+from app.models.library_root import LibraryRoot
+
+
+def create_library_with_root(db, name: str, path: str, **library_kwargs) -> Library:
+    """Create a Library plus its (only, active) LibraryRoot at `path`."""
+    library = Library(name=name, **library_kwargs)
+    db.add(library)
+    db.flush()
+
+    root = LibraryRoot(library_id=library.id, path=path, is_active=True)
+    db.add(root)
+    db.flush()
+
+    return library
+
+
+def create_comic(db, volume, root: LibraryRoot, relative_path: str, **comic_kwargs) -> Comic:
+    """Create a Comic tied to `root` at `relative_path`."""
+    comic = Comic(
+        volume_id=volume.id,
+        library_root_id=root.id,
+        relative_path=relative_path,
+        **comic_kwargs,
+    )
+    db.add(comic)
+    db.flush()
+    return comic

--- a/tests/services/test_generated_container_services.py
+++ b/tests/services/test_generated_container_services.py
@@ -1,26 +1,28 @@
 from app.models import (
     CollectionItem,
     Comic,
-    Library,
     ReadingListItem,
     Series,
     Volume,
 )
 from app.services.collection import CollectionService
 from app.services.reading_list import ReadingListService
+from tests.factories import create_library_with_root
 
 
 def _create_comic(db, suffix: str) -> Comic:
-    library = Library(name=f"Library {suffix}", path=f"/library/{suffix}")
+    library = create_library_with_root(db, f"Library {suffix}", f"/library/{suffix}")
+    root = library.active_root
     series = Series(name=f"Series {suffix}", library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
         volume=volume,
         filename=f"{suffix}.cbz",
-        file_path=f"/library/{suffix}/{suffix}.cbz",
+        library_root_id=root.id,
+        relative_path=f"{suffix}.cbz",
         page_count=24,
     )
-    db.add_all([library, series, volume, comic])
+    db.add_all([series, volume, comic])
     db.commit()
     db.refresh(comic)
     return comic

--- a/tests/services/test_kavita_migration.py
+++ b/tests/services/test_kavita_migration.py
@@ -1,12 +1,12 @@
 import sqlite3
 from datetime import datetime, timedelta, timezone
 
-from app.models.comic import Comic, Volume
-from app.models.library import Library
+from app.models.comic import Volume
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.user import User
 from app.services.kavita_migration import KavitaMigrationService
+from tests.factories import create_comic, create_library_with_root
 
 
 def _create_kavita_db(tmp_path, *, include_user_tables=True, include_mapping_tables=True, include_progress_table=True):
@@ -54,17 +54,16 @@ def _create_kavita_db(tmp_path, *, include_user_tables=True, include_mapping_tab
 
 
 def _seed_parker_series(db, *, prefix: str):
-    lib = Library(name=f"{prefix}-lib", path=f"/tmp/{prefix}-lib")
+    lib = create_library_with_root(db, f"{prefix}-lib", f"/tmp/{prefix}-lib")
     series = Series(name=f"{prefix}-series", library=lib)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([lib, series, volume])
+    db.add_all([series, volume])
     db.flush()
     return lib, series, volume
 
 
 def test_migrate_users_creates_admin_and_syncs_library_permissions(db, tmp_path):
-    parker_lib = Library(name="Main Library", path="/tmp/main-library")
-    db.add(parker_lib)
+    create_library_with_root(db, "Main Library", "/tmp/main-library")
     db.commit()
 
     kavita_path = _create_kavita_db(tmp_path, include_mapping_tables=False, include_progress_table=False)
@@ -124,53 +123,51 @@ def test_migrate_users_creates_admin_and_syncs_library_permissions(db, tmp_path)
 
 
 def test_map_comics_uses_suffix_then_unique_metadata_and_skips_ambiguous(db, tmp_path):
-    _, batman_series, batman_volume = _seed_parker_series(db, prefix="kmap-batman")
+    batman_lib, batman_series, batman_volume = _seed_parker_series(db, prefix="kmap-batman")
     batman_series.name = "Batman"
+    batman_lib.active_root.path = "D:/comics/DC/Batman"
 
-    _, flash_series, flash_volume = _seed_parker_series(db, prefix="kmap-flash")
+    flash_lib, flash_series, flash_volume = _seed_parker_series(db, prefix="kmap-flash")
     flash_series.name = "Flash"
+    flash_lib.active_root.path = "D:/comics/DC/Flash"
 
-    _, ambig_series, ambig_volume = _seed_parker_series(db, prefix="kmap-ambig")
+    ambig_lib, ambig_series, ambig_volume = _seed_parker_series(db, prefix="kmap-ambig")
     ambig_series.name = "X-Men"
+    ambig_lib.active_root.path = "D:/comics/Marvel/X-Men"
 
-    c_suffix = Comic(
-        volume_id=batman_volume.id,
+    c_suffix = create_comic(
+        db, batman_volume, batman_lib.active_root, "Batman #001.cbz",
         number="1",
         format=None,
         title="Batman 1",
         filename="batman-1.cbz",
-        file_path="D:/comics/DC/Batman/Batman #001.cbz",
         page_count=20,
     )
-    c_meta = Comic(
-        volume_id=flash_volume.id,
+    c_meta = create_comic(
+        db, flash_volume, flash_lib.active_root, "Flash Annual #005.cbz",
         number="5",
         format="annual",
         title="Flash Annual 5",
         filename="flash-annual-5.cbz",
-        file_path="D:/comics/DC/Flash/Flash Annual #005.cbz",
         page_count=30,
     )
-    c_ambig_a = Comic(
-        volume_id=ambig_volume.id,
+    c_ambig_a = create_comic(
+        db, ambig_volume, ambig_lib.active_root, "X-Men #007-a.cbz",
         number="7",
         format=None,
         title="X-Men 7A",
         filename="xmen-7a.cbz",
-        file_path="D:/comics/Marvel/X-Men/X-Men #007-a.cbz",
         page_count=22,
     )
-    c_ambig_b = Comic(
-        volume_id=ambig_volume.id,
+    c_ambig_b = create_comic(
+        db, ambig_volume, ambig_lib.active_root, "X-Men #007-b.cbz",
         number="7",
         format=None,
         title="X-Men 7B",
         filename="xmen-7b.cbz",
-        file_path="D:/comics/Marvel/X-Men/X-Men #007-b.cbz",
         page_count=22,
     )
 
-    db.add_all([c_suffix, c_meta, c_ambig_a, c_ambig_b])
     db.commit()
 
     kavita_path = _create_kavita_db(tmp_path, include_user_tables=False, include_progress_table=False)
@@ -227,7 +224,7 @@ def test_map_comics_uses_suffix_then_unique_metadata_and_skips_ambiguous(db, tmp
 
 
 def test_migrate_progress_normalizes_zero_based_and_updates_existing(db, tmp_path):
-    _, series, volume = _seed_parker_series(db, prefix="kprog")
+    lib, series, volume = _seed_parker_series(db, prefix="kprog")
     series.name = "Progress Series"
 
     user = User(
@@ -240,24 +237,21 @@ def test_migrate_progress_normalizes_zero_based_and_updates_existing(db, tmp_pat
     db.add(user)
     db.flush()
 
-    c_new = Comic(
-        volume_id=volume.id,
+    root = lib.active_root
+    c_new = create_comic(
+        db, volume, root, "progress-new.cbz",
         number="1",
         title="Progress New",
         filename="progress-new.cbz",
-        file_path="D:/comics/progress-new.cbz",
         page_count=10,
     )
-    c_existing = Comic(
-        volume_id=volume.id,
+    c_existing = create_comic(
+        db, volume, root, "progress-existing.cbz",
         number="2",
         title="Progress Existing",
         filename="progress-existing.cbz",
-        file_path="D:/comics/progress-existing.cbz",
         page_count=8,
     )
-    db.add_all([c_new, c_existing])
-    db.flush()
 
     existing_progress = ReadingProgress(
         user_id=user.id,

--- a/tests/services/test_maintenance_service.py
+++ b/tests/services/test_maintenance_service.py
@@ -1,25 +1,33 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from app.models.activity_log import ActivityLog
 from app.models.collection import Collection, CollectionItem
 from app.models.comic import Comic, Volume
 from app.models.credits import ComicCredit, Person
+from app.models.interactions import UserComicRating
 from app.models.library import Library
+from app.models.library_root import LibraryRoot
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.series import Series
 from app.models.tags import Character, Location, Team
+from app.models.user import User
 from app.services.maintenance import MaintenanceService
 import app.services.maintenance as maintenance_module
 
 
 def _create_library(db, name: str, tmp_path: Path) -> Library:
-    lib = Library(name=name, path=str(tmp_path / name))
+    lib = Library(name=name)
     db.add(lib)
+    db.flush()
+    root = LibraryRoot(library_id=lib.id, path=str(tmp_path / name), is_active=True)
+    db.add(root)
     db.flush()
     return lib
 
 
-def _create_comic(db, library: Library, slug: str, file_path: str, *, thumbnail_path: str = None) -> Comic:
+def _create_comic(db, library: Library, slug: str, relative_path: str, *, thumbnail_path: str = None) -> Comic:
+    root = library.active_root
     series = Series(name=f"{slug}-series", library_id=library.id)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -27,7 +35,8 @@ def _create_comic(db, library: Library, slug: str, file_path: str, *, thumbnail_
         number="1",
         title=f"{slug}-title",
         filename=f"{slug}.cbz",
-        file_path=file_path,
+        library_root_id=root.id,
+        relative_path=relative_path,
         page_count=12,
         thumbnail_path=thumbnail_path,
     )
@@ -47,7 +56,8 @@ def test_cleanup_orphans_global_removes_only_orphans(db, tmp_path):
         number="1",
         title="keep",
         filename="keep.cbz",
-        file_path=str(tmp_path / "keep.cbz"),
+        library_root_id=lib.active_root.id,
+        relative_path="keep.cbz",
         page_count=10,
     )
 
@@ -201,15 +211,15 @@ def test_cleanup_missing_files_scoped_with_batch_commits(db, tmp_path, monkeypat
     # 101 missing files in lib_a to trigger both the modulo-100 commit and final commit
     missing_ids = []
     for i in range(101):
-        comic = _create_comic(db, lib_a, f"a-missing-{i}", str(tmp_path / "missing" / f"a-{i}.cbz"))
+        comic = _create_comic(db, lib_a, f"a-missing-{i}", f"missing/a-{i}.cbz")
         missing_ids.append(comic.id)
 
-    existing_path = tmp_path / "exists" / "a-exists.cbz"
+    existing_path = Path(lib_a.active_root.path) / "exists" / "a-exists.cbz"
     existing_path.parent.mkdir(parents=True, exist_ok=True)
     existing_path.write_bytes(b"ok")
-    keep_comic = _create_comic(db, lib_a, "a-keep", str(existing_path))
+    keep_comic = _create_comic(db, lib_a, "a-keep", "exists/a-exists.cbz")
 
-    other_lib_missing = _create_comic(db, lib_b, "b-missing", str(tmp_path / "missing" / "b.cbz"))
+    other_lib_missing = _create_comic(db, lib_b, "b-missing", "missing/b.cbz")
     db.commit()
 
     service = MaintenanceService(db)
@@ -228,13 +238,64 @@ def test_cleanup_missing_files_scoped_with_batch_commits(db, tmp_path, monkeypat
     assert db.get(Comic, other_lib_missing.id) is not None
 
 
+def test_cleanup_missing_files_reconstructs_path_from_root_instead_of_stale_file_path(db, tmp_path):
+    lib = _create_library(db, "maint-root-reconstruct", tmp_path)
+
+    real_root = tmp_path / "real-root"
+    real_root.mkdir(parents=True, exist_ok=True)
+    root = LibraryRoot(library_id=lib.id, path=str(real_root), is_active=True)
+    db.add(root)
+    db.flush()
+
+    # Comic is initially stamped against the library's default root with a
+    # throwaway relative_path, then re-pointed at a second root belonging to
+    # the same library -- the janitor must resolve via whichever root the
+    # comic is actually stamped with, not assume it's always the "default" one.
+    on_disk = real_root / "issue.cbz"
+    on_disk.write_bytes(b"ok")
+    healthy = _create_comic(db, lib, "healthy", "placeholder.cbz")
+    healthy.library_root_id = root.id
+    healthy.relative_path = "issue.cbz"
+
+    # relative_path doesn't resolve to anything under the library's root.
+    truly_missing = _create_comic(db, lib, "missing", "stale-location/gone.cbz")
+    db.commit()
+
+    service = MaintenanceService(db)
+    deleted_ids = service.cleanup_missing_files(library_id=lib.id)
+
+    assert deleted_ids == [truly_missing.id]
+    assert db.get(Comic, healthy.id) is not None
+    assert db.get(Comic, truly_missing.id) is None
+
+
+def test_cleanup_missing_files_deletes_user_ratings_and_activity_log(db, tmp_path):
+    lib = _create_library(db, "maint-missing-cascade", tmp_path)
+    missing = _create_comic(db, lib, "missing-cascade", "stale-location/gone.cbz")
+
+    user = User(username="maint-cascade-user", email="maint-cascade@test.local", hashed_password="x")
+    db.add(user)
+    db.flush()
+
+    db.add(UserComicRating(user_id=user.id, comic_id=missing.id, rating=4))
+    db.add(ActivityLog(user_id=user.id, comic_id=missing.id, pages_read=1, start_page=0, end_page=1))
+    db.commit()
+
+    service = MaintenanceService(db)
+    deleted_ids = service.cleanup_missing_files(library_id=lib.id)
+
+    assert deleted_ids == [missing.id]
+    assert db.query(UserComicRating).filter_by(comic_id=missing.id).count() == 0
+    assert db.query(ActivityLog).filter_by(comic_id=missing.id).count() == 0
+
+
 def test_cleanup_missing_files_no_deletions_makes_no_commit(db, tmp_path, monkeypatch):
     lib = _create_library(db, "maint-missing-none", tmp_path)
 
-    existing_path = tmp_path / "exists" / "one.cbz"
+    existing_path = Path(lib.active_root.path) / "exists" / "one.cbz"
     existing_path.parent.mkdir(parents=True, exist_ok=True)
     existing_path.write_bytes(b"ok")
-    _create_comic(db, lib, "keep", str(existing_path))
+    _create_comic(db, lib, "keep", "exists/one.cbz")
     db.commit()
 
     service = MaintenanceService(db)
@@ -301,7 +362,7 @@ def test_cleanup_orphaned_thumbnails_deletes_unreferenced_and_logs_errors(db, tm
     (cover_dir / "nested").mkdir()
 
     lib = _create_library(db, "maint-thumb-lib", tmp_path)
-    _create_comic(db, lib, "thumb-comic", str(tmp_path / "thumb.cbz"), thumbnail_path=str(referenced))
+    _create_comic(db, lib, "thumb-comic", "thumb.cbz", thumbnail_path=str(referenced))
     db.commit()
 
     original_unlink = Path.unlink

--- a/tests/services/test_metadata_service.py
+++ b/tests/services/test_metadata_service.py
@@ -2,14 +2,15 @@ import json
 
 from app.models.comic import Comic, Volume
 from app.models.collection import Collection, CollectionItem
-from app.models.library import Library
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.series import Series
 from app.services.metadata import rehydrate_library_metadata_from_cache
+from tests.factories import create_library_with_root
 
 
 def test_rehydrate_library_metadata_from_cache_restores_expected_metadata(db):
-    library = Library(name="metadata-rehydrate-lib", path="/tmp/metadata-rehydrate-lib")
+    library = create_library_with_root(db, "metadata-rehydrate-lib", "/tmp/metadata-rehydrate-lib")
+    root = library.active_root
     series = Series(name="Metadata Rehydrate Series", library=library)
     volume = Volume(series=series, volume_number=1)
 
@@ -18,7 +19,8 @@ def test_rehydrate_library_metadata_from_cache_restores_expected_metadata(db):
         number="1",
         title="Restorable Issue",
         filename="restorable.cbz",
-        file_path="/tmp/restorable.cbz",
+        library_root_id=root.id,
+        relative_path="restorable.cbz",
         metadata_json=json.dumps(
             {
                 "alternate_series": "Event Gamma",
@@ -34,11 +36,12 @@ def test_rehydrate_library_metadata_from_cache_restores_expected_metadata(db):
         number="2",
         title="Missing Source",
         filename="missing-source.cbz",
-        file_path="/tmp/missing-source.cbz",
+        library_root_id=root.id,
+        relative_path="missing-source.cbz",
         metadata_json=None,
     )
 
-    db.add_all([library, series, volume, restorable, missing_source])
+    db.add_all([series, volume, restorable, missing_source])
     db.commit()
 
     summary = rehydrate_library_metadata_from_cache(

--- a/tests/services/test_metadata_writer.py
+++ b/tests/services/test_metadata_writer.py
@@ -4,11 +4,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from app.models.comic import Comic, Volume
-from app.models.library import Library
-from app.models.library_root import LibraryRoot
 from app.models.series import Series
 import app.database as database_module
 import app.services.workers.metadata_writer as metadata_writer_module
+from tests.factories import create_comic, create_library_with_root
 
 
 class _ReadQueue:
@@ -30,9 +29,10 @@ class _WriteQueue:
 
 
 class _FakeQuery:
-    def __init__(self, model, library_obj):
+    def __init__(self, model, library_obj, library_root_obj):
         self.model = model
         self.library_obj = library_obj
+        self.library_root_obj = library_root_obj
 
     def get(self, _library_id):
         return self.library_obj
@@ -47,7 +47,7 @@ class _FakeQuery:
         return self
 
     def first(self):
-        return None
+        return self.library_root_obj
 
     def all(self):
         return []
@@ -55,14 +55,15 @@ class _FakeQuery:
 
 class _FakeDB:
     def __init__(self, library_path):
-        self.library_obj = SimpleNamespace(path=library_path)
+        self.library_obj = SimpleNamespace(name="fake-lib")
+        self.library_root_obj = SimpleNamespace(id=1, path=library_path)
         self.closed = False
 
     def get(self, _model, _library_id):
         return self.library_obj
 
     def query(self, model):
-        return _FakeQuery(model, self.library_obj)
+        return _FakeQuery(model, self.library_obj, self.library_root_obj)
 
     def close(self):
         self.closed = True
@@ -103,28 +104,29 @@ def _metadata(**overrides):
     return payload
 
 
+def _seed_library_with_root(db, name, path):
+    library = create_library_with_root(db, name, path)
+    return library, library.active_root
+
+
 def test_apply_metadata_batch_import_update_and_error_paths(db):
-    library = Library(name="writer-lib", path="/tmp/writer-lib")
-    db.add(library)
-    db.flush()
+    library, root = _seed_library_with_root(db, "writer-lib", "/tmp/writer-lib")
 
     existing_series = Series(name="Series A", library_id=library.id)
     existing_volume = Volume(series=existing_series, volume_number=1)
     db.add_all([existing_series, existing_volume])
     db.flush()
 
-    existing_comic_path = "/tmp/existing.cbz"
-    existing_comic = Comic(
-        volume_id=existing_volume.id,
+    existing_comic_path = "/tmp/writer-lib/existing.cbz"
+    existing_comic = create_comic(
+        db, existing_volume, root, "existing.cbz",
         filename="existing.cbz",
-        file_path=existing_comic_path,
         page_count=10,
         number="1",
     )
-    db.add(existing_comic)
     db.commit()
 
-    existing_map = {existing_comic_path: existing_comic}
+    existing_by_key = {(root.id, "existing.cbz"): existing_comic}
 
     def get_or_create_series(name: str):
         series = db.query(Series).filter_by(name=name, library_id=library.id).first()
@@ -162,7 +164,7 @@ def test_apply_metadata_batch_import_update_and_error_paths(db):
             "error": False,
         },
         {
-            "file_path": "/tmp/new.cbz",
+            "file_path": "/tmp/writer-lib/new.cbz",
             "mtime": 333.0,
             "size": 444,
             "metadata": _metadata(series=None, volume=None, number="2", title="Imported New", raw_metadata={"n": 1}),
@@ -173,17 +175,19 @@ def test_apply_metadata_batch_import_update_and_error_paths(db):
     stats = metadata_writer_module._apply_metadata_batch(
         db,
         batch,
-        existing_map,
+        existing_by_key,
         get_or_create_series,
         get_or_create_volume,
         tag_service,
         credit_service,
         reading_list_service,
         collection_service,
+        library_root_id=root.id,
+        library_root_path="/tmp/writer-lib",
     )
 
     db.refresh(existing_comic)
-    imported_comic = db.query(Comic).filter_by(file_path="/tmp/new.cbz").first()
+    imported_comic = db.query(Comic).filter_by(relative_path="new.cbz").first()
     unknown_series = db.query(Series).filter_by(name="Unknown Series", library_id=library.id).first()
 
     assert stats["imported"] == 1
@@ -204,27 +208,91 @@ def test_apply_metadata_batch_import_update_and_error_paths(db):
     assert json.loads(imported_comic.metadata_json) == {"n": 1}
     assert unknown_series is not None
 
-    assert existing_map["/tmp/new.cbz"].id == imported_comic.id
+    assert existing_by_key[(root.id, "new.cbz")].id == imported_comic.id
     assert credit_service.add_credits_to_comic.call_count == 2
     assert reading_list_service.update_comic_reading_lists.call_count == 2
     assert collection_service.update_comic_collections.call_count == 2
 
 
-def test_apply_metadata_batch_disables_optional_metadata_flows(db):
-    library = Library(name="writer-disable-lib", path="/tmp/writer-disable-lib")
-    db.add(library)
-    db.flush()
+def test_apply_metadata_batch_matches_existing_comic_by_identity_when_path_differs(db):
+    library, root = _seed_library_with_root(db, "writer-identity-lib", "/tmp/writer-identity-lib")
 
     series = Series(name="Series A", library_id=library.id)
     volume = Volume(series=series, volume_number=1)
     db.add_all([series, volume])
     db.flush()
 
-    existing_path = "/tmp/disable-existing.cbz"
-    comic = Comic(
-        volume_id=volume.id,
+    # The comic is already stamped with the identity this scan's freshly computed
+    # relative_path resolves to -- that must be recognized as an update, not a
+    # duplicate import, even if some other lookup by path would've missed it.
+    existing_comic = create_comic(
+        db, volume, root, "existing.cbz",
+        filename="existing.cbz",
+        page_count=10,
+        number="1",
+    )
+    db.commit()
+
+    existing_by_key = {(root.id, "existing.cbz"): existing_comic}
+
+    def get_or_create_series(name: str):
+        return db.query(Series).filter_by(name=name, library_id=library.id).first()
+
+    def get_or_create_volume(series_obj, volume_num: int, _file_path: str):
+        return db.query(Volume).filter_by(series_id=series_obj.id, volume_number=volume_num).first()
+
+    tag_service = SimpleNamespace(
+        get_or_create_characters=MagicMock(return_value=[]),
+        get_or_create_teams=MagicMock(return_value=[]),
+        get_or_create_locations=MagicMock(return_value=[]),
+        get_or_create_genres=MagicMock(return_value=[]),
+    )
+    credit_service = SimpleNamespace(add_credits_to_comic=MagicMock())
+    reading_list_service = SimpleNamespace(update_comic_reading_lists=MagicMock())
+    collection_service = SimpleNamespace(update_comic_collections=MagicMock())
+
+    batch = [{
+        "file_path": "/tmp/writer-identity-lib/existing.cbz",
+        "mtime": 111.0,
+        "size": 222,
+        "metadata": _metadata(title="Renamed On Disk"),
+        "error": False,
+    }]
+
+    stats = metadata_writer_module._apply_metadata_batch(
+        db,
+        batch,
+        existing_by_key,
+        get_or_create_series,
+        get_or_create_volume,
+        tag_service,
+        credit_service,
+        reading_list_service,
+        collection_service,
+        library_root_id=root.id,
+        library_root_path="/tmp/writer-identity-lib",
+    )
+
+    assert stats["imported"] == 0
+    assert stats["updated"] == 1
+
+    db.refresh(existing_comic)
+    assert existing_comic.title == "Renamed On Disk"
+    assert db.query(Comic).count() == 1
+
+
+def test_apply_metadata_batch_disables_optional_metadata_flows(db):
+    library, root = _seed_library_with_root(db, "writer-disable-lib", "/tmp/writer-disable-lib")
+
+    series = Series(name="Series A", library_id=library.id)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    existing_path = "/tmp/writer-disable-lib/disable-existing.cbz"
+    comic = create_comic(
+        db, volume, root, "disable-existing.cbz",
         filename="disable-existing.cbz",
-        file_path=existing_path,
         page_count=10,
         number="1",
         alternate_series="Old List",
@@ -232,10 +300,9 @@ def test_apply_metadata_batch_disables_optional_metadata_flows(db):
         series_group="Old Group",
         story_arc="Old Arc",
     )
-    db.add(comic)
     db.commit()
 
-    existing_map = {existing_path: comic}
+    existing_by_key = {(root.id, "disable-existing.cbz"): comic}
 
     def get_or_create_series(name: str):
         return db.query(Series).filter_by(name=name, library_id=library.id).first()
@@ -273,13 +340,15 @@ def test_apply_metadata_batch_disables_optional_metadata_flows(db):
     metadata_writer_module._apply_metadata_batch(
         db,
         batch,
-        existing_map,
+        existing_by_key,
         get_or_create_series,
         get_or_create_volume,
         tag_service,
         credit_service,
         reading_list_service,
         collection_service,
+        library_root_id=root.id,
+        library_root_path="/tmp/writer-disable-lib",
         parse_reading_lists=False,
         parse_collections=False,
         parse_story_arcs=False,
@@ -295,9 +364,7 @@ def test_apply_metadata_batch_disables_optional_metadata_flows(db):
 
 
 def test_apply_metadata_batch_falls_back_to_volume_one_for_invalid_volume_metadata(db):
-    library = Library(name="writer-invalid-volume-lib", path="/tmp/writer-invalid-volume-lib")
-    db.add(library)
-    db.flush()
+    library, root = _seed_library_with_root(db, "writer-invalid-volume-lib", "/tmp/writer-invalid-volume-lib")
 
     def get_or_create_series(name: str):
         series = db.query(Series).filter_by(name=name, library_id=library.id).first()
@@ -326,7 +393,7 @@ def test_apply_metadata_batch_falls_back_to_volume_one_for_invalid_volume_metada
     collection_service = SimpleNamespace(update_comic_collections=MagicMock())
 
     batch = [{
-        "file_path": "/tmp/invalid-volume.cbz",
+        "file_path": "/tmp/writer-invalid-volume-lib/invalid-volume.cbz",
         "mtime": 123.0,
         "size": 456,
         "metadata": _metadata(volume="3bbbb", title="Invalid Volume"),
@@ -343,9 +410,11 @@ def test_apply_metadata_batch_falls_back_to_volume_one_for_invalid_volume_metada
         credit_service,
         reading_list_service,
         collection_service,
+        library_root_id=root.id,
+        library_root_path="/tmp/writer-invalid-volume-lib",
     )
 
-    imported = db.query(Comic).filter_by(file_path="/tmp/invalid-volume.cbz").first()
+    imported = db.query(Comic).filter_by(relative_path="invalid-volume.cbz").first()
     assert stats["imported"] == 1
     assert stats["errors"] == 0
     assert imported is not None
@@ -424,11 +493,10 @@ def test_metadata_writer_creates_series_volume_once_and_reuses_cache(monkeypatch
     library_path = tmp_path / "writer-cache-lib"
     library_path.mkdir(parents=True, exist_ok=True)
 
-    library = Library(name="writer-cache-lib", path=str(library_path))
-    db.add(library)
+    library, root = _seed_library_with_root(db, "writer-cache-lib", str(library_path))
     db.commit()
-    db.refresh(library)
     library_id = library.id
+    root_id = root.id
 
     class DummyTagService:
         def __init__(self, _db):
@@ -515,8 +583,8 @@ def test_metadata_writer_creates_series_volume_once_and_reuses_cache(monkeypatch
     assert len(created_volumes) == 1
     assert len(created_comics) == 2
 
-    first_comic = db.query(Comic).filter_by(file_path=item_one_path).first()
-    second_comic = db.query(Comic).filter_by(file_path=item_two_path).first()
+    first_comic = db.query(Comic).filter_by(library_root_id=root_id, relative_path="Brand Series/Vol 2/one.cbz").first()
+    second_comic = db.query(Comic).filter_by(library_root_id=root_id, relative_path="Brand Series/Vol 2/two.cbz").first()
     assert first_comic.number is None
     assert second_comic.number == "5"
 
@@ -529,15 +597,8 @@ def test_metadata_writer_populates_library_root_and_relative_path(monkeypatch, d
     library_path = tmp_path / "root-lib"
     library_path.mkdir(parents=True, exist_ok=True)
 
-    library = Library(name="root-lib", path=str(library_path))
-    db.add(library)
-    db.flush()
-
-    root = LibraryRoot(library_id=library.id, path=str(library_path), is_active=True)
-    db.add(root)
+    library, root = _seed_library_with_root(db, "root-lib", str(library_path))
     db.commit()
-    db.refresh(library)
-    db.refresh(root)
     library_id = library.id
     root_id = root.id
 
@@ -546,15 +607,14 @@ def test_metadata_writer_populates_library_root_and_relative_path(monkeypatch, d
     db.add_all([series, volume])
     db.flush()
 
-    existing_path = str(library_path / "Existing" / "existing.cbz")
-    existing_comic = Comic(
-        volume_id=volume.id,
+    existing_relative_path = "Existing/existing.cbz"
+    existing_path = str(library_path / existing_relative_path)
+    existing_comic = create_comic(
+        db, volume, root, existing_relative_path,
         filename="existing.cbz",
-        file_path=existing_path,
         page_count=1,
         number="1",
     )
-    db.add(existing_comic)
     db.commit()
 
     class DummyTagService:
@@ -630,8 +690,8 @@ def test_metadata_writer_populates_library_root_and_relative_path(monkeypatch, d
     assert summary["updated"] == 1
     assert summary["errors"] == 0
 
-    refreshed_existing = db.query(Comic).filter_by(file_path=existing_path).first()
-    new_comic = db.query(Comic).filter_by(file_path=new_path).first()
+    refreshed_existing = db.query(Comic).filter_by(library_root_id=root_id, relative_path=existing_relative_path).first()
+    new_comic = db.query(Comic).filter_by(library_root_id=root_id, relative_path="Fresh/fresh.cbz").first()
 
     assert refreshed_existing.library_root_id == root_id
     assert refreshed_existing.relative_path == "Existing/existing.cbz"
@@ -639,5 +699,3 @@ def test_metadata_writer_populates_library_root_and_relative_path(monkeypatch, d
     assert new_comic is not None
     assert new_comic.library_root_id == root_id
     assert new_comic.relative_path == "Fresh/fresh.cbz"
-
-

--- a/tests/services/test_scan_manager.py
+++ b/tests/services/test_scan_manager.py
@@ -8,8 +8,8 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 
 from app.models.job import JobStatus, JobType, ScanJob
-from app.models.library import Library
 import app.services.scan_manager as sm
+from tests.factories import create_library_with_root
 
 
 def _manager():
@@ -39,10 +39,10 @@ def test_scan_manager_init_short_circuits_when_initialized():
 def test_recover_interrupted_jobs_marks_running_as_failed(monkeypatch, db):
     manager = _manager()
 
-    lib = Library(name="recover-lib", path="/tmp/recover-lib", is_scanning=True)
+    lib = create_library_with_root(db, "recover-lib", "/tmp/recover-lib", is_scanning=True)
     running = ScanJob(library=lib, job_type=JobType.SCAN, status=JobStatus.RUNNING)
     pending = ScanJob(library=lib, job_type=JobType.SCAN, status=JobStatus.PENDING)
-    db.add_all([lib, running, pending])
+    db.add_all([running, pending])
     db.commit()
 
     monkeypatch.setattr(sm, "SessionLocal", _session_local_factory(db))
@@ -74,8 +74,7 @@ def test_recover_interrupted_jobs_logs_exception(monkeypatch):
 def test_set_library_scanning_status_updates_and_handles_empty_id(monkeypatch, db):
     manager = _manager()
 
-    lib = Library(name="set-flag-lib", path="/tmp/set-flag-lib", is_scanning=False)
-    db.add(lib)
+    lib = create_library_with_root(db, "set-flag-lib", "/tmp/set-flag-lib", is_scanning=False)
     db.commit()
 
     monkeypatch.setattr(sm, "SessionLocal", _session_local_factory(db))
@@ -219,9 +218,8 @@ def test_add_cleanup_task_and_add_thumbnail_task(monkeypatch, db):
 def test_fix_stuck_libraries_resets_only_without_running_job(monkeypatch, db):
     manager = _manager()
 
-    lib_active = Library(name="lib-active", path="/tmp/lib-active", is_scanning=True)
-    lib_stuck = Library(name="lib-stuck", path="/tmp/lib-stuck", is_scanning=True)
-    db.add_all([lib_active, lib_stuck])
+    lib_active = create_library_with_root(db, "lib-active", "/tmp/lib-active", is_scanning=True)
+    lib_stuck = create_library_with_root(db, "lib-stuck", "/tmp/lib-stuck", is_scanning=True)
     db.flush()
 
     db.add(ScanJob(library_id=lib_active.id, job_type=JobType.SCAN, status=JobStatus.RUNNING))
@@ -254,8 +252,7 @@ def test_run_scan_job_success_updates_and_queues_followup(monkeypatch, db):
     manager = _manager()
     monkeypatch.setattr(sm, "SessionLocal", _session_local_factory(db))
 
-    lib = Library(name="scan-lib", path="/tmp/scan-lib")
-    db.add(lib)
+    lib = create_library_with_root(db, "scan-lib", "/tmp/scan-lib")
     db.commit()
 
     scanner_mock = MagicMock()
@@ -297,8 +294,7 @@ def test_run_scan_job_handles_scanner_exception(monkeypatch, db):
     manager = _manager()
     monkeypatch.setattr(sm, "SessionLocal", _session_local_factory(db))
 
-    lib = Library(name="scan-fail-lib", path="/tmp/scan-fail-lib")
-    db.add(lib)
+    lib = create_library_with_root(db, "scan-fail-lib", "/tmp/scan-fail-lib")
     db.commit()
 
     scanner_mock = MagicMock()
@@ -443,14 +439,14 @@ def test_run_metadata_rehydrate_job_success(monkeypatch, db):
     manager = _manager()
     monkeypatch.setattr(sm, "SessionLocal", _session_local_factory(db))
 
-    lib = Library(
-        name="rehydrate-lib",
-        path="/tmp/rehydrate-lib",
+    lib = create_library_with_root(
+        db,
+        "rehydrate-lib",
+        "/tmp/rehydrate-lib",
         parse_reading_lists=True,
         parse_collections=False,
         parse_story_arcs=True,
     )
-    db.add(lib)
     db.commit()
 
     expected_summary = {"comics_scanned": 12, "reading_lists_restored": 3}
@@ -490,8 +486,7 @@ def test_run_metadata_rehydrate_job_failure_marks_failed(monkeypatch, db):
     manager = _manager()
     monkeypatch.setattr(sm, "SessionLocal", _session_local_factory(db))
 
-    lib = Library(name="rehydrate-fail", path="/tmp/rehydrate-fail")
-    db.add(lib)
+    lib = create_library_with_root(db, "rehydrate-fail", "/tmp/rehydrate-fail")
     db.commit()
 
     monkeypatch.setattr(

--- a/tests/services/test_scanner.py
+++ b/tests/services/test_scanner.py
@@ -4,17 +4,15 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.models.comic import Comic, Volume
-from app.models.library import Library
 from app.models.series import Series
 from app.services.scanner import LibraryScanner
 import app.services.scanner as scanner_module
+from tests.factories import create_comic, create_library_with_root
 
 
 def _build_scanner(db, tmp_path, *, name="scanner-lib"):
-    library = Library(name=name, path=str(tmp_path))
-    db.add(library)
+    library = create_library_with_root(db, name, str(tmp_path))
     db.commit()
-    db.refresh(library)
 
     scanner = LibraryScanner(library, db)
     scanner.reading_list_service.cleanup_empty_lists = MagicMock()
@@ -33,18 +31,21 @@ def test_scan_parallel_raises_when_library_path_missing(db, tmp_path):
 
 def test_cleanup_missing_files_deletes_and_commits(db, tmp_path):
     scanner, library = _build_scanner(db, tmp_path, name="scanner-cleanup-lib")
+    root = library.active_root
 
     series = Series(name="Cleanup Series", library_id=library.id)
     volume = Volume(series=series, volume_number=1)
     db.add_all([series, volume])
     db.flush()
 
-    keep = Comic(volume_id=volume.id, number="1", filename="keep.cbz", file_path=str(tmp_path / "keep.cbz"), page_count=10)
-    gone = Comic(volume_id=volume.id, number="2", filename="gone.cbz", file_path=str(tmp_path / "gone.cbz"), page_count=10)
-    db.add_all([keep, gone])
+    keep = create_comic(db, volume, root, "keep.cbz", number="1", filename="keep.cbz", page_count=10)
+    gone = create_comic(db, volume, root, "gone.cbz", number="2", filename="gone.cbz", page_count=10)
     db.commit()
 
-    deleted = scanner._cleanup_missing_files({str(tmp_path / "keep.cbz")}, {keep.file_path: keep, gone.file_path: gone})
+    deleted = scanner._cleanup_missing_files(
+        {(root.id, "keep.cbz")},
+        {(root.id, "keep.cbz"): keep, (root.id, "gone.cbz"): gone},
+    )
 
     assert deleted == 1
     assert db.get(Comic, gone.id) is None
@@ -79,20 +80,21 @@ def test_reconcile_sidecars_guard_paths(db, tmp_path):
     scanner, _ = _build_scanner(db, tmp_path, name="scanner-reconcile-lib")
 
     root_file = tmp_path / "root.cbz"
-    scanner._reconcile_sidecars(root_file, {})
+    scanner._reconcile_sidecars(root_file, None, str(tmp_path))
 
     nested = tmp_path / "Series" / "Issue" / "a.cbz"
     scanner.reconciled_folders.add(str(nested.parent))
-    scanner._reconcile_sidecars(nested, {})
+    scanner._reconcile_sidecars(nested, None, str(tmp_path))
 
     scanner.reconciled_folders.clear()
-    scanner._reconcile_sidecars(nested, {})
+    scanner._reconcile_sidecars(nested, None, str(tmp_path))
 
     assert str(nested.parent) not in scanner.reconciled_folders
 
 
 def test_reconcile_sidecars_updates_series_and_volume_once(db, tmp_path, monkeypatch):
     scanner, library = _build_scanner(db, tmp_path, name="scanner-reconcile-update-lib")
+    root = library.active_root
 
     series = Series(name="Recon Series", library_id=library.id, summary_override="old-series")
     volume = Volume(series=series, volume_number=1, summary_override="old-volume")
@@ -100,18 +102,19 @@ def test_reconcile_sidecars_updates_series_and_volume_once(db, tmp_path, monkeyp
         volume=volume,
         number="1",
         filename="a.cbz",
-        file_path=str(tmp_path / "Recon Series" / "Issue" / "a.cbz"),
+        library_root_id=root.id,
+        relative_path="Recon Series/Issue/a.cbz",
         page_count=10,
     )
     db.add_all([series, volume, comic])
     db.commit()
 
-    file_path = Path(comic.file_path)
+    file_path = Path(root.path) / "Recon Series" / "Issue" / "a.cbz"
 
     resolver = MagicMock(side_effect=["new-volume", "new-series"])
     monkeypatch.setattr(scanner, "_resolve_sidecar_from_parents", resolver)
 
-    scanner._reconcile_sidecars(file_path, {str(file_path): comic})
+    scanner._reconcile_sidecars(file_path, comic, root.path)
 
     assert volume.summary_override == "new-volume"
     assert series.summary_override == "new-series"
@@ -120,12 +123,13 @@ def test_reconcile_sidecars_updates_series_and_volume_once(db, tmp_path, monkeyp
     assert str(file_path.parent) in scanner.reconciled_folders
 
     resolver.reset_mock()
-    scanner._reconcile_sidecars(file_path, {str(file_path): comic})
+    scanner._reconcile_sidecars(file_path, comic, root.path)
     resolver.assert_not_called()
 
 
 def test_scan_parallel_clears_reconciliation_caches_each_run(db, tmp_path):
     scanner, library = _build_scanner(db, tmp_path, name="scanner-cache-reset-lib")
+    root = library.active_root
 
     comic_path = tmp_path / "Series" / "Issue" / "reset.cbz"
     comic_path.parent.mkdir(parents=True, exist_ok=True)
@@ -136,15 +140,13 @@ def test_scan_parallel_clears_reconciliation_caches_each_run(db, tmp_path):
     db.add_all([series, volume])
     db.flush()
 
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, root, "Series/Issue/reset.cbz",
         number="1",
         filename=comic_path.name,
-        file_path=str(comic_path),
         file_modified_at=comic_path.stat().st_mtime + 60,
         page_count=10,
     )
-    db.add(comic)
     db.commit()
 
     scanner.reconciled_folders.add("stale-folder")

--- a/tests/services/test_scanner_parallel.py
+++ b/tests/services/test_scanner_parallel.py
@@ -9,13 +9,23 @@ from sqlalchemy.orm import sessionmaker
 
 import app.services.scanner as scanner_module
 from app.database import Base
-from app.models import Collection, CollectionItem, Comic, Library, ReadingList, ReadingListItem
+from app.models import (
+    Collection,
+    CollectionItem,
+    Comic,
+    ReadingList,
+    ReadingListItem,
+    Series,
+    Volume,
+)
 from app.services.scanner import LibraryScanner
+from tests.factories import create_comic, create_library_with_root
 
 
 class DummyQuery:
-    def __init__(self, existing):
+    def __init__(self, existing, library_root):
         self._existing = existing
+        self._library_root = library_root
 
     def join(self, *_args, **_kwargs):
         return self
@@ -26,14 +36,18 @@ class DummyQuery:
     def all(self):
         return list(self._existing)
 
+    def first(self):
+        return self._library_root
+
 
 class DummyDB:
-    def __init__(self, existing):
+    def __init__(self, existing, library_root=None):
         self._existing = existing
+        self._library_root = library_root
         self.commit_calls = 0
 
     def query(self, *_args, **_kwargs):
-        return DummyQuery(self._existing)
+        return DummyQuery(self._existing, self._library_root)
 
     def commit(self):
         self.commit_calls += 1
@@ -168,13 +182,20 @@ def test_scan_parallel_orchestrates_pool_writer_and_summary(monkeypatch, tmp_pat
     changed = _create_file(library_path / "changed.cbz")
     _create_file(library_path / "new.cbz")
 
+    library_root = SimpleNamespace(id=1, path=str(library_path))
     existing = [
-        SimpleNamespace(file_path=str(unchanged), file_modified_at=unchanged.stat().st_mtime + 30),
-        SimpleNamespace(file_path=str(changed), file_modified_at=changed.stat().st_mtime - 30),
+        SimpleNamespace(
+            library_root_id=1, relative_path="unchanged.cbz",
+            file_modified_at=unchanged.stat().st_mtime + 30,
+        ),
+        SimpleNamespace(
+            library_root_id=1, relative_path="changed.cbz",
+            file_modified_at=changed.stat().st_mtime - 30,
+        ),
     ]
 
-    db = DummyDB(existing)
-    library = SimpleNamespace(path=str(library_path), name="Test", id=42, last_scanned=None)
+    db = DummyDB(existing, library_root=library_root)
+    library = SimpleNamespace(name="Test", id=42, last_scanned=None)
     scanner = LibraryScanner(library, db)
 
     scanner._reconcile_sidecars = lambda *_args, **_kwargs: None
@@ -221,12 +242,16 @@ def test_scan_parallel_no_tasks_skips_parallel_components(monkeypatch, tmp_path)
     library_path = tmp_path / "library"
     unchanged = _create_file(library_path / "only.cbz")
 
+    library_root = SimpleNamespace(id=1, path=str(library_path))
     existing = [
-        SimpleNamespace(file_path=str(unchanged), file_modified_at=unchanged.stat().st_mtime + 30),
+        SimpleNamespace(
+            library_root_id=1, relative_path="only.cbz",
+            file_modified_at=unchanged.stat().st_mtime + 30,
+        ),
     ]
 
-    db = DummyDB(existing)
-    library = SimpleNamespace(path=str(library_path), name="Test", id=7, last_scanned=None)
+    db = DummyDB(existing, library_root=library_root)
+    library = SimpleNamespace(name="Test", id=7, last_scanned=None)
     scanner = LibraryScanner(library, db)
 
     scanner._reconcile_sidecars = lambda *_args, **_kwargs: None
@@ -252,8 +277,9 @@ def test_scan_parallel_auto_worker_count_uses_half_cores(monkeypatch, tmp_path):
     library_path = tmp_path / "library"
     _create_file(library_path / "new.cbz")
 
-    db = DummyDB(existing=[])
-    library = SimpleNamespace(path=str(library_path), name="Test", id=99, last_scanned=None)
+    library_root = SimpleNamespace(id=1, path=str(library_path))
+    db = DummyDB(existing=[], library_root=library_root)
+    library = SimpleNamespace(name="Test", id=99, last_scanned=None)
     scanner = LibraryScanner(library, db)
 
     scanner._reconcile_sidecars = lambda *_args, **_kwargs: None
@@ -286,8 +312,9 @@ def test_scan_parallel_timeout_terminates_stuck_writer(monkeypatch, tmp_path):
     library_path = tmp_path / "library"
     _create_file(library_path / "new.cbz")
 
-    db = DummyDB(existing=[])
-    library = SimpleNamespace(path=str(library_path), name="Test", id=100, last_scanned=None)
+    library_root = SimpleNamespace(id=1, path=str(library_path))
+    db = DummyDB(existing=[], library_root=library_root)
+    library = SimpleNamespace(name="Test", id=100, last_scanned=None)
     scanner = LibraryScanner(library, db)
 
     scanner._reconcile_sidecars = lambda *_args, **_kwargs: None
@@ -327,8 +354,9 @@ def test_scan_parallel_pool_error_still_signals_and_joins_writer(monkeypatch, tm
     library_path = tmp_path / "library"
     _create_file(library_path / "new.cbz")
 
-    db = DummyDB(existing=[])
-    library = SimpleNamespace(path=str(library_path), name="Test", id=101, last_scanned=None)
+    library_root = SimpleNamespace(id=1, path=str(library_path))
+    db = DummyDB(existing=[], library_root=library_root)
+    library = SimpleNamespace(name="Test", id=101, last_scanned=None)
     scanner = LibraryScanner(library, db)
 
     scanner._reconcile_sidecars = lambda *_args, **_kwargs: None
@@ -365,8 +393,9 @@ def test_scan_parallel_requested_workers_capped_by_cpu_count(monkeypatch, tmp_pa
     library_path = tmp_path / "library"
     _create_file(library_path / "new.cbz")
 
-    db = DummyDB(existing=[])
-    library = SimpleNamespace(path=str(library_path), name="Test", id=102, last_scanned=None)
+    library_root = SimpleNamespace(id=1, path=str(library_path))
+    db = DummyDB(existing=[], library_root=library_root)
+    library = SimpleNamespace(name="Test", id=102, last_scanned=None)
     scanner = LibraryScanner(library, db)
 
     scanner._reconcile_sidecars = lambda *_args, **_kwargs: None
@@ -405,8 +434,9 @@ def test_scan_parallel_swallows_sentinel_put_error_during_failure_cleanup(monkey
     library_path = tmp_path / "library"
     _create_file(library_path / "new.cbz")
 
-    db = DummyDB(existing=[])
-    library = SimpleNamespace(path=str(library_path), name="Test", id=103, last_scanned=None)
+    library_root = SimpleNamespace(id=1, path=str(library_path))
+    db = DummyDB(existing=[], library_root=library_root)
+    library = SimpleNamespace(name="Test", id=103, last_scanned=None)
     scanner = LibraryScanner(library, db)
 
     scanner._reconcile_sidecars = lambda *_args, **_kwargs: None
@@ -446,9 +476,9 @@ def test_scan_parallel_passes_library_metadata_flags_to_writer(monkeypatch, tmp_
     library_path = tmp_path / "library"
     _create_file(library_path / "new.cbz")
 
-    db = DummyDB(existing=[])
+    library_root = SimpleNamespace(id=1, path=str(library_path))
+    db = DummyDB(existing=[], library_root=library_root)
     library = SimpleNamespace(
-        path=str(library_path),
         name="Flagged",
         id=104,
         last_scanned=None,
@@ -526,10 +556,8 @@ def test_scan_parallel_real_pool_and_writer_smoke(monkeypatch, tmp_path):
 
     db = SessionLocal()
     try:
-        library = Library(name="Parallel Smoke", path=str(library_path))
-        db.add(library)
+        library = create_library_with_root(db, "Parallel Smoke", str(library_path))
         db.commit()
-        db.refresh(library)
 
         scanner = LibraryScanner(library, db)
         result = scanner.scan_parallel(force=False, worker_limit=2)
@@ -552,4 +580,68 @@ def test_scan_parallel_real_pool_and_writer_smoke(monkeypatch, tmp_path):
         assert verify_db.query(ReadingListItem).filter(ReadingListItem.reading_list_id == reading_list.id).count() == 2
     finally:
         verify_db.close()
+        engine.dispose()
+
+
+def test_scan_parallel_self_heals_legacy_comic_missing_root_stamp(monkeypatch, tmp_path):
+    """
+    Confirms an existing comic whose file is unchanged still gets skipped (not
+    re-imported) once its identity is already correctly stamped -- the scanner's
+    matching purely by (library_root_id, relative_path) must find it without
+    ever routing it through the metadata writer.
+    """
+    library_path = tmp_path / "library"
+    library_path.mkdir(parents=True, exist_ok=True)
+    alpha_path = _create_file(library_path / "alpha.cbz")
+
+    db_path = tmp_path / "self-heal.db"
+    db_url = f"sqlite:///{db_path.as_posix()}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+
+    spawn_ctx = multiprocessing.get_context("spawn")
+    monkeypatch.setattr(scanner_module, "Queue", spawn_ctx.Queue)
+    monkeypatch.setattr(scanner_module.multiprocessing, "Process", spawn_ctx.Process)
+    monkeypatch.setattr(scanner_module.multiprocessing, "Pool", spawn_ctx.Pool)
+
+    engine = create_engine(
+        db_url,
+        connect_args={"check_same_thread": False, "timeout": 60},
+    )
+    SessionLocal = sessionmaker(autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    db = SessionLocal()
+    try:
+        library = create_library_with_root(db, "Self Heal", str(library_path))
+        root = library.active_root
+        db.commit()
+
+        series = Series(name="Self Heal Series", library_id=library.id)
+        volume = Volume(series=series, volume_number=1)
+        db.add_all([series, volume])
+        db.flush()
+
+        comic = create_comic(
+            db, volume, root, "alpha.cbz",
+            number="1",
+            filename="alpha.cbz",
+            file_modified_at=alpha_path.stat().st_mtime,
+            page_count=1,
+        )
+        db.commit()
+
+        scanner = LibraryScanner(library, db)
+        result = scanner.scan_parallel(force=False, worker_limit=1)
+
+        # Unchanged file -> never sent to the metadata writer.
+        assert result["imported"] == 0
+        assert result["updated"] == 0
+        assert result["skipped"] == 1
+        assert result["deleted"] == 0
+
+        db.refresh(comic)
+        assert comic.library_root_id == root.id
+        assert comic.relative_path == "alpha.cbz"
+    finally:
+        db.close()
         engine.dispose()

--- a/tests/services/test_search_service.py
+++ b/tests/services/test_search_service.py
@@ -6,41 +6,39 @@ from sqlalchemy import literal_column
 
 from app.models.comic import Comic, Volume
 from app.models.interactions import UserComicRating
-from app.models.library import Library
 from app.models.series import Series
 from app.models.user import User
 from app.schemas.search import SearchFilter, SearchRequest
 from app.services.search import SearchService
+from tests.factories import create_comic, create_library_with_root
 
 
 def _seed_search_graph(db):
-    library = Library(name="search-lib", path="/tmp/search-lib")
+    library = create_library_with_root(db, "search-lib", "/tmp/search-lib")
+    root = library.active_root
     series = Series(name="Search Series", library=library)
     volume = Volume(series=series, volume_number=1)
 
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
 
-    alpha = Comic(
-        volume_id=volume.id,
+    alpha = create_comic(
+        db, volume, root, "alpha.cbz",
         number="1",
         title="Alpha Dawn",
         year=2020,
         publisher="Marvel",
         filename="alpha.cbz",
-        file_path="/tmp/alpha.cbz",
     )
-    beta = Comic(
-        volume_id=volume.id,
+    beta = create_comic(
+        db, volume, root, "beta.cbz",
         number="2",
         title="Beta Night",
         year=2021,
         publisher="DC",
         filename="beta.cbz",
-        file_path="/tmp/beta.cbz",
     )
 
-    db.add_all([alpha, beta])
     db.commit()
 
     for obj in (library, series, volume, alpha, beta):

--- a/tests/services/test_sidecar_reconciliation.py
+++ b/tests/services/test_sidecar_reconciliation.py
@@ -2,10 +2,11 @@ import logging
 import os
 
 from app.models.comic import Comic, Volume
-from app.models.library import Library
 from app.models.series import Series
 from app.services.scanner import LibraryScanner
 from app.services.sidecar_service import SidecarService
+from app.core.path_utils import compute_relative_path
+from tests.factories import create_library_with_root
 
 
 def _write_dummy_comic(path):
@@ -13,12 +14,13 @@ def _write_dummy_comic(path):
     path.write_bytes(b"not-a-real-archive")
 
 
-def _create_existing_comic(db, volume_id, file_path, number):
+def _create_existing_comic(db, volume_id, root, file_path, number):
     mtime = os.path.getmtime(file_path)
     comic = Comic(
         volume_id=volume_id,
         filename=file_path.name,
-        file_path=str(file_path),
+        library_root_id=root.id,
+        relative_path=compute_relative_path(root.path, str(file_path)),
         file_modified_at=mtime + 60,  # Ensure scanner skips metadata extraction path
         file_size=file_path.stat().st_size,
         page_count=24,
@@ -31,9 +33,7 @@ def _create_existing_comic(db, volume_id, file_path, number):
 
 
 def _setup_library_series_volume(db, library_path):
-    library = Library(name="Test Library", path=str(library_path))
-    db.add(library)
-    db.flush()
+    library = create_library_with_root(db, "Test Library", str(library_path))
 
     series = Series(name="Hawk and Dove", library_id=library.id, summary_override="old-series")
     db.add(series)
@@ -64,7 +64,7 @@ def test_sidecar_reconcile_from_parent_folder_for_deep_file(db, tmp_path):
 
     comic_file = deep_path / "hawk-and-dove-03.cbz"
     _write_dummy_comic(comic_file)
-    _create_existing_comic(db, volume.id, comic_file, number=1)
+    _create_existing_comic(db, volume.id, library.active_root, comic_file, number=1)
     db.commit()
 
     scanner = LibraryScanner(library, db)
@@ -102,8 +102,8 @@ def test_sidecar_reconcile_logs_once_per_entity_when_multiple_subfolders(db, tmp
     comic_b = deep_path / "hawk-and-dove-03-b.cbz"
     _write_dummy_comic(comic_a)
     _write_dummy_comic(comic_b)
-    _create_existing_comic(db, volume.id, comic_a, number=1)
-    _create_existing_comic(db, volume.id, comic_b, number=2)
+    _create_existing_comic(db, volume.id, library.active_root, comic_a, number=1)
+    _create_existing_comic(db, volume.id, library.active_root, comic_b, number=2)
     db.commit()
 
     caplog.set_level(logging.INFO, logger="app.services.scanner")

--- a/tests/services/test_startup_diagnostics.py
+++ b/tests/services/test_startup_diagnostics.py
@@ -3,9 +3,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from app.models.comic import Comic, Volume
-from app.models.library import Library
 from app.models.series import Series
 from app.models.user import User
+from tests.factories import create_library_with_root
 from app.services.startup_diagnostics import (
     RUNTIME_MODE_CONTAINER,
     RUNTIME_MODE_LOCAL,
@@ -73,7 +73,8 @@ def test_log_startup_diagnostics_logs_populated_database_summary(db, caplog, tmp
         is_superuser=True,
         is_active=True,
     )
-    library = Library(name="Main Library", path="/comics/main")
+    library = create_library_with_root(db, "Main Library", "/comics/main")
+    root = library.active_root
     series = Series(name="Amazing Tales", library=library)
     volume = Volume(series=series, volume_number=1)
     comic = Comic(
@@ -81,10 +82,11 @@ def test_log_startup_diagnostics_logs_populated_database_summary(db, caplog, tmp
         number="1",
         title="Amazing Tales #1",
         filename="amazing-tales-1.cbz",
-        file_path="/comics/main/Amazing Tales #1.cbz",
+        library_root_id=root.id,
+        relative_path="Amazing Tales #1.cbz",
     )
 
-    db.add_all([user, library, series, volume, comic])
+    db.add_all([user, series, volume, comic])
     db.commit()
 
     db_path = tmp_path / "comics.db"
@@ -198,8 +200,7 @@ def test_build_support_snapshot_wraps_diagnostics_with_metadata():
 
 
 def test_collect_startup_diagnostics_marks_default_comics_root_as_container_runtime(db, tmp_path):
-    library = Library(name="Container Library", path="/comics/main")
-    db.add(library)
+    create_library_with_root(db, "Container Library", "/comics/main")
     db.commit()
 
     db_path = tmp_path / "comics.db"
@@ -214,8 +215,7 @@ def test_collect_startup_diagnostics_marks_default_comics_root_as_container_runt
 
 
 def test_collect_startup_diagnostics_marks_missing_default_comics_root_as_local_when_library_paths_are_local(db, tmp_path):
-    library = Library(name="Local Library", path="C:/Users/test/MyComics")
-    db.add(library)
+    create_library_with_root(db, "Local Library", "C:/Users/test/MyComics")
     db.commit()
 
     db_path = tmp_path / "comics.db"
@@ -233,10 +233,8 @@ def test_collect_startup_diagnostics_tracks_library_path_existence(db, tmp_path)
     existing_library_root = tmp_path / "Comics"
     existing_library_root.mkdir()
 
-    db.add_all([
-        Library(name="Existing", path=str(existing_library_root)),
-        Library(name="Missing", path=str(tmp_path / "DoesNotExist")),
-    ])
+    create_library_with_root(db, "Existing", str(existing_library_root))
+    create_library_with_root(db, "Missing", str(tmp_path / "DoesNotExist"))
     db.commit()
 
     db_path = tmp_path / "comics.db"

--- a/tests/services/test_statistics_service.py
+++ b/tests/services/test_statistics_service.py
@@ -3,29 +3,31 @@ from datetime import datetime, time, timedelta, timezone
 from app.models.activity_log import ActivityLog
 from app.models.comic import Comic, Volume
 from app.models.credits import ComicCredit, Person
-from app.models.library import Library
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
 from app.models.tags import Character, Genre
 from app.services.statistics import StatisticsService
+from tests.factories import create_library_with_root
 
 
 def _create_series_volume(db, prefix: str):
-    library = Library(name=f"{prefix}-lib", path=f"/tmp/{prefix}-lib")
+    library = create_library_with_root(db, f"{prefix}-lib", f"/tmp/{prefix}-lib")
     series = Series(name=f"{prefix}-series", library=library)
     volume = Volume(series=series, volume_number=1)
-    db.add_all([library, series, volume])
+    db.add_all([series, volume])
     db.flush()
     return series, volume
 
 
 def _create_comic(db, volume: Volume, slug: str, number: str, page_count: int, *, age_rating: str = "Teen"):
+    root = volume.series.library.active_root
     comic = Comic(
         volume_id=volume.id,
         number=number,
         title=f"{slug}-title",
         filename=f"{slug}.cbz",
-        file_path=f"/tmp/{slug}.cbz",
+        library_root_id=root.id,
+        relative_path=f"{slug}.cbz",
         page_count=page_count,
         publisher="Stat Pub",
         age_rating=age_rating,

--- a/tests/services/test_thumbnailer_service.py
+++ b/tests/services/test_thumbnailer_service.py
@@ -5,8 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from app.models.comic import Comic, Volume
-from app.models.library import Library
+from app.models.comic import Volume
 from app.models.series import Series
 from app.services.thumbnailer import (
     ThumbnailService,
@@ -15,6 +14,7 @@ from app.services.thumbnailer import (
     _thumbnail_writer,
 )
 import app.services.thumbnailer as thumbnailer_module
+from tests.factories import create_comic, create_library_with_root
 
 
 class _ReadQueue:
@@ -101,9 +101,7 @@ class _FakePool:
 
 
 def _seed_library_and_comics(db, tmp_path, *, lib_name="thumb-lib"):
-    lib = Library(name=lib_name, path=str(tmp_path / lib_name))
-    db.add(lib)
-    db.flush()
+    lib = create_library_with_root(db, lib_name, str(tmp_path / lib_name))
 
     series = Series(name=f"{lib_name}-series", library_id=lib.id)
     volume = Volume(series=series, volume_number=1)
@@ -114,25 +112,23 @@ def _seed_library_and_comics(db, tmp_path, *, lib_name="thumb-lib"):
 
 
 def test_apply_batch_updates_processed_and_reports_error_and_missing(db, tmp_path):
-    _lib, _series, volume = _seed_library_and_comics(db, tmp_path, lib_name="thumb-batch-lib")
+    lib, _series, volume = _seed_library_and_comics(db, tmp_path, lib_name="thumb-batch-lib")
+    root = lib.active_root
 
-    comic_with_palette = Comic(
-        volume_id=volume.id,
+    comic_with_palette = create_comic(
+        db, volume, root, "one.cbz",
         number="1",
         filename="one.cbz",
-        file_path=str(tmp_path / "one.cbz"),
         page_count=10,
         is_dirty=True,
     )
-    comic_no_palette = Comic(
-        volume_id=volume.id,
+    comic_no_palette = create_comic(
+        db, volume, root, "two.cbz",
         number="2",
         filename="two.cbz",
-        file_path=str(tmp_path / "two.cbz"),
         page_count=12,
         is_dirty=True,
     )
-    db.add_all([comic_with_palette, comic_no_palette])
     db.commit()
 
     outcomes = _apply_batch(
@@ -371,32 +367,30 @@ def test_get_target_comics_requires_library_and_filters_dirty(db, tmp_path):
 
     lib_a, _series_a, volume_a = _seed_library_and_comics(db, tmp_path, lib_name="target-lib-a")
     lib_b, _series_b, volume_b = _seed_library_and_comics(db, tmp_path, lib_name="target-lib-b")
+    root_a = lib_a.active_root
+    root_b = lib_b.active_root
 
-    dirty_a = Comic(
-        volume_id=volume_a.id,
+    dirty_a = create_comic(
+        db, volume_a, root_a, "dirty-a.cbz",
         number="1",
         filename="dirty-a.cbz",
-        file_path=str(tmp_path / "dirty-a.cbz"),
         page_count=10,
         is_dirty=True,
     )
-    clean_a = Comic(
-        volume_id=volume_a.id,
+    clean_a = create_comic(
+        db, volume_a, root_a, "clean-a.cbz",
         number="2",
         filename="clean-a.cbz",
-        file_path=str(tmp_path / "clean-a.cbz"),
         page_count=10,
         is_dirty=False,
     )
-    dirty_b = Comic(
-        volume_id=volume_b.id,
+    dirty_b = create_comic(
+        db, volume_b, root_b, "dirty-b.cbz",
         number="1",
         filename="dirty-b.cbz",
-        file_path=str(tmp_path / "dirty-b.cbz"),
         page_count=10,
         is_dirty=True,
     )
-    db.add_all([dirty_a, clean_a, dirty_b])
     db.commit()
 
     scoped_service = ThumbnailService(db, library_id=lib_a.id)
@@ -429,7 +423,7 @@ def test_process_missing_thumbnails_parallel_all_skipped_short_circuit(db, tmp_p
 
     skipped_comic = SimpleNamespace(
         id=1,
-        file_path=str(tmp_path / "comic.cbz"),
+        absolute_path=str(tmp_path / "comic.cbz"),
         thumbnail_path=str(thumb),
         color_primary="#111",
         is_dirty=False,
@@ -452,7 +446,7 @@ def test_process_missing_thumbnails_parallel_worker_limit_override(db, tmp_path,
 
     dirty = SimpleNamespace(
         id=5,
-        file_path=str(tmp_path / "dirty.cbz"),
+        absolute_path=str(tmp_path / "dirty.cbz"),
         thumbnail_path=None,
         color_primary=None,
         is_dirty=True,
@@ -477,15 +471,13 @@ def test_process_missing_thumbnails_parallel_worker_limit_override(db, tmp_path,
 
 def test_process_missing_thumbnails_parallel_auto_worker_count_for_series(db, tmp_path, monkeypatch):
     lib, series, volume = _seed_library_and_comics(db, tmp_path, lib_name="auto-worker-lib")
-    comic = Comic(
-        volume_id=volume.id,
+    comic = create_comic(
+        db, volume, lib.active_root, "auto.cbz",
         number="1",
         filename="auto.cbz",
-        file_path=str(tmp_path / "auto.cbz"),
         page_count=10,
         is_dirty=True,
     )
-    db.add(comic)
     db.commit()
 
     service = ThumbnailService(db, library_id=None)
@@ -512,7 +504,7 @@ def test_process_missing_thumbnails_parallel_respects_requested_worker_cap(db, t
 
     dirty = SimpleNamespace(
         id=9,
-        file_path=str(tmp_path / "dirty2.cbz"),
+        absolute_path=str(tmp_path / "dirty2.cbz"),
         thumbnail_path=None,
         color_primary=None,
         is_dirty=True,
@@ -541,7 +533,7 @@ def test_process_missing_thumbnails_parallel_timeout_terminates_stuck_writer(db,
 
     dirty = SimpleNamespace(
         id=11,
-        file_path=str(tmp_path / "stuck.cbz"),
+        absolute_path=str(tmp_path / "stuck.cbz"),
         thumbnail_path=None,
         color_primary=None,
         is_dirty=True,

--- a/tests/services/test_watcher_service.py
+++ b/tests/services/test_watcher_service.py
@@ -154,10 +154,11 @@ def test_refresh_watches_adds_and_removes_and_closes_session(monkeypatch):
     old_handler = MagicMock()
     inst.watches = {1: (old_watch, old_handler)}
 
-    lib = SimpleNamespace(id=2, path="/library/two")
+    lib = SimpleNamespace(id=2, active_root=SimpleNamespace(path="/library/two"))
 
     db = MagicMock()
     q = db.query.return_value
+    q.options.return_value = q
     q.filter.return_value = q
     q.all.return_value = [lib]
     monkeypatch.setattr(watcher, "SessionLocal", lambda: db)
@@ -189,8 +190,9 @@ def test_refresh_watches_keeps_existing_watch_without_reschedule(monkeypatch):
 
     db = MagicMock()
     q = db.query.return_value
+    q.options.return_value = q
     q.filter.return_value = q
-    q.all.return_value = [SimpleNamespace(id=9, path="/library/nine")]
+    q.all.return_value = [SimpleNamespace(id=9, active_root=SimpleNamespace(path="/library/nine"))]
 
     monkeypatch.setattr(watcher, "SessionLocal", lambda: db)
     monkeypatch.setattr(watcher, "get_cached_setting", lambda key, default: 600)
@@ -208,8 +210,9 @@ def test_refresh_watches_logs_schedule_errors(monkeypatch):
 
     db = MagicMock()
     q = db.query.return_value
+    q.options.return_value = q
     q.filter.return_value = q
-    q.all.return_value = [SimpleNamespace(id=12, path="/library/bad")]
+    q.all.return_value = [SimpleNamespace(id=12, active_root=SimpleNamespace(path="/library/bad"))]
 
     monkeypatch.setattr(watcher, "SessionLocal", lambda: db)
     monkeypatch.setattr(watcher, "get_cached_setting", lambda key, default: 10)


### PR DESCRIPTION

This PR completes the first phase of library-root identity work needed before safe library relocation and future multi-root library support.

Parker now treats a comic’s physical location as `(library_root_id, relative_path)` instead of a cached absolute `Comic.file_path`, and treats `LibraryRoot` as the physical storage root instead of `Library.path`.

Multi-root libraries and the actual relocation flow are intentionally not included in this changeset.


Previously, changing a library path could cause Parker to treat existing comics as deleted and then re-import the same files at the new absolute path. That broke continuity for user-attached state such as reading progress, bookmarks, Parker ratings, reading lists, stacks, and collections.

This PR establishes the durable root-relative identity model needed to preserve comic identity across future root relocation.

## Changes

- Finalized `LibraryRoot` as the physical storage root model.
- Made `Comic.library_root_id` and `Comic.relative_path` required.
- Added a unique index on `(library_root_id, relative_path)`.
- Removed legacy `Comic.file_path` and `Library.path` columns.
- Updated scanner matching and cleanup to use `(library_root_id, relative_path)`.
- Updated metadata writer dedupe/update behavior to use root-relative identity.
- Updated reader, comics API, reports, OPDS, thumbnailer, maintenance, Kavita migration, watcher, and startup diagnostics to resolve absolute paths from `LibraryRoot.path + Comic.relative_path`.
- Blocked direct library path edits until an explicit relocation flow exists.
- Made library creation atomic so a `Library` cannot be persisted without its active `LibraryRoot`.
- Improved path comparison helpers so matching works consistently across Windows/Linux path strings and root paths like `/` or `C:\`.
- Added explicit migration cleanup for unresolved comics and dependent rows, including batched deletes to avoid SQLite bind-parameter limits.
- Added ORM cascade relationships for `UserComicRating` and `ActivityLog` when comics are deleted through normal app paths.
- Added shared test factories for creating libraries, roots, and comics under the new required identity model.


## Migrations

This PR adds three migrations:

- `71464b56eb8a`: retries the original root-identity backfill using corrected OS-independent path matching.
- `7e3ba96ed6dc`: finalizes root identity by retrying matching, deleting unresolved comics and dependent rows, making identity columns non-null, and making `(library_root_id, relative_path)` unique.
- `9def8df8ed7c`: drops legacy `Comic.file_path` and `Library.path`.

## Upgrade Notes

If an admin previously changed a library folder path and did not rescan that library afterward, they should scan before upgrading.

During upgrade, comics that cannot be matched to their library root will be deleted. They can be re-imported on a later scan, but user-attached state for those comic rows will not carry over.

Users with NAS or mounted storage should make sure library paths are reachable before upgrading, since the migration cannot distinguish an unavailable mount from genuinely missing files.

## Out Of Scope in this PR

- Multi-root libraries.
- Library relocation UI/API.
- Root add/remove/disable lifecycle actions.
- Content-hash deduplication.
- Merging libraries.
- Root-level permissions.

## Validation

- Focused API/service/path test coverage around libraries, scanner, metadata writer, maintenance, reader, OPDS, and Kavita migration.
- Verified library creation rollback behavior when root creation fails.
- Verified normal maintenance cleanup deletes `UserComicRating` and `ActivityLog` rows when deleting missing comics.
- Verified migration cleanup against a scratch SQLite database with 1200 unresolved comics and dependent bookmark rows across delete-batch boundaries.
- Verified release note formatting and diff whitespace checks.

