### PR TITLE
Add non-mutating library relocation preview backend

### DIFF
--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from typing import List, Annotated, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import func, case
 from sqlalchemy.orm import selectinload
 from datetime import datetime, timezone
@@ -18,6 +18,11 @@ from app.models.comic import Comic, Volume
 from app.models.interactions import UserLibraryPin
 from app.models.reading_progress import ReadingProgress
 from app.services.scan_manager import scan_manager
+from app.services.library_relocation import (
+    DEFAULT_SAMPLE_LIMIT,
+    LibraryRelocationError,
+    preview_library_root_relocation,
+)
 from app.services.watcher import library_watcher
 from app.api.deps import PaginationParams, PaginatedResponse, SessionDep, CurrentUser, AdminUser, LibraryDep
 
@@ -481,6 +486,13 @@ class LibraryUpdate(BaseModel):
     parse_collections: Optional[bool] = None
     parse_story_arcs: Optional[bool] = None
 
+
+class LibraryRelocationPreviewRequest(BaseModel):
+    path: str
+    root_id: Optional[int] = None
+    sample_limit: int = Field(DEFAULT_SAMPLE_LIMIT, ge=0, le=100)
+
+
 @router.patch("/{library_id}", tags=["admin"], name="update")
 async def update_library(
         library_id: int,
@@ -558,6 +570,38 @@ async def update_library(
         response["rehydration"] = rehydration_result
 
     return response
+
+
+@router.post("/{library_id}/relocation/preview", tags=["admin"], name="relocation_preview")
+async def preview_library_relocation(
+        library_id: int,
+        preview_in: LibraryRelocationPreviewRequest,
+        db: SessionDep,
+        admin_user: AdminUser,
+):
+    """Preview a library root relocation without changing stored paths."""
+    library = (
+        db.query(Library)
+        .options(selectinload(Library.roots))
+        .filter(Library.id == library_id)
+        .first()
+    )
+    if not library:
+        raise HTTPException(status_code=404, detail="Library not found")
+
+    try:
+        preview = preview_library_root_relocation(
+            db,
+            library=library,
+            proposed_path=preview_in.path,
+            root_id=preview_in.root_id,
+            sample_limit=preview_in.sample_limit,
+        )
+    except LibraryRelocationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return preview.to_dict()
+
 
 @router.delete("/{library_id}", tags=["admin"], name="delete")
 async def delete_library(library_id: int,

--- a/app/services/library_relocation.py
+++ b/app/services/library_relocation.py
@@ -1,0 +1,230 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.core.path_utils import compute_relative_path, paths_overlap, resolve_absolute_path
+from app.models.comic import Comic
+from app.models.library import Library
+from app.models.library_root import LibraryRoot
+
+
+DEFAULT_SAMPLE_LIMIT = 10
+
+
+class LibraryRelocationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class RelocationPathSample:
+    relative_path: str
+    path: str
+
+    def to_dict(self) -> dict:
+        return {
+            "relative_path": self.relative_path,
+            "path": self.path,
+        }
+
+
+@dataclass(frozen=True)
+class LibraryRootRelocationPreview:
+    library_id: int
+    root_id: int
+    current_path: str
+    proposed_path: str
+    total_existing: int
+    total_scanned: int
+    matched_count: int
+    missing_count: int
+    new_count: int
+    matched_samples: list[RelocationPathSample]
+    missing_samples: list[RelocationPathSample]
+    new_samples: list[RelocationPathSample]
+
+    def to_dict(self) -> dict:
+        return {
+            "library_id": self.library_id,
+            "root_id": self.root_id,
+            "current_path": self.current_path,
+            "proposed_path": self.proposed_path,
+            "total_existing": self.total_existing,
+            "total_scanned": self.total_scanned,
+            "matched_count": self.matched_count,
+            "missing_count": self.missing_count,
+            "new_count": self.new_count,
+            "matched_samples": [sample.to_dict() for sample in self.matched_samples],
+            "missing_samples": [sample.to_dict() for sample in self.missing_samples],
+            "new_samples": [sample.to_dict() for sample in self.new_samples],
+        }
+
+
+def preview_library_root_relocation(
+    db: Session,
+    *,
+    library: Library,
+    proposed_path: str,
+    root_id: int | None = None,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+) -> LibraryRootRelocationPreview:
+    selected_root = _select_relocation_root(library, root_id)
+    resolved_proposed_path = _resolve_proposed_path(proposed_path)
+    resolved_proposed_path_str = str(resolved_proposed_path)
+    current_comparison_path = _comparison_path(selected_root.path)
+
+    if _paths_equal(current_comparison_path, resolved_proposed_path_str):
+        raise LibraryRelocationError("Relocation path must be different from the current root path")
+
+    if paths_overlap(current_comparison_path, resolved_proposed_path_str):
+        raise LibraryRelocationError("Relocation path overlaps with the current root path")
+
+    overlapping_root = _find_overlapping_root(
+        db,
+        resolved_proposed_path_str,
+        exclude_root_id=selected_root.id,
+    )
+    if overlapping_root is not None:
+        library_name = overlapping_root.library.name if overlapping_root.library else "unknown"
+        raise LibraryRelocationError(
+            f"Relocation path overlaps with existing root for library '{library_name}'"
+        )
+
+    sample_limit = max(0, sample_limit)
+    comics = (
+        db.query(Comic)
+        .filter(Comic.library_root_id == selected_root.id)
+        .order_by(Comic.relative_path)
+        .all()
+    )
+    existing_relative_paths = {comic.relative_path for comic in comics}
+
+    matched_count = 0
+    missing_count = 0
+    matched_samples: list[RelocationPathSample] = []
+    missing_samples: list[RelocationPathSample] = []
+
+    for comic in comics:
+        expected_path = resolve_absolute_path(resolved_proposed_path_str, comic.relative_path)
+        if Path(expected_path).is_file():
+            matched_count += 1
+            _append_sample(matched_samples, comic.relative_path, expected_path, sample_limit)
+        else:
+            missing_count += 1
+            _append_sample(missing_samples, comic.relative_path, expected_path, sample_limit)
+
+    scanned_count = 0
+    new_count = 0
+    new_samples: list[RelocationPathSample] = []
+    supported_extensions = {extension.lower() for extension in settings.supported_extensions}
+
+    try:
+        scanned_files = sorted(resolved_proposed_path.rglob("*"), key=lambda path: str(path).lower())
+        for scanned_file in scanned_files:
+            if not scanned_file.is_file():
+                continue
+            if scanned_file.suffix.lower() not in supported_extensions:
+                continue
+
+            relative_path = compute_relative_path(resolved_proposed_path_str, str(scanned_file))
+            if relative_path is None:
+                continue
+
+            scanned_count += 1
+            if relative_path in existing_relative_paths:
+                continue
+
+            new_count += 1
+            _append_sample(new_samples, relative_path, str(scanned_file), sample_limit)
+    except OSError as exc:
+        raise LibraryRelocationError(f"Relocation path cannot be scanned: {exc}") from exc
+
+    return LibraryRootRelocationPreview(
+        library_id=library.id,
+        root_id=selected_root.id,
+        current_path=selected_root.path,
+        proposed_path=resolved_proposed_path_str,
+        total_existing=len(comics),
+        total_scanned=scanned_count,
+        matched_count=matched_count,
+        missing_count=missing_count,
+        new_count=new_count,
+        matched_samples=matched_samples,
+        missing_samples=missing_samples,
+        new_samples=new_samples,
+    )
+
+
+def _select_relocation_root(library: Library, root_id: int | None) -> LibraryRoot:
+    if root_id is not None:
+        root = next((candidate for candidate in library.roots if candidate.id == root_id), None)
+        if root is None:
+            raise LibraryRelocationError("Library root not found")
+        return root
+
+    active_roots = [root for root in library.roots if root.is_active]
+    if not active_roots:
+        raise LibraryRelocationError("Library has no active root to relocate")
+    if len(active_roots) > 1:
+        raise LibraryRelocationError("root_id is required when a library has multiple active roots")
+
+    return active_roots[0]
+
+
+def _resolve_proposed_path(proposed_path: str) -> Path:
+    if not proposed_path.strip():
+        raise LibraryRelocationError("Relocation path is required")
+
+    try:
+        resolved_path = Path(proposed_path).expanduser().resolve(strict=True)
+    except OSError as exc:
+        raise LibraryRelocationError("Relocation path must be an existing directory") from exc
+
+    if not resolved_path.is_dir():
+        raise LibraryRelocationError("Relocation path must be an existing directory")
+
+    return resolved_path
+
+
+def _find_overlapping_root(
+    db: Session,
+    candidate_path: str,
+    *,
+    exclude_root_id: int | None = None,
+) -> LibraryRoot | None:
+    query = db.query(LibraryRoot)
+    if exclude_root_id is not None:
+        query = query.filter(LibraryRoot.id != exclude_root_id)
+
+    for root in query.all():
+        if paths_overlap(candidate_path, _comparison_path(root.path)):
+            return root
+
+    return None
+
+
+def _comparison_path(path: str) -> str:
+    try:
+        return str(Path(path).expanduser().resolve(strict=True))
+    except OSError:
+        return path
+
+
+def _paths_equal(first_path: str, second_path: str) -> bool:
+    return (
+        compute_relative_path(first_path, second_path) == ""
+        and compute_relative_path(second_path, first_path) == ""
+    )
+
+
+def _append_sample(
+    samples: list[RelocationPathSample],
+    relative_path: str,
+    path: str,
+    sample_limit: int,
+) -> None:
+    if len(samples) >= sample_limit:
+        return
+
+    samples.append(RelocationPathSample(relative_path=relative_path, path=path))

--- a/docs/library-relocation-scope.md
+++ b/docs/library-relocation-scope.md
@@ -1,6 +1,6 @@
 # Library Relocation Scope
 
-Status: Phase 1 (schema + guardrail) and the full Compatibility Field Removal Plan are implemented; relocation flow itself not yet built
+Status: Phase 1 (schema + guardrail), the full Compatibility Field Removal Plan, and the relocation preview backend are implemented; confirmation/UI are not yet built
 
 This note captures a future enhancement for safely changing the filesystem path of an existing Parker library without losing comic identity.
 
@@ -12,6 +12,12 @@ Phase 1 (schema + guardrail) is done:
 - Migration backfills one root per existing library and each comic's relative path (see `app/core/path_utils.py:compute_relative_path`).
 - `create_library` now creates a matching `LibraryRoot`.
 - Editing a library's path is hard-blocked in the API and admin UI (400 on change) until the relocation flow below exists.
+
+The relocation preview backend is done:
+
+- Admin `POST /api/libraries/{library_id}/relocation/preview` computes matched, missing, and new archive counts without mutating stored root paths.
+- Preview targets a `LibraryRoot`; `root_id` is optional only when the library has one active root, and becomes required when multiple active roots would make the target ambiguous.
+- Path overlap validation is root-level and rejects overlap with the current root or any other root, including roots in the same library.
 
 The full Compatibility Field Removal Plan (all four stages) is also done, landing together in one release (`0.1.25`) rather than staged over time — see the plan section below for why:
 
@@ -27,7 +33,7 @@ That behavior is understandable from the current data model, but it is risky bec
 
 ## Why This Exists
 
-Parker currently stores physical file identity primarily as `Comic.file_path`.
+Parker previously stored physical file identity primarily as `Comic.file_path`.
 
 If a library moves from one server-visible path to another, the same archive can look like a completely different comic:
 
@@ -36,7 +42,7 @@ If a library moves from one server-visible path to another, the same archive can
 
 The comic content and logical position are the same, but the stored absolute path changed.
 
-Today, changing `Library.path` does not rewrite existing comic paths. During the next scan, `LibraryScanner` scans the new root, builds a set of discovered paths, and removes existing comics whose old paths were not seen. The scanner then imports matching files at their new paths as new rows.
+Before path edits were blocked, changing `Library.path` did not rewrite existing comic paths. During the next scan, `LibraryScanner` scanned the new root, built a set of discovered paths, and removed existing comics whose old paths were not seen. The scanner then imported matching files at their new paths as new rows.
 
 That can break continuity for:
 
@@ -67,7 +73,7 @@ Introduce a durable root record and store comic paths relative to that root:
 - `LibraryRoot` represents a physical filesystem root
 - `Comic.library_root_id` points to the physical root that contains the file
 - `Comic.relative_path` stores the path under that root
-- `Comic.file_path` may initially remain as a cached absolute path for compatibility
+- `Comic.absolute_path` reconstructs the absolute path from the root path and relative path when needed
 
 This allows Parker to preserve `Comic.id` when only the root path changes.
 
@@ -121,7 +127,7 @@ A safe relocation should look like this:
    - new files found under the new root
    - conflicts or duplicate candidates
 5. Admin confirms.
-6. Parker updates the root path and cached `Comic.file_path` values for matched comics.
+6. Parker updates the selected root path.
 7. Parker queues or recommends a scan.
 
 Important rule:
@@ -165,7 +171,7 @@ Cleanup should operate within the relevant root identity, not by comparing old a
 3. **Read-path cutover.** Every reader of `file_path`/`Library.path` — the comic reader, thumbnail generation, comics/reports API responses, OPDS, the Kavita migration tool, the library API, watcher, and startup diagnostics — reconstructs the absolute path on demand via `Comic.absolute_path` / `Library.active_root`, backed by `resolve_absolute_path` in `app/core/path_utils.py`.
 4. **Column removal.** Migration `9def8df8ed7c` dropped `Comic.file_path` and `Library.path` for good.
 
-Stage 1 remains a prerequisite for the relocation flow below to be considered safe — that flow is still unbuilt.
+Stage 1 remains a prerequisite for the relocation flow below to be considered safe. The non-mutating preview backend is now built; confirmation and UI are still unbuilt.
 
 ## Admin UI Guardrails
 

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -71,6 +71,11 @@ def _create_library_series_fixture(db, *, lib_name: str):
     }
 
 
+def _write_comic_file(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"comic")
+
+
 def test_admin_can_create_library(admin_client, db):
     payload = {"name": "Marvel Comics", "path": "/data/marvel"}
 
@@ -574,6 +579,119 @@ def test_update_library_allows_unchanged_path(admin_client, db):
     assert response.status_code == 200
     assert response.json()["name"] == "Renamed"
     assert response.json()["path"] == "/tmp/original"
+
+
+def test_preview_library_relocation_returns_counts_without_updating_root(admin_client, db, tmp_path):
+    current_root_path = tmp_path / "api-current"
+    proposed_root_path = tmp_path / "api-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "API Relocation Preview", str(current_root_path))
+    root = library.active_root
+    series = Series(name="API Preview Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    create_comic(db, volume, root, "Alpha/one.cbz", filename="one.cbz")
+    create_comic(db, volume, root, "Beta/two.cbz", filename="two.cbz")
+    db.commit()
+
+    library_id = library.id
+    root_id = root.id
+    _write_comic_file(proposed_root_path / "Alpha" / "one.cbz")
+    _write_comic_file(proposed_root_path / "Extra" / "three.cbz")
+
+    response = admin_client.post(
+        f"/api/libraries/{library_id}/relocation/preview",
+        json={"path": str(proposed_root_path)},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["library_id"] == library_id
+    assert payload["root_id"] == root_id
+    assert payload["current_path"] == str(current_root_path)
+    assert payload["proposed_path"] == str(proposed_root_path.resolve())
+    assert payload["total_existing"] == 2
+    assert payload["total_scanned"] == 2
+    assert payload["matched_count"] == 1
+    assert payload["missing_count"] == 1
+    assert payload["new_count"] == 1
+    assert payload["matched_samples"][0]["relative_path"] == "Alpha/one.cbz"
+    assert payload["missing_samples"][0]["relative_path"] == "Beta/two.cbz"
+    assert payload["new_samples"][0]["relative_path"] == "Extra/three.cbz"
+
+    db.refresh(root)
+    assert root.path == str(current_root_path)
+
+
+def test_preview_library_relocation_requires_root_id_when_multiple_roots_are_active(admin_client, db, tmp_path):
+    first_root_path = tmp_path / "api-first"
+    second_root_path = tmp_path / "api-second"
+    proposed_root_path = tmp_path / "api-proposed"
+    first_root_path.mkdir()
+    second_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "API Multi Root Preview", str(first_root_path))
+    second_root = LibraryRoot(library_id=library.id, path=str(second_root_path), is_active=True)
+    db.add(second_root)
+    db.commit()
+
+    default_response = admin_client.post(
+        f"/api/libraries/{library.id}/relocation/preview",
+        json={"path": str(proposed_root_path)},
+    )
+
+    assert default_response.status_code == 400
+    assert default_response.json() == {
+        "detail": "root_id is required when a library has multiple active roots"
+    }
+
+    explicit_response = admin_client.post(
+        f"/api/libraries/{library.id}/relocation/preview",
+        json={"path": str(proposed_root_path), "root_id": second_root.id},
+    )
+
+    assert explicit_response.status_code == 200
+    assert explicit_response.json()["root_id"] == second_root.id
+
+
+def test_preview_library_relocation_rejects_sibling_root_overlap(admin_client, db, tmp_path):
+    first_root_path = tmp_path / "api-sibling-first"
+    second_root_path = tmp_path / "api-sibling-second"
+    first_root_path.mkdir()
+    second_root_path.mkdir()
+
+    library = create_library_with_root(db, "API Sibling Preview", str(first_root_path))
+    first_root_id = library.active_root.id
+    db.add(LibraryRoot(library_id=library.id, path=str(second_root_path), is_active=True))
+    db.commit()
+
+    response = admin_client.post(
+        f"/api/libraries/{library.id}/relocation/preview",
+        json={"path": str(second_root_path), "root_id": first_root_id},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Relocation path overlaps with existing root for library 'API Sibling Preview'"
+    }
+
+
+def test_preview_library_relocation_returns_404_for_missing_library(admin_client, tmp_path):
+    proposed_root_path = tmp_path / "missing-api-proposed"
+    proposed_root_path.mkdir()
+
+    response = admin_client.post(
+        "/api/libraries/999999/relocation/preview",
+        json={"path": str(proposed_root_path)},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Library not found"}
 
 
 def test_update_library_returns_404_for_missing_library(admin_client):

--- a/tests/services/test_library_relocation.py
+++ b/tests/services/test_library_relocation.py
@@ -1,0 +1,166 @@
+import pytest
+
+from app.models.comic import Volume
+from app.models.library_root import LibraryRoot
+from app.models.series import Series
+from app.services.library_relocation import (
+    LibraryRelocationError,
+    preview_library_root_relocation,
+)
+from tests.factories import create_comic, create_library_with_root
+
+
+def _create_volume(db, library):
+    series = Series(name=f"{library.name} Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+    return volume
+
+
+def _write_file(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"comic")
+
+
+def test_preview_library_root_relocation_counts_matched_missing_and_new_files(db, tmp_path):
+    current_root_path = tmp_path / "current"
+    proposed_root_path = tmp_path / "proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "Relocation Preview", str(current_root_path))
+    root = library.active_root
+    volume = _create_volume(db, library)
+
+    create_comic(db, volume, root, "Alpha/one.cbz", filename="one.cbz")
+    create_comic(db, volume, root, "Beta/two.cbz", filename="two.cbz")
+    create_comic(db, volume, root, "Gamma/three.cbr", filename="three.cbr")
+    db.commit()
+
+    _write_file(proposed_root_path / "Alpha" / "one.cbz")
+    _write_file(proposed_root_path / "Gamma" / "three.cbr")
+    _write_file(proposed_root_path / "New" / "four.cbz")
+    _write_file(proposed_root_path / "ignored.txt")
+
+    preview = preview_library_root_relocation(
+        db,
+        library=library,
+        proposed_path=str(proposed_root_path),
+    )
+
+    assert preview.library_id == library.id
+    assert preview.root_id == root.id
+    assert preview.current_path == str(current_root_path)
+    assert preview.proposed_path == str(proposed_root_path.resolve())
+    assert preview.total_existing == 3
+    assert preview.total_scanned == 3
+    assert preview.matched_count == 2
+    assert preview.missing_count == 1
+    assert preview.new_count == 1
+    assert [sample.relative_path for sample in preview.matched_samples] == [
+        "Alpha/one.cbz",
+        "Gamma/three.cbr",
+    ]
+    assert [sample.relative_path for sample in preview.missing_samples] == ["Beta/two.cbz"]
+    assert [sample.relative_path for sample in preview.new_samples] == ["New/four.cbz"]
+
+    db.refresh(root)
+    assert root.path == str(current_root_path)
+
+
+def test_preview_library_root_relocation_requires_root_id_for_multiple_active_roots(db, tmp_path):
+    first_root_path = tmp_path / "first"
+    second_root_path = tmp_path / "second"
+    proposed_root_path = tmp_path / "proposed"
+    first_root_path.mkdir()
+    second_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "Multi Root Preview", str(first_root_path))
+    db.add(LibraryRoot(library_id=library.id, path=str(second_root_path), is_active=True))
+    db.commit()
+
+    with pytest.raises(LibraryRelocationError, match="root_id is required"):
+        preview_library_root_relocation(
+            db,
+            library=library,
+            proposed_path=str(proposed_root_path),
+        )
+
+
+def test_preview_library_root_relocation_accepts_explicit_root_id(db, tmp_path):
+    first_root_path = tmp_path / "first"
+    second_root_path = tmp_path / "second"
+    proposed_root_path = tmp_path / "proposed"
+    first_root_path.mkdir()
+    second_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "Explicit Root Preview", str(first_root_path))
+    second_root = LibraryRoot(library_id=library.id, path=str(second_root_path), is_active=True)
+    db.add(second_root)
+    db.commit()
+
+    preview = preview_library_root_relocation(
+        db,
+        library=library,
+        root_id=second_root.id,
+        proposed_path=str(proposed_root_path),
+    )
+
+    assert preview.root_id == second_root.id
+    assert preview.current_path == str(second_root_path)
+
+
+def test_preview_library_root_relocation_rejects_overlap_with_sibling_root(db, tmp_path):
+    first_root_path = tmp_path / "first"
+    second_root_path = tmp_path / "second"
+    first_root_path.mkdir()
+    second_root_path.mkdir()
+
+    library = create_library_with_root(db, "Sibling Root Preview", str(first_root_path))
+    first_root_id = library.active_root.id
+    second_root = LibraryRoot(library_id=library.id, path=str(second_root_path), is_active=True)
+    db.add(second_root)
+    db.commit()
+
+    with pytest.raises(LibraryRelocationError, match="overlaps with existing root"):
+        preview_library_root_relocation(
+            db,
+            library=library,
+            root_id=first_root_id,
+            proposed_path=str(second_root_path),
+        )
+
+
+def test_preview_library_root_relocation_rejects_current_root_child(db, tmp_path):
+    current_root_path = tmp_path / "current"
+    proposed_root_path = current_root_path / "nested"
+    proposed_root_path.mkdir(parents=True)
+
+    library = create_library_with_root(db, "Nested Root Preview", str(current_root_path))
+    db.commit()
+
+    with pytest.raises(LibraryRelocationError, match="current root path"):
+        preview_library_root_relocation(
+            db,
+            library=library,
+            proposed_path=str(proposed_root_path),
+        )
+
+
+def test_preview_library_root_relocation_compares_resolved_current_root_path(db, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    current_root_path = tmp_path / "relative-current"
+    current_root_path.mkdir()
+
+    library = create_library_with_root(db, "Relative Current Root Preview", "relative-current")
+    db.commit()
+
+    with pytest.raises(LibraryRelocationError, match="different from the current root path"):
+        preview_library_root_relocation(
+            db,
+            library=library,
+            proposed_path=str(current_root_path.resolve()),
+        )


### PR DESCRIPTION

This PR adds the first backend slice of the library relocation flow: an admin-only preview endpoint that evaluates moving a library root to a new filesystem path without changing any stored data.

The preview compares existing comics by `LibraryRoot` + `Comic.relative_path`, then reports which files would match at the proposed root, which existing comics would be missing, and which supported archive files at the proposed root would be new imports.

**Added**
- New relocation preview service in `app/services/library_relocation.py`.
- Admin endpoint:
  - `POST /api/libraries/{library_id}/relocation/preview`
- Preview request fields:
  - `path`
  - optional `root_id`
  - optional bounded `sample_limit`
- Preview response includes:
  - `library_id`
  - `root_id`
  - `current_path`
  - `proposed_path`
  - `total_existing`
  - `total_scanned`
  - `matched_count`
  - `missing_count`
  - `new_count`
  - matched/missing/new path samples

**Changed**
- Relocation preview is root-oriented rather than library-path-oriented.
- `root_id` defaults only when the library has one active root.
- If multiple active roots exist, preview requires explicit `root_id`.
- Path overlap validation now checks at the `LibraryRoot` level for relocation preview, excluding only the selected root.
- Updated relocation scope docs to mark the preview backend as implemented and remove stale references to updating cached `Comic.file_path`.

**Multi-Root Readiness**
This intentionally avoids encoding “library has exactly one active root” as a long-term invariant.

For future multi-root support:
- relocation targets a specific `LibraryRoot`
- same-library sibling roots are protected
- proposed paths cannot overlap the selected root, another root in the same library, or a root in another library
- confirmation can reuse the same preview/validation path so preview and write behavior stay aligned

**Validation**
Focused test run:

```powershell
.\.venv\Scripts\python.exe -m pytest tests\services\test_library_relocation.py tests\api\test_libraries.py
```

Result:

```text
43 passed
```

**Notes**
This PR is intentionally non-mutating. It does not update `LibraryRoot.path`, queue scans, or change the admin UI. Those are left for the next backend confirmation PR and subsequent UI wiring.

