### PR TITLE
Harden library relocation against active scans

### DIFF
--- a/app/schemas/setting.py
+++ b/app/schemas/setting.py
@@ -10,6 +10,7 @@ class SettingBase(BaseModel):
     description: Optional[str] = None
     options: Optional[List[Any]] = None
     depends_on: Optional[Any] = None
+    min_value: Optional[Any] = None
 
 class SettingUpdate(BaseModel):
     value: Any

--- a/app/services/library_relocation.py
+++ b/app/services/library_relocation.py
@@ -6,11 +6,13 @@ from sqlalchemy.orm import Session
 from app.config import settings
 from app.core.path_utils import compute_relative_path, paths_overlap, resolve_absolute_path
 from app.models.comic import Comic
+from app.models.job import JobStatus, JobType, ScanJob
 from app.models.library import Library
 from app.models.library_root import LibraryRoot
 
 
 DEFAULT_SAMPLE_LIMIT = 10
+LIBRARY_SCAN_ACTIVE_MESSAGE = "Library cannot be relocated while a scan is queued or running"
 NO_RELOCATION_MATCHES_MESSAGE = (
     "No existing comics were found at the new path. Move the library files first, "
     "preserving the same folder structure, then preview again."
@@ -102,6 +104,8 @@ def preview_library_root_relocation(
     root_id: int | None = None,
     sample_limit: int = DEFAULT_SAMPLE_LIMIT,
 ) -> LibraryRootRelocationPreview:
+    _ensure_library_not_scanning(db, library)
+
     selected_root = _select_relocation_root(library, root_id)
     resolved_proposed_path = _resolve_proposed_path(proposed_path)
     resolved_proposed_path_str = _path_for_storage(resolved_proposed_path)
@@ -207,6 +211,8 @@ def confirm_library_root_relocation(
     if preview.confirm_blocked:
         raise LibraryRelocationError(NO_RELOCATION_MATCHES_MESSAGE)
 
+    _ensure_library_not_scanning(db, library)
+
     selected_root = _select_relocation_root(library, preview.root_id)
     selected_root.path = preview.proposed_path
 
@@ -221,6 +227,23 @@ def confirm_library_root_relocation(
         scan_recommended=True,
         scan_reasons=_scan_reasons(preview),
     )
+
+
+def _ensure_library_not_scanning(db: Session, library: Library) -> None:
+    if library.is_scanning:
+        raise LibraryRelocationError(LIBRARY_SCAN_ACTIVE_MESSAGE)
+
+    active_scan_job = (
+        db.query(ScanJob)
+        .filter(
+            ScanJob.library_id == library.id,
+            ScanJob.job_type.in_([JobType.SCAN, JobType.THUMBNAIL, JobType.CLEANUP]),
+            ScanJob.status.in_([JobStatus.PENDING, JobStatus.RUNNING]),
+        )
+        .first()
+    )
+    if active_scan_job is not None:
+        raise LibraryRelocationError(LIBRARY_SCAN_ACTIVE_MESSAGE)
 
 
 def _select_relocation_root(library: Library, root_id: int | None) -> LibraryRoot:

--- a/app/services/settings_service.py
+++ b/app/services/settings_service.py
@@ -1,13 +1,15 @@
 from sqlalchemy.orm import Session
 import multiprocessing
 from app.models.setting import SystemSetting
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Optional
 
 from app.api.deps import SessionDep
 from app.core.settings_loader import invalidate_settings_cache
 from app.core.login_backgrounds import SOLID_COLORS, STATIC_COVERS
 
 SERVER_DISPLAY_NAME_MAX_LENGTH = 32
+SCANNING_BATCH_WINDOW_MIN_SECONDS = 60
+SETTING_RUNTIME_METADATA_FIELDS = ("min_value",)
 
 
 class SettingValidationError(ValueError):
@@ -69,7 +71,10 @@ class SettingsService:
             "key": "scanning.batch_window", "value": "600",
             "category": "scanning", "data_type": "int",
             "label": "Scan Batch Window (Sec)",
-            "description": "Time to wait for file operations to settle."
+            "description": f"Time to wait for file operations to settle. Minimum {SCANNING_BATCH_WINDOW_MIN_SECONDS} seconds.",
+            "min_value": SCANNING_BATCH_WINDOW_MIN_SECONDS,
+            "validation_label": "Scan batch window",
+            "unit_label": "seconds",
         },
         {
             "key": "ui.login_background_style", "value": "random_covers",
@@ -277,6 +282,20 @@ class SettingsService:
 
     ]
 
+    @classmethod
+    def min_value_for(cls, key: str) -> Optional[int]:
+        definition = cls._definition_for(key)
+        if not definition or "min_value" not in definition:
+            return None
+        return int(definition["min_value"])
+
+    @classmethod
+    def _definition_for(cls, key: str) -> Optional[Dict[str, Any]]:
+        for definition in cls.DEFAULTS:
+            if definition["key"] == key:
+                return definition
+        return None
+
     def initialize_defaults(self):
         """
         Seeds default settings and updates metadata (labels, descriptions) for existing ones.
@@ -294,7 +313,7 @@ class SettingsService:
 
             if key not in existing_settings:
                 # Case 1: New Setting -> Create it fully (including default value)
-                obj = SystemSetting(**default)
+                obj = SystemSetting(**self._stored_setting_kwargs(default))
                 self.db.add(obj)
             else:
                 # Case 2: Existing Setting -> Sync metadata only
@@ -316,6 +335,12 @@ class SettingsService:
                 if "depends_on" in default:
                     setting.depends_on = default["depends_on"]
 
+                if "min_value" in default:
+                    try:
+                        setting.value = self._normalize_int_setting(setting, setting.value, default)
+                    except SettingValidationError:
+                        setting.value = str(default["min_value"])
+
                 # NOTE: If we strictly needed to force-update a value (e.g. security patch),
                 # we would need explicit logic here, but usually we leave .value alone.
 
@@ -327,6 +352,7 @@ class SettingsService:
         grouped = {}
         for s in settings:
             s.value = self._cast_value(s.value, s.data_type)  # Cast for API
+            self._attach_runtime_metadata(s)
             if s.category not in grouped:
                 grouped[s.category] = []
             grouped[s.category].append(s)
@@ -345,6 +371,8 @@ class SettingsService:
         if not setting:
             raise ValueError("Setting not found")
 
+        definition = self._definition_for(key) or {}
+
         # Convert to string for storage
         if setting.data_type == "bool":
             setting.value = str(value).lower()  # "true"/"false"
@@ -355,6 +383,9 @@ class SettingsService:
                 raise SettingValidationError(
                     f"Server display name must be {SERVER_DISPLAY_NAME_MAX_LENGTH} characters or fewer"
                 )
+
+            if setting.data_type == "int":
+                normalized_value = self._normalize_int_setting(setting, normalized_value, definition)
 
             setting.value = normalized_value
 
@@ -367,6 +398,7 @@ class SettingsService:
         # Cast the value back to Python type (bool/int) so the API returns
         # actual JSON booleans, not strings like "false".
         setting.value = self._cast_value(setting.value, setting.data_type)
+        self._attach_runtime_metadata(setting)
 
         return setting
 
@@ -378,3 +410,38 @@ class SettingsService:
         if data_type == "bool":
             return value.lower() in ('true', '1', 't', 'yes')
         return value
+
+    def _normalize_int_setting(
+        self,
+        setting: SystemSetting,
+        value: Any,
+        definition: Dict[str, Any],
+    ) -> str:
+        label = definition.get("validation_label", setting.label or setting.key)
+        try:
+            number = int(str(value).strip())
+        except (TypeError, ValueError):
+            raise SettingValidationError(f"{label} must be a whole number")
+
+        min_value = definition.get("min_value")
+        if min_value is not None and number < int(min_value):
+            unit_label = definition.get("unit_label")
+            minimum = f"{min_value} {unit_label}" if unit_label else str(min_value)
+            raise SettingValidationError(
+                f"{label} must be at least {minimum}"
+            )
+
+        return str(number)
+
+    def _attach_runtime_metadata(self, setting: SystemSetting):
+        definition = self._definition_for(setting.key) or {}
+        for field in SETTING_RUNTIME_METADATA_FIELDS:
+            setattr(setting, field, definition.get(field))
+
+    def _stored_setting_kwargs(self, definition: Dict[str, Any]) -> Dict[str, Any]:
+        column_names = set(SystemSetting.__table__.columns.keys())
+        return {
+            key: value
+            for key, value in definition.items()
+            if key in column_names
+        }

--- a/app/services/watcher.py
+++ b/app/services/watcher.py
@@ -8,6 +8,7 @@ from watchdog.events import FileSystemEventHandler
 from app.database import SessionLocal
 from app.models.library import Library
 from app.services.scan_manager import scan_manager
+from app.services.settings_service import SettingsService
 
 from app.core.settings_loader import get_cached_setting
 
@@ -141,7 +142,7 @@ class LibraryWatcher:
             # Fetch Dynamic Setting (Default 600s if missing)
             # We fetch it once per refresh so all new watches use the updated value.
             # (Existing watches won't update their timeout until they are restarted, which is fine)
-            batch_window = get_cached_setting("scanning.batch_window", 600)
+            batch_window = _get_batch_window_seconds()
 
             # 2. Add new watches
             for lib in libraries:
@@ -180,3 +181,14 @@ class LibraryWatcher:
 
 # Global Instance
 library_watcher = LibraryWatcher()
+
+
+def _get_batch_window_seconds() -> int:
+    raw_value = get_cached_setting("scanning.batch_window", 600)
+    try:
+        seconds = int(raw_value)
+    except (TypeError, ValueError):
+        return 600
+
+    min_value = SettingsService.min_value_for("scanning.batch_window") or 0
+    return max(seconds, min_value)

--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -161,6 +161,7 @@
                                             x-model="setting.tempValue"
                                             x-on:focus="setting.tempValue = setting.value"
                                             :maxlength="inputMaxLength(setting) || null"
+                                            :min="inputMin(setting) || null"
                                             class="w-full rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-white outline-none transition-colors focus:border-blue-500"
                                         >
                                         <button
@@ -301,6 +302,10 @@ function settingsManager() {
             return null;
         },
 
+        inputMin(setting) {
+            return setting.min_value !== undefined && setting.min_value !== null ? setting.min_value : null;
+        },
+
         /**
          * Transforms a flat list of options into a structure for rendering groups.
          * Returns: { orphans: [], groups: { "GroupName": [opt, opt] } }
@@ -339,7 +344,14 @@ function settingsManager() {
                     body: JSON.stringify({ value: newValue })
                 });
                 
-                if(!res.ok) throw new Error();
+                if(!res.ok) {
+                    let message = "Error saving setting";
+                    try {
+                        const payload = await res.json();
+                        if (payload.detail) message = payload.detail;
+                    } catch(parseError) {}
+                    throw new Error(message);
+                }
                 
                 // Refresh local state to match server format
                 const updated = await res.json();
@@ -349,7 +361,7 @@ function settingsManager() {
             } catch(e) {
                 setting.value = oldVal; // Revert
                 setting.tempValue = oldVal;
-                window.parker.showToast("Error saving setting", "error");
+                window.parker.showToast(e.message || "Error saving setting", "error");
             }
         },
         

--- a/docs/library-relocation-scope.md
+++ b/docs/library-relocation-scope.md
@@ -19,6 +19,8 @@ The relocation preview/confirmation flow is done:
 - Admin `POST /api/libraries/{library_id}/relocation/confirm` recomputes the same impact summary, updates only the selected `LibraryRoot.path`, and returns `scan_recommended: true` without queuing a scan.
 - The admin library UI exposes a dedicated relocate action with preview counts, sample paths, confirmation, and an explicit post-confirm force-scan option.
 - Confirmation is blocked when a library already has comics and none of them match at the proposed new root. Admins must move the files first, preserving relative paths, then preview again.
+- Preview and confirmation are blocked while a scan pipeline job for the library is queued or running.
+- Watcher-triggered scan churn is limited by a 60-second minimum on the admin-configurable scan batch window.
 - Preview targets a `LibraryRoot`; `root_id` is optional only when the library has one active root, and becomes required when multiple active roots would make the target ambiguous.
 - Path overlap validation is root-level and rejects overlap with the current root or any other root, including roots in the same library.
 
@@ -121,17 +123,18 @@ The first migration should preserve current behavior.
 
 A safe relocation should look like this:
 
-1. Admin selects an existing library root.
-2. Admin chooses a new root path.
-3. Parker computes each existing comic's expected new path from `new_root / relative_path`.
-4. Parker previews:
+1. Admin waits for active or queued scan work to finish.
+2. Admin selects an existing library root.
+3. Admin chooses a new root path.
+4. Parker computes each existing comic's expected new path from `new_root / relative_path`.
+5. Parker previews:
    - matched files at the new root
    - missing files at the new root
    - new files found under the new root
    - conflicts or duplicate candidates
-5. Admin confirms, unless the library has existing comics and zero of them match at the new root.
-6. Parker updates the selected root path.
-7. Parker queues or recommends a scan.
+6. Admin confirms, unless the library has existing comics and zero of them match at the new root.
+7. Parker updates the selected root path.
+8. Parker queues or recommends a scan.
 
 Important rule:
 
@@ -224,10 +227,18 @@ Minimum coverage should include:
 
 ## Open Questions
 
-- Should relocation be allowed while a library scan is running?
+- Should relocation also block on any queued or running library job beyond the scan pipeline?
 - Should Parker eventually require an explicit override when some, but not all, files are missing from the new root?
 - Should relocation update `last_scanned` or require a follow-up scan?
 - Should unmatched files remain in the database as disabled/missing records, or continue using current cleanup behavior after confirmation?
+
+## Residual Concurrency Risk
+
+Relocation preview and confirmation now block while the target library has `is_scanning` set or has a pending/running scan-pipeline job (`scan`, `thumbnail`, or `cleanup`). Confirmation also re-checks immediately before updating `LibraryRoot.path`.
+
+The watcher batch window also has a 60-second floor to prevent admins from configuring near-immediate watcher scans that can create excessive scan churn around filesystem-heavy operations.
+
+There is still a narrow race where a new scan could be queued after confirmation's final guard check but before the root path update commits. Closing that completely would require a relocation lock that scan enqueue/start also honors. For now this is documented as an accepted residual risk because relocation is admin-only, deliberate, and the common active/queued scan cases are guarded.
 
 ## Effort Estimate
 

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -7,13 +7,14 @@ from app.main import app
 from app.api.deps import get_current_user
 from app.models.comic import Comic, Volume
 from app.models.collection import Collection, CollectionItem
+from app.models.job import JobStatus, JobType, ScanJob
 from app.models.library import Library
 from app.models.library_root import LibraryRoot
 from app.models.interactions import UserLibraryPin
 from app.models.reading_list import ReadingList, ReadingListItem
 from app.models.reading_progress import ReadingProgress
 from app.models.series import Series
-from app.services.library_relocation import NO_RELOCATION_MATCHES_MESSAGE
+from app.services.library_relocation import LIBRARY_SCAN_ACTIVE_MESSAGE, NO_RELOCATION_MATCHES_MESSAGE
 from tests.factories import create_comic, create_library_with_root
 
 
@@ -663,6 +664,44 @@ def test_preview_library_relocation_marks_all_missing_as_not_confirmable(admin_c
     assert root.path == str(current_root_path)
 
 
+def test_preview_library_relocation_rejects_scanning_library(admin_client, db, tmp_path):
+    current_root_path = tmp_path / "api-scanning-current"
+    proposed_root_path = tmp_path / "api-scanning-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "API Scanning Preview", str(current_root_path))
+    library.is_scanning = True
+    db.commit()
+
+    response = admin_client.post(
+        f"/api/libraries/{library.id}/relocation/preview",
+        json={"path": str(proposed_root_path)},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": LIBRARY_SCAN_ACTIVE_MESSAGE}
+
+
+def test_preview_library_relocation_rejects_queued_scan_job(admin_client, db, tmp_path):
+    current_root_path = tmp_path / "api-queued-current"
+    proposed_root_path = tmp_path / "api-queued-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "API Queued Preview", str(current_root_path))
+    db.add(ScanJob(library_id=library.id, job_type=JobType.SCAN, status=JobStatus.PENDING))
+    db.commit()
+
+    response = admin_client.post(
+        f"/api/libraries/{library.id}/relocation/preview",
+        json={"path": str(proposed_root_path)},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": LIBRARY_SCAN_ACTIVE_MESSAGE}
+
+
 def test_preview_library_relocation_requires_root_id_when_multiple_roots_are_active(admin_client, db, tmp_path):
     first_root_path = tmp_path / "api-first"
     second_root_path = tmp_path / "api-second"
@@ -789,6 +828,43 @@ def test_confirm_library_relocation_updates_root_without_queuing_scan(admin_clie
     assert root.path == proposed_root_path.resolve().as_posix()
     assert db.get(Comic, matched_id).relative_path == "Alpha/one.cbz"
     assert db.get(Comic, missing_id).relative_path == "Beta/two.cbz"
+
+
+def test_confirm_library_relocation_rejects_active_scan_job(admin_client, db, tmp_path):
+    current_root_path = tmp_path / "confirm-api-active-current"
+    proposed_root_path = tmp_path / "confirm-api-active-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "API Confirm Active Scan", str(current_root_path))
+    root = library.active_root
+    series = Series(name="API Confirm Active Scan Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    create_comic(db, volume, root, "Alpha/one.cbz", filename="one.cbz")
+    db.add(ScanJob(library_id=library.id, job_type=JobType.CLEANUP, status=JobStatus.RUNNING))
+    db.commit()
+
+    _write_comic_file(proposed_root_path / "Alpha" / "one.cbz")
+
+    with (
+        patch("app.api.libraries.library_watcher.refresh_watches") as mock_refresh_watches,
+        patch("app.api.libraries.scan_manager.add_task") as mock_add_scan_task,
+    ):
+        response = admin_client.post(
+            f"/api/libraries/{library.id}/relocation/confirm",
+            json={"path": str(proposed_root_path)},
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": LIBRARY_SCAN_ACTIVE_MESSAGE}
+    mock_refresh_watches.assert_not_called()
+    mock_add_scan_task.assert_not_called()
+
+    db.refresh(root)
+    assert root.path == str(current_root_path)
 
 
 def test_confirm_library_relocation_rejects_all_missing(admin_client, db, tmp_path):

--- a/tests/api/test_settings.py
+++ b/tests/api/test_settings.py
@@ -1,7 +1,11 @@
 from unittest.mock import patch
 
 from app.models.setting import SystemSetting
-from app.services.settings_service import SettingsService, SERVER_DISPLAY_NAME_MAX_LENGTH
+from app.services.settings_service import (
+    SCANNING_BATCH_WINDOW_MIN_SECONDS,
+    SERVER_DISPLAY_NAME_MAX_LENGTH,
+    SettingsService,
+)
 from app.api.deps import get_current_user_optional
 from app.main import app
 
@@ -42,6 +46,21 @@ def test_get_settings_grouped_list_returns_service_payload(admin_client):
     payload = response.json()
     assert payload["ui"][0]["key"] == "ui.background_style"
     assert payload["ui"][0]["value"] == "solid"
+
+
+def test_get_settings_grouped_list_includes_min_value_metadata(admin_client, db):
+    SettingsService(db).initialize_defaults()
+
+    response = admin_client.get("/api/settings/")
+
+    assert response.status_code == 200
+    scanning_settings = response.json()["scanning"]
+    batch_window = next(
+        setting
+        for setting in scanning_settings
+        if setting["key"] == "scanning.batch_window"
+    )
+    assert batch_window["min_value"] == SCANNING_BATCH_WINDOW_MIN_SECONDS
 
 
 def test_get_protected_setting_requires_auth(client):
@@ -100,6 +119,18 @@ def test_update_setting_rejects_server_display_name_that_is_too_long(admin_clien
     assert f"{SERVER_DISPLAY_NAME_MAX_LENGTH} characters or fewer" in response.json()["detail"]
 
 
+def test_update_setting_rejects_scan_batch_window_below_minimum(admin_client, db):
+    SettingsService(db).initialize_defaults()
+
+    response = admin_client.patch(
+        "/api/settings/scanning.batch_window",
+        json={"value": SCANNING_BATCH_WINDOW_MIN_SECONDS - 1},
+    )
+
+    assert response.status_code == 422
+    assert f"at least {SCANNING_BATCH_WINDOW_MIN_SECONDS} seconds" in response.json()["detail"]
+
+
 def test_initialize_defaults_seeds_short_server_display_name(db):
     service = SettingsService(db)
 
@@ -120,6 +151,28 @@ def test_initialize_defaults_seeds_single_volume_redirect_setting(db):
     assert service.get("ui.auto_redirect_single_volume_series") is False
     assert setting.category == "appearance"
     assert setting.data_type == "bool"
+
+
+def test_initialize_defaults_clamps_existing_scan_batch_window_below_minimum(db):
+    db.add(
+        SystemSetting(
+            key="scanning.batch_window",
+            value=str(SCANNING_BATCH_WINDOW_MIN_SECONDS - 1),
+            category="scanning",
+            data_type="int",
+            label="Old Label",
+            description="Old description",
+        )
+    )
+    db.commit()
+
+    service = SettingsService(db)
+    service.initialize_defaults()
+
+    setting = db.query(SystemSetting).filter(SystemSetting.key == "scanning.batch_window").first()
+    assert setting is not None
+    assert service.get("scanning.batch_window") == SCANNING_BATCH_WINDOW_MIN_SECONDS
+    assert setting.label == "Scan Batch Window (Sec)"
 
 
 def test_initialize_defaults_preserves_existing_custom_server_display_name(db):

--- a/tests/services/test_library_relocation.py
+++ b/tests/services/test_library_relocation.py
@@ -1,9 +1,11 @@
 import pytest
 
 from app.models.comic import Comic, Volume
+from app.models.job import JobStatus, JobType, ScanJob
 from app.models.library_root import LibraryRoot
 from app.models.series import Series
 from app.services.library_relocation import (
+    LIBRARY_SCAN_ACTIVE_MESSAGE,
     LibraryRelocationError,
     NO_RELOCATION_MATCHES_MESSAGE,
     confirm_library_root_relocation,
@@ -71,6 +73,44 @@ def test_preview_library_root_relocation_counts_matched_missing_and_new_files(db
 
     db.refresh(root)
     assert root.path == str(current_root_path)
+
+
+def test_preview_library_root_relocation_rejects_scanning_library(db, tmp_path):
+    current_root_path = tmp_path / "scanning-current"
+    proposed_root_path = tmp_path / "scanning-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "Scanning Preview", str(current_root_path))
+    library.is_scanning = True
+    db.commit()
+
+    with pytest.raises(LibraryRelocationError, match="scan is queued or running"):
+        preview_library_root_relocation(
+            db,
+            library=library,
+            proposed_path=str(proposed_root_path),
+        )
+
+
+def test_preview_library_root_relocation_rejects_queued_scan_job(db, tmp_path):
+    current_root_path = tmp_path / "queued-current"
+    proposed_root_path = tmp_path / "queued-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "Queued Preview", str(current_root_path))
+    db.add(ScanJob(library_id=library.id, job_type=JobType.SCAN, status=JobStatus.PENDING))
+    db.commit()
+
+    with pytest.raises(LibraryRelocationError) as exc_info:
+        preview_library_root_relocation(
+            db,
+            library=library,
+            proposed_path=str(proposed_root_path),
+        )
+
+    assert str(exc_info.value) == LIBRARY_SCAN_ACTIVE_MESSAGE
 
 
 def test_preview_library_root_relocation_requires_root_id_for_multiple_active_roots(db, tmp_path):
@@ -223,6 +263,33 @@ def test_confirm_library_root_relocation_updates_root_and_preserves_comic_identi
     assert refreshed_missing.library_root_id == root_id
     assert refreshed_matched.relative_path == "Alpha/one.cbz"
     assert refreshed_missing.relative_path == "Beta/two.cbz"
+
+
+def test_confirm_library_root_relocation_rejects_running_cleanup_job(db, tmp_path):
+    current_root_path = tmp_path / "cleanup-current"
+    proposed_root_path = tmp_path / "cleanup-proposed"
+    current_root_path.mkdir()
+    proposed_root_path.mkdir()
+
+    library = create_library_with_root(db, "Cleanup Confirm", str(current_root_path))
+    root = library.active_root
+    volume = _create_volume(db, library)
+    create_comic(db, volume, root, "Alpha/one.cbz", filename="one.cbz")
+    db.add(ScanJob(library_id=library.id, job_type=JobType.CLEANUP, status=JobStatus.RUNNING))
+    db.commit()
+
+    _write_file(proposed_root_path / "Alpha" / "one.cbz")
+
+    with pytest.raises(LibraryRelocationError) as exc_info:
+        confirm_library_root_relocation(
+            db,
+            library=library,
+            proposed_path=str(proposed_root_path),
+        )
+
+    assert str(exc_info.value) == LIBRARY_SCAN_ACTIVE_MESSAGE
+    db.refresh(root)
+    assert root.path == str(current_root_path)
 
 
 def test_confirm_library_root_relocation_rejects_when_no_existing_files_match(db, tmp_path):

--- a/tests/services/test_watcher_service.py
+++ b/tests/services/test_watcher_service.py
@@ -6,6 +6,7 @@ import pytest
 from watchdog.observers import Observer
 
 import app.services.watcher as watcher
+from app.services.settings_service import SCANNING_BATCH_WINDOW_MIN_SECONDS
 
 
 class DummyTimer:
@@ -163,7 +164,7 @@ def test_refresh_watches_adds_and_removes_and_closes_session(monkeypatch):
     q.all.return_value = [lib]
     monkeypatch.setattr(watcher, "SessionLocal", lambda: db)
 
-    monkeypatch.setattr(watcher, "get_cached_setting", lambda key, default: "45")
+    monkeypatch.setattr(watcher, "get_cached_setting", lambda key, default: "75")
 
     new_handler = MagicMock()
     handler_ctor = MagicMock(return_value=new_handler)
@@ -173,12 +174,47 @@ def test_refresh_watches_adds_and_removes_and_closes_session(monkeypatch):
 
     inst.refresh_watches()
 
-    handler_ctor.assert_called_once_with(2, 45)
+    handler_ctor.assert_called_once_with(2, 75)
     inst.observer.schedule.assert_called_once_with(new_handler, "/library/two", recursive=True)
     old_handler.stop.assert_called_once()
     inst.observer.unschedule.assert_called_once_with(old_watch)
     assert 1 not in inst.watches
     assert 2 in inst.watches
+    db.close.assert_called_once()
+
+
+def test_refresh_watches_clamps_batch_window_to_minimum(monkeypatch):
+    inst = _watcher_instance()
+
+    lib = SimpleNamespace(id=14, active_root=SimpleNamespace(path="/library/minimum"))
+
+    db = MagicMock()
+    q = db.query.return_value
+    q.options.return_value = q
+    q.filter.return_value = q
+    q.all.return_value = [lib]
+    monkeypatch.setattr(watcher, "SessionLocal", lambda: db)
+
+    monkeypatch.setattr(
+        watcher,
+        "get_cached_setting",
+        lambda key, default: str(SCANNING_BATCH_WINDOW_MIN_SECONDS - 1),
+    )
+
+    new_handler = MagicMock()
+    handler_ctor = MagicMock(return_value=new_handler)
+    monkeypatch.setattr(watcher, "LibraryEventHandler", handler_ctor)
+
+    inst.observer.schedule.return_value = "new-watch"
+
+    inst.refresh_watches()
+
+    handler_ctor.assert_called_once_with(14, SCANNING_BATCH_WINDOW_MIN_SECONDS)
+    inst.observer.schedule.assert_called_once_with(
+        new_handler,
+        "/library/minimum",
+        recursive=True,
+    )
     db.close.assert_called_once()
 
 


### PR DESCRIPTION

This PR tightens the safety around library root relocation so an admin cannot preview or confirm a relocation while scan-related work is already queued or running for that library. The relocation flow now checks both the library’s `is_scanning` flag and pending/running scan pipeline jobs before previewing or committing a root path change.

It also reduces watcher-triggered scan churn by enforcing a minimum scan batch window. The batch window setting now uses reusable settings metadata (`min_value`) instead of a one-off key-specific check, so future numeric settings can reuse the same validation shape.

**Changes**
- Block relocation preview when the target library is actively scanning or has queued/running scan pipeline work.
- Block relocation confirmation under the same conditions.
- Re-check scan state immediately before updating the selected `LibraryRoot.path`.
- Treat `scan`, `thumbnail`, and `cleanup` jobs as scan-pipeline work for relocation blocking.
- Add `min_value` metadata support for settings definitions.
- Enforce a 60-second minimum for `scanning.batch_window`.
- Clamp existing too-low batch window values during settings initialization.
- Defensively clamp watcher batch window values when creating new watchers.
- Expose `min_value` through the settings API schema.
- Use `setting.min_value` in the admin settings UI number input.
- Show server-provided settings validation errors in the admin settings toast.
- Document the remaining narrow relocation/scan race and the batch-window mitigation.

**Residual Risk**
There is still a small race where a scan could be queued after confirmation’s final guard check but before the root path update commits. Fully closing that would require a relocation lock that scan enqueue/start also honors. This PR documents that risk and covers the common active/queued scan cases.

**Validation**
- `git diff --check`
- `.\.venv\Scripts\python.exe -m pytest tests\api\test_libraries.py tests\services\test_library_relocation.py tests\api\test_settings.py tests\services\test_watcher_service.py`
- Result: `85 passed`