### PR TITLE
Add the admin UI for library root relocation.

### DIFF
--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -96,6 +96,10 @@ def _resolve_library_browser_path(path: Optional[str] = None) -> tuple[FsPath, F
     return root, current
 
 
+def _browser_path(path: FsPath) -> str:
+    return path.as_posix()
+
+
 @router.get("/", name="list")
 async def list_libraries(db: SessionDep,
                          current_user: CurrentUser,
@@ -200,7 +204,7 @@ async def browse_library_paths(admin_user: AdminUser, path: Optional[str] = Quer
 
         entries.append({
             "name": child.name,
-            "path": str(resolved_child),
+            "path": _browser_path(resolved_child),
         })
 
     parent = None
@@ -208,13 +212,13 @@ async def browse_library_paths(admin_user: AdminUser, path: Optional[str] = Quer
         parent_path = current.parent.resolve()
         try:
             parent_path.relative_to(root)
-            parent = str(parent_path)
+            parent = _browser_path(parent_path)
         except ValueError:
-            parent = str(root)
+            parent = _browser_path(root)
 
     return {
-        "root": str(root),
-        "current": str(current),
+        "root": _browser_path(root),
+        "current": _browser_path(current),
         "parent": parent,
         "entries": entries,
     }

--- a/app/services/library_relocation.py
+++ b/app/services/library_relocation.py
@@ -11,6 +11,10 @@ from app.models.library_root import LibraryRoot
 
 
 DEFAULT_SAMPLE_LIMIT = 10
+NO_RELOCATION_MATCHES_MESSAGE = (
+    "No existing comics were found at the new path. Move the library files first, "
+    "preserving the same folder structure, then preview again."
+)
 
 
 class LibraryRelocationError(ValueError):
@@ -44,6 +48,17 @@ class LibraryRootRelocationPreview:
     missing_samples: list[RelocationPathSample]
     new_samples: list[RelocationPathSample]
 
+    @property
+    def confirm_blocked(self) -> bool:
+        return self.total_existing > 0 and self.matched_count == 0
+
+    @property
+    def confirm_blocked_reason(self) -> str | None:
+        if not self.confirm_blocked:
+            return None
+
+        return NO_RELOCATION_MATCHES_MESSAGE
+
     def to_dict(self) -> dict:
         return {
             "library_id": self.library_id,
@@ -58,6 +73,8 @@ class LibraryRootRelocationPreview:
             "matched_samples": [sample.to_dict() for sample in self.matched_samples],
             "missing_samples": [sample.to_dict() for sample in self.missing_samples],
             "new_samples": [sample.to_dict() for sample in self.new_samples],
+            "confirm_blocked": self.confirm_blocked,
+            "confirm_blocked_reason": self.confirm_blocked_reason,
         }
 
 
@@ -87,7 +104,7 @@ def preview_library_root_relocation(
 ) -> LibraryRootRelocationPreview:
     selected_root = _select_relocation_root(library, root_id)
     resolved_proposed_path = _resolve_proposed_path(proposed_path)
-    resolved_proposed_path_str = str(resolved_proposed_path)
+    resolved_proposed_path_str = _path_for_storage(resolved_proposed_path)
     current_comparison_path = _comparison_path(selected_root.path)
 
     if _paths_equal(current_comparison_path, resolved_proposed_path_str):
@@ -152,7 +169,7 @@ def preview_library_root_relocation(
                 continue
 
             new_count += 1
-            _append_sample(new_samples, relative_path, str(scanned_file), sample_limit)
+            _append_sample(new_samples, relative_path, scanned_file.as_posix(), sample_limit)
     except OSError as exc:
         raise LibraryRelocationError(f"Relocation path cannot be scanned: {exc}") from exc
 
@@ -187,6 +204,8 @@ def confirm_library_root_relocation(
         root_id=root_id,
         sample_limit=sample_limit,
     )
+    if preview.confirm_blocked:
+        raise LibraryRelocationError(NO_RELOCATION_MATCHES_MESSAGE)
 
     selected_root = _select_relocation_root(library, preview.root_id)
     selected_root.path = preview.proposed_path
@@ -254,9 +273,9 @@ def _find_overlapping_root(
 
 def _comparison_path(path: str) -> str:
     try:
-        return str(Path(path).expanduser().resolve(strict=True))
+        return _path_for_storage(Path(path).expanduser().resolve(strict=True))
     except OSError:
-        return path
+        return path.replace("\\", "/")
 
 
 def _scan_reasons(preview: LibraryRootRelocationPreview) -> list[str]:
@@ -268,6 +287,10 @@ def _scan_reasons(preview: LibraryRootRelocationPreview) -> list[str]:
         reasons.append("Import new archive files found at the new root")
 
     return reasons
+
+
+def _path_for_storage(path: Path) -> str:
+    return path.as_posix()
 
 
 def _paths_equal(first_path: str, second_path: str) -> bool:

--- a/app/templates/admin/libraries.html
+++ b/app/templates/admin/libraries.html
@@ -56,6 +56,14 @@
 
                             <div class="h-4 w-px bg-gray-700 mx-1"></div>
 
+                            <button
+                                x-on:click="openRelocateModal(lib)"
+                                class="text-amber-300 hover:text-white text-sm font-medium px-2 disabled:opacity-30 disabled:cursor-not-allowed"
+                                :disabled="lib.is_scanning"
+                                title="Relocate library path"
+                            >
+                                Relocate
+                            </button>
                             <button x-on:click="openEditModal(lib)" class="text-blue-400 hover:text-white text-sm font-medium px-2">Edit</button>
                             <button x-on:click="deleteLibrary(lib)" class="text-red-400 hover:text-white text-sm font-medium px-2">Delete</button>
                         </td>
@@ -206,6 +214,217 @@
         </div>
     </div>
 
+    <div x-show="showRelocationModal" class="fixed inset-0 bg-black/80 flex items-center justify-center z-50 px-4" style="display: none;" x-transition.opacity>
+        <div class="bg-gray-800 p-6 rounded-lg w-full max-w-3xl max-h-[90vh] overflow-y-auto border border-gray-700 shadow-2xl" x-on:click.away="closeRelocationModal()">
+            <div class="flex items-start justify-between gap-4 mb-5">
+                <div class="min-w-0">
+                    <h2 class="text-xl font-bold text-white">Relocate Library Path</h2>
+                    <p class="text-sm text-gray-400 truncate" x-text="relocation.library?.name"></p>
+                </div>
+                <button
+                    type="button"
+                    x-on:click="closeRelocationModal()"
+                    class="text-gray-500 hover:text-white text-sm"
+                >
+                    Close
+                </button>
+            </div>
+
+            <div class="space-y-5">
+                <div>
+                    <label class="block text-sm text-gray-400 mb-1">Current Path</label>
+                    <div class="w-full bg-gray-900 border border-gray-700 rounded px-3 py-2 text-sm text-gray-300 font-mono break-all" x-text="relocation.library?.path"></div>
+                </div>
+
+                <div>
+                    <label class="block text-sm text-gray-400 mb-1">New Path</label>
+                    <div class="flex gap-2">
+                        <input
+                            type="text"
+                            x-model="relocation.path"
+                            x-on:input="resetRelocationPreview()"
+                            class="flex-1 bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none"
+                            placeholder="/comics/relocated"
+                            :disabled="relocation.completed"
+                        >
+                        <button
+                            type="button"
+                            x-on:click="openDirectoryBrowser('relocation')"
+                            class="bg-gray-700 hover:bg-gray-600 text-white px-3 py-2 rounded transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                            :disabled="relocation.completed"
+                        >
+                            Browse
+                        </button>
+                    </div>
+                </div>
+
+                <div x-show="pathBrowser.open && pathBrowser.target === 'relocation'" class="border border-gray-700 rounded bg-gray-900 overflow-hidden" style="display: none;">
+                    <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-gray-700">
+                        <div class="min-w-0">
+                            <p class="text-[10px] uppercase tracking-wide text-gray-500">Browsing</p>
+                            <p class="text-xs text-gray-300 font-mono truncate" x-text="pathBrowser.current || 'Loading...'"></p>
+                        </div>
+                        <button
+                            type="button"
+                            x-on:click="closeDirectoryBrowser()"
+                            class="text-gray-500 hover:text-white text-sm"
+                        >
+                            Close
+                        </button>
+                    </div>
+
+                    <div x-show="pathBrowser.error" class="px-3 py-3 text-sm text-red-300 bg-red-950/30 border-b border-red-900/50" x-text="pathBrowser.error"></div>
+                    <div x-show="pathBrowser.notice" class="px-3 py-3 text-sm text-amber-200 bg-amber-950/30 border-b border-amber-900/50" x-text="pathBrowser.notice"></div>
+                    <div x-show="pathBrowser.loading" class="px-3 py-4 text-sm text-gray-400">Loading folders...</div>
+
+                    <div x-show="!pathBrowser.loading && !pathBrowser.error" class="max-h-64 overflow-y-auto">
+                        <button
+                            type="button"
+                            x-show="pathBrowser.parent"
+                            x-on:click="browseDirectory(pathBrowser.parent)"
+                            class="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-800 border-b border-gray-800"
+                        >
+                            ../
+                        </button>
+
+                        <template x-for="entry in pathBrowser.entries" :key="entry.path">
+                            <button
+                                type="button"
+                                x-on:click="browseDirectory(entry.path)"
+                                class="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-800 border-b border-gray-800 last:border-b-0"
+                            >
+                                <span class="text-blue-300 mr-2">/</span><span x-text="entry.name"></span>
+                            </button>
+                        </template>
+
+                        <div x-show="pathBrowser.entries.length === 0" class="px-3 py-4 text-sm text-gray-500">
+                            No subfolders found.
+                        </div>
+                    </div>
+
+                    <div class="flex justify-end gap-2 px-3 py-2 border-t border-gray-700 bg-gray-950/50">
+                        <button
+                            type="button"
+                            x-on:click="useBrowsedDirectory()"
+                            class="bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 rounded text-sm transition-colors"
+                            :disabled="!pathBrowser.current"
+                        >
+                            Use This Folder
+                        </button>
+                    </div>
+                </div>
+
+                <div x-show="relocation.error" class="rounded border border-red-900/60 bg-red-950/30 px-3 py-2 text-sm text-red-200" x-text="relocation.error"></div>
+
+                <div x-show="relocation.preview" class="space-y-4" style="display: none;">
+                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3 border-y border-gray-700 py-4">
+                        <div>
+                            <p class="text-[10px] uppercase tracking-wide text-gray-500">Matched</p>
+                            <p class="text-2xl font-bold text-green-300" x-text="relocation.preview?.matched_count ?? 0"></p>
+                        </div>
+                        <div>
+                            <p class="text-[10px] uppercase tracking-wide text-gray-500">Missing</p>
+                            <p class="text-2xl font-bold text-amber-300" x-text="relocation.preview?.missing_count ?? 0"></p>
+                        </div>
+                        <div>
+                            <p class="text-[10px] uppercase tracking-wide text-gray-500">New</p>
+                            <p class="text-2xl font-bold text-blue-300" x-text="relocation.preview?.new_count ?? 0"></p>
+                        </div>
+                    </div>
+
+                    <div
+                        x-show="relocationConfirmBlocked()"
+                        class="rounded border border-red-900/60 bg-red-950/30 px-3 py-2 text-sm text-red-200"
+                        x-text="relocationConfirmBlockReason()"
+                    ></div>
+
+                    <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 text-sm">
+                        <div>
+                            <div class="mb-2">
+                                <h3 class="font-semibold text-green-200">Matched Files</h3>
+                                <p class="text-xs text-gray-500" x-text="relocationSampleSummary('matched')"></p>
+                            </div>
+                            <template x-if="relocation.preview?.matched_samples?.length">
+                                <ul class="space-y-1 text-gray-300">
+                                    <template x-for="sample in relocation.preview.matched_samples" :key="sample.relative_path">
+                                        <li class="font-mono text-xs break-all" x-text="sample.relative_path"></li>
+                                    </template>
+                                </ul>
+                            </template>
+                            <p x-show="!relocation.preview?.matched_samples?.length" class="text-gray-500 text-xs">No samples.</p>
+                        </div>
+                        <div>
+                            <div class="mb-2">
+                                <h3 class="font-semibold text-amber-200">Missing Files</h3>
+                                <p class="text-xs text-gray-500" x-text="relocationSampleSummary('missing')"></p>
+                            </div>
+                            <template x-if="relocation.preview?.missing_samples?.length">
+                                <ul class="space-y-1 text-gray-300">
+                                    <template x-for="sample in relocation.preview.missing_samples" :key="sample.relative_path">
+                                        <li class="font-mono text-xs break-all" x-text="sample.relative_path"></li>
+                                    </template>
+                                </ul>
+                            </template>
+                            <p x-show="!relocation.preview?.missing_samples?.length" class="text-gray-500 text-xs">No samples.</p>
+                        </div>
+                        <div>
+                            <div class="mb-2">
+                                <h3 class="font-semibold text-blue-200">New Files</h3>
+                                <p class="text-xs text-gray-500" x-text="relocationSampleSummary('new')"></p>
+                            </div>
+                            <template x-if="relocation.preview?.new_samples?.length">
+                                <ul class="space-y-1 text-gray-300">
+                                    <template x-for="sample in relocation.preview.new_samples" :key="sample.relative_path">
+                                        <li class="font-mono text-xs break-all" x-text="sample.relative_path"></li>
+                                    </template>
+                                </ul>
+                            </template>
+                            <p x-show="!relocation.preview?.new_samples?.length" class="text-gray-500 text-xs">No samples.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div x-show="relocation.completed" class="rounded border border-amber-500/30 bg-amber-950/30 px-3 py-3 text-sm text-amber-100" style="display: none;">
+                    <p class="font-semibold">Relocation complete. Scan recommended.</p>
+                    <ul class="mt-2 space-y-1 text-xs text-amber-100/80">
+                        <template x-for="reason in relocation.confirmation?.scan_reasons || []" :key="reason">
+                            <li x-text="reason"></li>
+                        </template>
+                    </ul>
+                </div>
+
+                <div class="flex flex-wrap justify-end gap-2 pt-2 border-t border-gray-700">
+                    <button x-on:click="closeRelocationModal()" class="text-gray-400 hover:text-white px-4 py-2 transition-colors">
+                        <span x-text="relocation.completed ? 'Close' : 'Cancel'"></span>
+                    </button>
+                    <button
+                        x-show="!relocation.completed"
+                        x-on:click="previewRelocation()"
+                        class="bg-gray-700 hover:bg-gray-600 text-white px-4 py-2 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        :disabled="relocation.previewLoading || relocation.confirming || !relocation.path"
+                    >
+                        <span x-text="relocation.previewLoading ? 'Previewing...' : 'Preview'"></span>
+                    </button>
+                    <button
+                        x-show="!relocation.completed"
+                        x-on:click="confirmRelocation()"
+                        class="bg-amber-600 hover:bg-amber-500 text-white px-4 py-2 rounded transition-colors shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                        :disabled="!relocation.preview || relocation.confirming || relocationConfirmBlocked()"
+                    >
+                        <span x-text="relocation.confirming ? 'Relocating...' : 'Confirm Relocation'"></span>
+                    </button>
+                    <button
+                        x-show="relocation.completed && relocation.confirmation?.scan_recommended"
+                        x-on:click="runRelocationScan()"
+                        class="bg-green-600 hover:bg-green-500 text-white px-4 py-2 rounded transition-colors shadow-lg"
+                    >
+                        Run Force Scan
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
 </div>
 
 <script>
@@ -213,6 +432,7 @@ function libraryManager() {
     return {
         libraries: [],
         showModal: false,
+        showRelocationModal: false,
         isEditing: false,
         form: {
             id: null,
@@ -223,8 +443,19 @@ function libraryManager() {
             parse_collections: true,
             parse_story_arcs: true,
         },
+        relocation: {
+            library: null,
+            path: '',
+            preview: null,
+            confirmation: null,
+            error: '',
+            previewLoading: false,
+            confirming: false,
+            completed: false,
+        },
         pathBrowser: {
             open: false,
+            target: 'form',
             loading: false,
             error: '',
             notice: '',
@@ -285,9 +516,54 @@ function libraryManager() {
             this.showModal = true;
         },
 
-        async openDirectoryBrowser() {
+        resetRelocationState() {
+            this.relocation = {
+                library: null,
+                path: '',
+                preview: null,
+                confirmation: null,
+                error: '',
+                previewLoading: false,
+                confirming: false,
+                completed: false,
+            };
+        },
+
+        openRelocateModal(lib) {
+            this.showModal = false;
+            this.closeDirectoryBrowser();
+            this.relocation = {
+                library: lib,
+                path: lib.path || '',
+                preview: null,
+                confirmation: null,
+                error: '',
+                previewLoading: false,
+                confirming: false,
+                completed: false,
+            };
+            this.showRelocationModal = true;
+        },
+
+        closeRelocationModal() {
+            this.showRelocationModal = false;
+            this.closeDirectoryBrowser();
+            this.resetRelocationState();
+        },
+
+        resetRelocationPreview() {
+            this.relocation.preview = null;
+            this.relocation.confirmation = null;
+            this.relocation.error = '';
+            this.relocation.completed = false;
+        },
+
+        async openDirectoryBrowser(target = 'form') {
+            this.pathBrowser.target = target;
             this.pathBrowser.open = true;
-            const requestedPath = this.form.path || null;
+            const requestedPath = target === 'relocation'
+                ? (this.relocation.path || this.relocation.library?.path || null)
+                : (this.form.path || null);
             const openedRequestedPath = await this.browseDirectory(requestedPath);
 
             if (!openedRequestedPath && requestedPath) {
@@ -301,6 +577,7 @@ function libraryManager() {
 
         closeDirectoryBrowser() {
             this.pathBrowser.open = false;
+            this.pathBrowser.target = 'form';
             this.pathBrowser.loading = false;
             this.pathBrowser.error = '';
             this.pathBrowser.notice = '';
@@ -337,7 +614,12 @@ function libraryManager() {
 
         useBrowsedDirectory() {
             if (!this.pathBrowser.current) return;
-            this.form.path = this.pathBrowser.current;
+            if (this.pathBrowser.target === 'relocation') {
+                this.relocation.path = this.pathBrowser.current;
+                this.resetRelocationPreview();
+            } else {
+                this.form.path = this.pathBrowser.current;
+            }
             this.closeDirectoryBrowser();
         },
 
@@ -400,6 +682,121 @@ function libraryManager() {
                 console.error(e);
                 await window.parker.dialog.alert('Error', 'Network error occurred');
             }
+        },
+
+        async previewRelocation() {
+            if (!this.relocation.library || !this.relocation.path) return;
+
+            this.relocation.previewLoading = true;
+            this.relocation.error = '';
+            this.relocation.preview = null;
+            this.relocation.confirmation = null;
+
+            try {
+                const res = await fetch(
+                    window.parker.route('libraries.relocation_preview', { library_id: this.relocation.library.id }),
+                    {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ path: this.relocation.path })
+                    }
+                );
+                const payload = await res.json();
+
+                if (!res.ok) {
+                    throw new Error(payload.detail || 'Unable to preview relocation');
+                }
+
+                this.relocation.preview = payload;
+            } catch (e) {
+                console.error(e);
+                this.relocation.error = e.message || 'Unable to preview relocation';
+            } finally {
+                this.relocation.previewLoading = false;
+            }
+        },
+
+        relocationConfirmBlocked() {
+            return Boolean(this.relocation.preview?.confirm_blocked);
+        },
+
+        relocationConfirmBlockReason() {
+            return this.relocation.preview?.confirm_blocked_reason || '';
+        },
+
+        relocationSampleSummary(kind) {
+            const preview = this.relocation.preview;
+            if (!preview) return '';
+
+            const total = Number(preview[`${kind}_count`] || 0);
+            const shown = (preview[`${kind}_samples`] || []).length;
+
+            if (total === 0) return 'No files found.';
+            if (shown === 0) return 'No samples shown.';
+            if (shown < total) return `Showing ${shown.toLocaleString()} of ${total.toLocaleString()}`;
+
+            return `Showing ${shown.toLocaleString()} ${shown === 1 ? 'file' : 'files'}`;
+        },
+
+        async confirmRelocation() {
+            if (!this.relocation.library || !this.relocation.path || !this.relocation.preview) return;
+            if (this.relocationConfirmBlocked()) {
+                this.relocation.error = this.relocationConfirmBlockReason();
+                return;
+            }
+
+            const confirmed = await window.parker.dialog.confirm(
+                `Relocate ${this.relocation.library.name}?`,
+                'The library path will change, existing comic records will be preserved, and no scan will start automatically.',
+                { isDestructive: false, confirmText: 'Relocate' }
+            );
+
+            if (!confirmed) return;
+
+            this.relocation.confirming = true;
+            this.relocation.error = '';
+
+            try {
+                const res = await fetch(
+                    window.parker.route('libraries.relocation_confirm', { library_id: this.relocation.library.id }),
+                    {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ path: this.relocation.path })
+                    }
+                );
+                const payload = await res.json();
+
+                if (!res.ok) {
+                    throw new Error(payload.detail || 'Unable to confirm relocation');
+                }
+
+                this.relocation.confirmation = payload;
+                this.relocation.preview = payload;
+                this.relocation.completed = true;
+                this.relocation.path = payload.current_path;
+                this.relocation.library.path = payload.current_path;
+
+                const updated = this.libraries.find((lib) => lib.id === payload.library_id);
+                if (updated) updated.path = payload.current_path;
+
+                await this.loadLibraries();
+                window.parker.showToast('Library relocated', 'success');
+            } catch (e) {
+                console.error(e);
+                this.relocation.error = e.message || 'Unable to confirm relocation';
+            } finally {
+                this.relocation.confirming = false;
+            }
+        },
+
+        async runRelocationScan() {
+            const libraryId = this.relocation.library?.id;
+            const library = this.libraries.find((lib) => lib.id === libraryId) || this.relocation.library;
+            if (!library) return;
+
+            this.closeRelocationModal();
+            await this.triggerScan(library, true);
         },
 
         async deleteLibrary(lib) {

--- a/app/templates/admin/libraries.html
+++ b/app/templates/admin/libraries.html
@@ -215,7 +215,7 @@
     </div>
 
     <div x-show="showRelocationModal" class="fixed inset-0 bg-black/80 flex items-center justify-center z-50 px-4" style="display: none;" x-transition.opacity>
-        <div class="bg-gray-800 p-6 rounded-lg w-full max-w-3xl max-h-[90vh] overflow-y-auto border border-gray-700 shadow-2xl" x-on:click.away="closeRelocationModal()">
+        <div class="bg-gray-800 p-6 rounded-lg w-full max-w-3xl max-h-[90vh] overflow-y-auto border border-gray-700 shadow-2xl">
             <div class="flex items-start justify-between gap-4 mb-5">
                 <div class="min-w-0">
                     <h2 class="text-xl font-bold text-white">Relocate Library Path</h2>
@@ -771,6 +771,7 @@ function libraryManager() {
                     throw new Error(payload.detail || 'Unable to confirm relocation');
                 }
 
+                this.showRelocationModal = true;
                 this.relocation.confirmation = payload;
                 this.relocation.preview = payload;
                 this.relocation.completed = true;
@@ -782,6 +783,20 @@ function libraryManager() {
 
                 await this.loadLibraries();
                 window.parker.showToast('Library relocated', 'success');
+
+                if (payload.scan_recommended) {
+                    const scanLibrary = this.libraries.find((lib) => lib.id === payload.library_id) || this.relocation.library;
+                    const runScan = await window.parker.dialog.confirm(
+                        'Scan Recommended',
+                        'Relocation is complete. Run a force scan now to verify moved files and reconcile any new or missing archives?',
+                        { isDestructive: false, confirmText: 'Run Force Scan', cancelText: 'Not Now' }
+                    );
+
+                    if (runScan && scanLibrary) {
+                        this.closeRelocationModal();
+                        await this.startScan(scanLibrary, true);
+                    }
+                }
             } catch (e) {
                 console.error(e);
                 this.relocation.error = e.message || 'Unable to confirm relocation';
@@ -837,6 +852,10 @@ function libraryManager() {
 
             if (!confirmed) return;
 
+            await this.startScan(lib, force);
+        },
+
+        async startScan(lib, force) {
             lib.is_scanning = true; // Optimistic update
 
             const res = await fetch(window.parker.route('libraries.scan', { library_id: lib.id }, `force=${force}`), { method: 'POST' });

--- a/docs/library-relocation-scope.md
+++ b/docs/library-relocation-scope.md
@@ -1,6 +1,6 @@
 # Library Relocation Scope
 
-Status: Phase 1 (schema + guardrail), the full Compatibility Field Removal Plan, and the relocation preview/confirmation backend are implemented; UI is not yet built
+Status: Phase 1 (schema + guardrail), the full Compatibility Field Removal Plan, and the relocation preview/confirmation flow are implemented
 
 This note captures a future enhancement for safely changing the filesystem path of an existing Parker library without losing comic identity.
 
@@ -11,12 +11,14 @@ Phase 1 (schema + guardrail) is done:
 - `library_roots` table added; `Comic.library_root_id` and `Comic.relative_path` added (migration `d4a1f6e8b3c2`).
 - Migration backfills one root per existing library and each comic's relative path (see `app/core/path_utils.py:compute_relative_path`).
 - `create_library` now creates a matching `LibraryRoot`.
-- Editing a library's path is hard-blocked in the API and admin UI (400 on change) until the relocation flow below exists.
+- Editing a library's path remains hard-blocked in the generic edit flow; admins use the dedicated relocate action for path moves.
 
-The relocation preview/confirmation backend is done:
+The relocation preview/confirmation flow is done:
 
 - Admin `POST /api/libraries/{library_id}/relocation/preview` computes matched, missing, and new archive counts without mutating stored root paths.
 - Admin `POST /api/libraries/{library_id}/relocation/confirm` recomputes the same impact summary, updates only the selected `LibraryRoot.path`, and returns `scan_recommended: true` without queuing a scan.
+- The admin library UI exposes a dedicated relocate action with preview counts, sample paths, confirmation, and an explicit post-confirm force-scan option.
+- Confirmation is blocked when a library already has comics and none of them match at the proposed new root. Admins must move the files first, preserving relative paths, then preview again.
 - Preview targets a `LibraryRoot`; `root_id` is optional only when the library has one active root, and becomes required when multiple active roots would make the target ambiguous.
 - Path overlap validation is root-level and rejects overlap with the current root or any other root, including roots in the same library.
 
@@ -127,7 +129,7 @@ A safe relocation should look like this:
    - missing files at the new root
    - new files found under the new root
    - conflicts or duplicate candidates
-5. Admin confirms.
+5. Admin confirms, unless the library has existing comics and zero of them match at the new root.
 6. Parker updates the selected root path.
 7. Parker queues or recommends a scan.
 
@@ -146,6 +148,8 @@ Initial matching should be conservative:
 3. do not use content hashes in the first implementation unless there is already a hashing system
 
 If a file is missing from the new root, the preview should not delete it automatically.
+
+If no existing comics match at the new root, confirmation should be blocked. That usually means the admin picked the wrong folder, picked the empty destination before moving files, or changed the relative folder layout enough that Parker cannot preserve comic identity.
 
 If a file appears at the new root but has no existing relative-path match, it should be treated as a new import candidate.
 
@@ -172,7 +176,7 @@ Cleanup should operate within the relevant root identity, not by comparing old a
 3. **Read-path cutover.** Every reader of `file_path`/`Library.path` — the comic reader, thumbnail generation, comics/reports API responses, OPDS, the Kavita migration tool, the library API, watcher, and startup diagnostics — reconstructs the absolute path on demand via `Comic.absolute_path` / `Library.active_root`, backed by `resolve_absolute_path` in `app/core/path_utils.py`.
 4. **Column removal.** Migration `9def8df8ed7c` dropped `Comic.file_path` and `Library.path` for good.
 
-Stage 1 remains a prerequisite for the relocation flow below to be considered safe. The backend preview and confirmation endpoints are now built; UI is still unbuilt.
+Stage 1 remains a prerequisite for the relocation flow below to be considered safe. The backend preview/confirmation endpoints and admin UI are now built.
 
 ## Admin UI Guardrails
 
@@ -221,7 +225,7 @@ Minimum coverage should include:
 ## Open Questions
 
 - Should relocation be allowed while a library scan is running?
-- Should Parker allow relocation when some files are missing from the new root?
+- Should Parker eventually require an explicit override when some, but not all, files are missing from the new root?
 - Should relocation update `last_scanned` or require a follow-up scan?
 - Should unmatched files remain in the database as disabled/missing records, or continue using current cleanup behavior after confirmation?
 

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -13,6 +13,7 @@ from app.models.interactions import UserLibraryPin
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
+from app.services.library_relocation import NO_RELOCATION_MATCHES_MESSAGE
 from tests.factories import create_comic, create_library_with_root
 
 
@@ -203,12 +204,12 @@ def test_admin_can_browse_library_paths_within_configured_root(admin_client, mon
 
     assert root_response.status_code == 200
     root_payload = root_response.json()
-    assert root_payload["root"] == str(root.resolve())
-    assert root_payload["current"] == str(root.resolve())
+    assert root_payload["root"] == root.resolve().as_posix()
+    assert root_payload["current"] == root.resolve().as_posix()
     assert root_payload["parent"] is None
     assert root_payload["entries"] == [
-        {"name": "Alpha", "path": str(alpha.resolve())},
-        {"name": "Zeta", "path": str(zeta.resolve())},
+        {"name": "Alpha", "path": alpha.resolve().as_posix()},
+        {"name": "Zeta", "path": zeta.resolve().as_posix()},
     ]
 
     child_response = admin_client.get(
@@ -218,9 +219,9 @@ def test_admin_can_browse_library_paths_within_configured_root(admin_client, mon
 
     assert child_response.status_code == 200
     child_payload = child_response.json()
-    assert child_payload["current"] == str(alpha.resolve())
-    assert child_payload["parent"] == str(root.resolve())
-    assert child_payload["entries"] == [{"name": "Nested", "path": str(nested.resolve())}]
+    assert child_payload["current"] == alpha.resolve().as_posix()
+    assert child_payload["parent"] == root.resolve().as_posix()
+    assert child_payload["entries"] == [{"name": "Nested", "path": nested.resolve().as_posix()}]
 
 
 def test_library_path_browser_rejects_non_admin(auth_client, monkeypatch, tmp_path):
@@ -613,15 +614,50 @@ def test_preview_library_relocation_returns_counts_without_updating_root(admin_c
     assert payload["library_id"] == library_id
     assert payload["root_id"] == root_id
     assert payload["current_path"] == str(current_root_path)
-    assert payload["proposed_path"] == str(proposed_root_path.resolve())
+    assert payload["proposed_path"] == proposed_root_path.resolve().as_posix()
     assert payload["total_existing"] == 2
     assert payload["total_scanned"] == 2
     assert payload["matched_count"] == 1
     assert payload["missing_count"] == 1
     assert payload["new_count"] == 1
+    assert payload["confirm_blocked"] is False
+    assert payload["confirm_blocked_reason"] is None
     assert payload["matched_samples"][0]["relative_path"] == "Alpha/one.cbz"
     assert payload["missing_samples"][0]["relative_path"] == "Beta/two.cbz"
     assert payload["new_samples"][0]["relative_path"] == "Extra/three.cbz"
+
+    db.refresh(root)
+    assert root.path == str(current_root_path)
+
+
+def test_preview_library_relocation_marks_all_missing_as_not_confirmable(admin_client, db, tmp_path):
+    current_root_path = tmp_path / "api-all-missing-current"
+    proposed_root_path = tmp_path / "api-all-missing-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "API All Missing Preview", str(current_root_path))
+    root = library.active_root
+    series = Series(name="API All Missing Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    create_comic(db, volume, root, "Alpha/one.cbz", filename="one.cbz")
+    db.commit()
+
+    response = admin_client.post(
+        f"/api/libraries/{library.id}/relocation/preview",
+        json={"path": str(proposed_root_path)},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total_existing"] == 1
+    assert payload["matched_count"] == 0
+    assert payload["missing_count"] == 1
+    assert payload["confirm_blocked"] is True
+    assert payload["confirm_blocked_reason"] == NO_RELOCATION_MATCHES_MESSAGE
 
     db.refresh(root)
     assert root.path == str(current_root_path)
@@ -734,8 +770,8 @@ def test_confirm_library_relocation_updates_root_without_queuing_scan(admin_clie
     assert payload["root_id"] == root_id
     assert payload["relocated"] is True
     assert payload["previous_path"] == str(current_root_path)
-    assert payload["current_path"] == str(proposed_root_path.resolve())
-    assert payload["proposed_path"] == str(proposed_root_path.resolve())
+    assert payload["current_path"] == proposed_root_path.resolve().as_posix()
+    assert payload["proposed_path"] == proposed_root_path.resolve().as_posix()
     assert payload["matched_count"] == 1
     assert payload["missing_count"] == 1
     assert payload["new_count"] == 1
@@ -750,9 +786,43 @@ def test_confirm_library_relocation_updates_root_without_queuing_scan(admin_clie
     mock_add_scan_task.assert_not_called()
 
     db.refresh(root)
-    assert root.path == str(proposed_root_path.resolve())
+    assert root.path == proposed_root_path.resolve().as_posix()
     assert db.get(Comic, matched_id).relative_path == "Alpha/one.cbz"
     assert db.get(Comic, missing_id).relative_path == "Beta/two.cbz"
+
+
+def test_confirm_library_relocation_rejects_all_missing(admin_client, db, tmp_path):
+    current_root_path = tmp_path / "confirm-api-all-missing-current"
+    proposed_root_path = tmp_path / "confirm-api-all-missing-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "API Confirm All Missing", str(current_root_path))
+    root = library.active_root
+    series = Series(name="API Confirm All Missing Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    create_comic(db, volume, root, "Alpha/one.cbz", filename="one.cbz")
+    db.commit()
+
+    with (
+        patch("app.api.libraries.library_watcher.refresh_watches") as mock_refresh_watches,
+        patch("app.api.libraries.scan_manager.add_task") as mock_add_scan_task,
+    ):
+        response = admin_client.post(
+            f"/api/libraries/{library.id}/relocation/confirm",
+            json={"path": str(proposed_root_path)},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": NO_RELOCATION_MATCHES_MESSAGE}
+    mock_refresh_watches.assert_not_called()
+    mock_add_scan_task.assert_not_called()
+
+    db.refresh(root)
+    assert root.path == str(current_root_path)
 
 
 def test_confirm_library_relocation_returns_404_for_missing_library(admin_client, tmp_path):

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -131,6 +131,14 @@ def test_admin_libraries_page_exposes_folder_browser_route(admin_client):
     body = response.text
     assert "Browse" in body
     assert "libraries.browse" in body
+    assert "Relocate" in body
+    assert "libraries.relocation_preview" in body
+    assert "libraries.relocation_confirm" in body
+    assert "scan_recommended" in body
+    assert "confirm_blocked" in body
+    assert "relocationConfirmBlocked" in body
+    assert "relocationSampleSummary" in body
+    assert "Showing ${shown.toLocaleString()} of ${total.toLocaleString()}" in body
     assert "The path is locked for existing libraries" in body
 
 

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -139,6 +139,8 @@ def test_admin_libraries_page_exposes_folder_browser_route(admin_client):
     assert "relocationConfirmBlocked" in body
     assert "relocationSampleSummary" in body
     assert "Showing ${shown.toLocaleString()} of ${total.toLocaleString()}" in body
+    assert "Scan Recommended" in body
+    assert "startScan(scanLibrary, true)" in body
     assert "The path is locked for existing libraries" in body
 
 

--- a/tests/browser/test_admin_library_relocation.py
+++ b/tests/browser/test_admin_library_relocation.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+import pytest
+
+from app.config import settings
+from app.models.comic import Volume
+from app.models.library_root import LibraryRoot
+from app.models.series import Series
+from app.models.user import User
+from tests.factories import create_comic, create_library_with_root
+
+
+def _write_file(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"comic")
+
+
+@pytest.mark.browser
+def test_admin_library_relocation_preview_and_confirm_flow(page, browser_server, tmp_path):
+    current_root = tmp_path / "relocation-ui-current"
+    proposed_root = tmp_path / "relocation-ui-proposed"
+    current_root.mkdir()
+    proposed_root.mkdir()
+
+    session = browser_server["db_factory"]()
+    try:
+        user = session.get(User, browser_server["seed"]["user_id"])
+        user.is_superuser = True
+
+        library = create_library_with_root(session, "Relocation UI Library", str(current_root))
+        root = library.active_root
+        series = Series(name="Relocation UI Series", library=library)
+        volume = Volume(series=series, volume_number=1)
+        session.add_all([series, volume])
+        session.flush()
+        create_comic(session, volume, root, "Alpha/one.cbz", filename="one.cbz")
+        create_comic(session, volume, root, "Beta/two.cbz", filename="two.cbz")
+        session.commit()
+        root_id = root.id
+    finally:
+        session.close()
+
+    _write_file(proposed_root / "Alpha" / "one.cbz")
+    _write_file(proposed_root / "Extra" / "three.cbz")
+
+    original_comics_path = settings.comics_path
+    settings.comics_path = tmp_path
+    try:
+        page.goto(f"{browser_server['base_url']}/admin/libraries", wait_until="networkidle")
+
+        row = page.get_by_role("row").filter(has_text="Relocation UI Library").first
+        row.wait_for()
+        row.get_by_role("button", name="Relocate").click()
+
+        page.get_by_role("heading", name="Relocate Library Path").wait_for()
+        page.get_by_role("button", name="Browse").click()
+        page.get_by_role("button", name="../").click()
+        page.get_by_role("button", name=f"/{proposed_root.name}").click()
+        page.get_by_role("button", name="Use This Folder").click()
+        path_input = page.get_by_placeholder("/comics/relocated")
+        path_input.wait_for(state="visible")
+        assert path_input.input_value() == proposed_root.resolve().as_posix()
+        page.get_by_role("button", name="Preview").click()
+
+        page.get_by_text("Matched Files").wait_for()
+        page.get_by_text("Alpha/one.cbz").wait_for()
+        page.get_by_text("Beta/two.cbz").wait_for()
+        page.get_by_text("Extra/three.cbz").wait_for()
+
+        page.get_by_role("button", name="Confirm Relocation").click()
+        page.get_by_role("heading", name="Relocate Relocation UI Library?").wait_for()
+        page.locator('[x-data="globalDialog()"]').get_by_role("button", name="Relocate").click()
+
+        page.get_by_text("Relocation complete. Scan recommended.").wait_for()
+        page.get_by_role("button", name="Run Force Scan").wait_for()
+        assert path_input.input_value() == proposed_root.resolve().as_posix()
+
+        session = browser_server["db_factory"]()
+        try:
+            relocated_root = session.get(LibraryRoot, root_id)
+            assert relocated_root.path == proposed_root.resolve().as_posix()
+        finally:
+            session.close()
+    finally:
+        settings.comics_path = original_comics_path
+        session = browser_server["db_factory"]()
+        try:
+            user = session.get(User, browser_server["seed"]["user_id"])
+            if user is not None:
+                user.is_superuser = False
+                session.commit()
+        finally:
+            session.close()

--- a/tests/browser/test_admin_library_relocation.py
+++ b/tests/browser/test_admin_library_relocation.py
@@ -71,6 +71,8 @@ def test_admin_library_relocation_preview_and_confirm_flow(page, browser_server,
         page.get_by_role("heading", name="Relocate Relocation UI Library?").wait_for()
         page.locator('[x-data="globalDialog()"]').get_by_role("button", name="Relocate").click()
 
+        page.get_by_role("heading", name="Scan Recommended").wait_for()
+        page.locator('[x-data="globalDialog()"]').get_by_role("button", name="Not Now").click()
         page.get_by_text("Relocation complete. Scan recommended.").wait_for()
         page.get_by_role("button", name="Run Force Scan").wait_for()
         assert path_input.input_value() == proposed_root.resolve().as_posix()

--- a/tests/services/test_library_relocation.py
+++ b/tests/services/test_library_relocation.py
@@ -5,6 +5,7 @@ from app.models.library_root import LibraryRoot
 from app.models.series import Series
 from app.services.library_relocation import (
     LibraryRelocationError,
+    NO_RELOCATION_MATCHES_MESSAGE,
     confirm_library_root_relocation,
     preview_library_root_relocation,
 )
@@ -53,12 +54,14 @@ def test_preview_library_root_relocation_counts_matched_missing_and_new_files(db
     assert preview.library_id == library.id
     assert preview.root_id == root.id
     assert preview.current_path == str(current_root_path)
-    assert preview.proposed_path == str(proposed_root_path.resolve())
+    assert preview.proposed_path == proposed_root_path.resolve().as_posix()
     assert preview.total_existing == 3
     assert preview.total_scanned == 3
     assert preview.matched_count == 2
     assert preview.missing_count == 1
     assert preview.new_count == 1
+    assert preview.confirm_blocked is False
+    assert preview.confirm_blocked_reason is None
     assert [sample.relative_path for sample in preview.matched_samples] == [
         "Alpha/one.cbz",
         "Gamma/three.cbr",
@@ -197,8 +200,8 @@ def test_confirm_library_root_relocation_updates_root_and_preserves_comic_identi
     payload = confirmation.to_dict()
     assert payload["relocated"] is True
     assert payload["previous_path"] == str(current_root_path)
-    assert payload["current_path"] == str(proposed_root_path.resolve())
-    assert payload["proposed_path"] == str(proposed_root_path.resolve())
+    assert payload["current_path"] == proposed_root_path.resolve().as_posix()
+    assert payload["proposed_path"] == proposed_root_path.resolve().as_posix()
     assert payload["matched_count"] == 1
     assert payload["missing_count"] == 1
     assert payload["new_count"] == 1
@@ -210,7 +213,7 @@ def test_confirm_library_root_relocation_updates_root_and_preserves_comic_identi
     ]
 
     refreshed_root = db.get(LibraryRoot, root_id)
-    assert refreshed_root.path == str(proposed_root_path.resolve())
+    assert refreshed_root.path == proposed_root_path.resolve().as_posix()
 
     refreshed_matched = db.get(Comic, matched_id)
     refreshed_missing = db.get(Comic, missing_id)
@@ -220,6 +223,66 @@ def test_confirm_library_root_relocation_updates_root_and_preserves_comic_identi
     assert refreshed_missing.library_root_id == root_id
     assert refreshed_matched.relative_path == "Alpha/one.cbz"
     assert refreshed_missing.relative_path == "Beta/two.cbz"
+
+
+def test_confirm_library_root_relocation_rejects_when_no_existing_files_match(db, tmp_path):
+    current_root_path = tmp_path / "all-missing-current"
+    proposed_root_path = tmp_path / "all-missing-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "All Missing Relocation", str(current_root_path))
+    root = library.active_root
+    volume = _create_volume(db, library)
+    create_comic(db, volume, root, "Alpha/one.cbz", filename="one.cbz")
+    create_comic(db, volume, root, "Beta/two.cbz", filename="two.cbz")
+    db.commit()
+
+    preview = preview_library_root_relocation(
+        db,
+        library=library,
+        proposed_path=str(proposed_root_path),
+    )
+
+    assert preview.total_existing == 2
+    assert preview.matched_count == 0
+    assert preview.missing_count == 2
+    assert preview.confirm_blocked is True
+    assert preview.confirm_blocked_reason == NO_RELOCATION_MATCHES_MESSAGE
+
+    with pytest.raises(LibraryRelocationError, match="No existing comics were found"):
+        confirm_library_root_relocation(
+            db,
+            library=library,
+            proposed_path=str(proposed_root_path),
+        )
+
+    db.refresh(root)
+    assert root.path == str(current_root_path)
+
+
+def test_confirm_library_root_relocation_allows_empty_library(db, tmp_path):
+    current_root_path = tmp_path / "empty-current"
+    proposed_root_path = tmp_path / "empty-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "Empty Relocation", str(current_root_path))
+    root = library.active_root
+    root_id = root.id
+    db.commit()
+
+    confirmation = confirm_library_root_relocation(
+        db,
+        library=library,
+        proposed_path=str(proposed_root_path),
+    )
+
+    assert confirmation.preview.total_existing == 0
+    assert confirmation.preview.confirm_blocked is False
+
+    refreshed_root = db.get(LibraryRoot, root_id)
+    assert refreshed_root.path == proposed_root_path.resolve().as_posix()
 
 
 def test_confirm_library_root_relocation_reuses_preview_validation(db, tmp_path):


### PR DESCRIPTION

Adds the admin UI for library root relocation. Admins can now preview a proposed new library path, review matched/missing/new file counts, confirm a safe relocation, and optionally run a force scan afterward.

This completes the first user-facing relocation flow for single-root libraries while keeping the implementation compatible with future multi-root support.

## Details

- Adds a dedicated `Relocate` action on the Admin > Libraries page.
- Adds a relocation modal showing:
  - current library path
  - new target path
  - folder browser support
  - matched, missing, and new archive counts
  - capped sample lists for each category
  - sample list summaries like `Showing 10 of 12,000`
- Normalizes Browse-selected and stored relocation paths to `/` separators.
- Keeps Preview non-mutating so admins can safely inspect a target path before changing anything.
- Blocks confirmation when a library has existing comics but zero matched files at the proposed new root.
  - This prevents confirming an empty/wrong destination before files have been moved.
  - Empty libraries can still relocate.
  - Partial matches remain confirmable with scan recommendation.
- Confirming relocation updates only the selected `LibraryRoot.path`.
- Confirming relocation does not queue a scan automatically.
- Shows scan recommendation after confirm and provides an explicit `Run Force Scan` action.

## Validation

Ran focused API, service, page, and browser coverage:

```powershell
.\.venv\Scripts\python.exe -m pytest tests\api\test_libraries.py tests\services\test_library_relocation.py tests\api\test_pages.py tests\browser\test_admin_library_relocation.py