### PR TITLE
Multi root final phase

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -41,8 +41,8 @@ This file captures follow-up work that should not get lost between releases.
   Follow-up goal: Decide whether to replace ColorThief, patch/vendor the small palette extraction path, or move Parker's palette generation to a maintained Pillow-based quantization approach before upgrading to Pillow 14.
   Guardrail: This is not a `0.1.24` release blocker while Parker remains pinned to Pillow 12.x and tests pass.
 
-- Design support for multi-root libraries after relocation groundwork exists.
-  Context: Parker currently assumes one configured filesystem root per library, but some users may want a single logical library to aggregate comics from multiple folder locations across disks, shares, or staged/import storage.
-  Scope risk: This is likely a medium-to-large architectural change rather than a simple admin-form enhancement because it would affect the data model, scanning, file watching, duplicate handling, library stats, and background-job fairness assumptions. It should build on `library_roots`, `Comic.library_root_id`, and `Comic.relative_path` rather than inventing a separate root model.
-  Follow-up goal: Define root add/relocate/disable/remove flows, how root-level failures and duplicate files should be handled, and what scanner/watcher changes would be required before implementation work begins.
+- Finish product support for multi-root libraries.
+  Context: The relocation/root-identity groundwork exists: Parker has `library_roots`, comics are identified by `Comic.library_root_id` plus `Comic.relative_path`, and the scanner/writer/watcher/diagnostics/janitor foundation is multi-root-aware. The admin/API surface still largely treats one active root as the editable path for a library.
+  Scope risk: The remaining work is still product-facing and needs careful root lifecycle policy, validation, and UX rather than just another scanner change.
+  Follow-up goal: Add explicit root add/disable/remove flows, decide the inaccessible/offline root policy, validate overlapping roots across all libraries, and update admin/UI surfaces to manage multiple roots intentionally.
   Design note: `docs/multi-root-library-scope.md`

--- a/app/models/library.py
+++ b/app/models/library.py
@@ -28,3 +28,7 @@ class Library(Base):
     @property
     def active_root(self) -> Optional["LibraryRoot"]:
         return next((r for r in self.roots if r.is_active), None)
+
+    @property
+    def active_roots(self) -> list["LibraryRoot"]:
+        return [r for r in self.roots if r.is_active]

--- a/app/services/maintenance.py
+++ b/app/services/maintenance.py
@@ -23,6 +23,22 @@ class MaintenanceService:
         self.logger = logging.getLogger(__name__)
         self.enrichment = EnrichmentService()
 
+    def _active_root_paths_for_cleanup(self, library_id: int = None) -> dict[int, str]:
+        query = self.db.query(LibraryRoot).filter(LibraryRoot.is_active == True)
+        if library_id:
+            query = query.filter(LibraryRoot.library_id == library_id)
+
+        roots = query.order_by(LibraryRoot.id).all()
+        missing_roots = [root for root in roots if not os.path.exists(root.path)]
+        if missing_roots:
+            missing_root = missing_roots[0]
+            raise FileNotFoundError(
+                "Janitor cleanup aborted because active library root path "
+                f"does not exist: {missing_root.path}"
+            )
+
+        return {root.id: root.path for root in roots}
+
     def cleanup_orphans(self, library_id: int = None) -> dict:
         """
         Delete metadata entities that are no longer associated with any comics.
@@ -104,15 +120,14 @@ class MaintenanceService:
         """
         Removes dead records and returns a list of their IDs for thumbnail cleanup.
         """
+        root_paths = self._active_root_paths_for_cleanup(library_id)
+
         query = self.db.query(Comic)
         if library_id:
             query = query.join(Volume).join(Series).filter(Series.library_id == library_id)
 
         comics = query.all()
         deleted_ids = []
-
-        # Cache root paths since many comics typically share the same root(s).
-        root_paths: dict[int, str] = {}
 
         for comic in comics:
             if comic.library_root_id not in root_paths:
@@ -209,4 +224,3 @@ class MaintenanceService:
             self.db.commit()
 
         return {"updated": updated_count, "total_scanned": len(lists)}
-    

--- a/app/services/scanner.py
+++ b/app/services/scanner.py
@@ -45,18 +45,20 @@ class LibraryScanner:
         """
         Parallel metadata extraction + single-writer DB updates.
         """
-        library_root = (
+        library_roots = (
             self.db.query(LibraryRoot)
             .filter(LibraryRoot.library_id == self.library.id, LibraryRoot.is_active == True)
-            .first()
+            .order_by(LibraryRoot.id)
+            .all()
         )
-        if library_root is None:
-            raise FileNotFoundError(f"Library '{self.library.name}' has no active root configured")
+        if not library_roots:
+            raise FileNotFoundError(f"Library '{self.library.name}' has no active roots configured")
 
-        library_path = Path(library_root.path)
+        root_paths = [(library_root, Path(library_root.path)) for library_root in library_roots]
 
-        if not library_path.exists():
-            raise FileNotFoundError(f"Library path does not exist: {library_root.path}")
+        for library_root, library_path in root_paths:
+            if not library_path.exists():
+                raise FileNotFoundError(f"Library path does not exist: {library_root.path}")
 
         self.reconciled_folders.clear()
         self.reconciled_volumes.clear()
@@ -81,37 +83,46 @@ class LibraryScanner:
         scanned_keys = set()
         skipped = 0
 
-        for file_path in library_path.rglob("*"):
-            if file_path.suffix.lower() not in self.supported_extensions:
-                continue
-
-            file_path_str = str(file_path)
-            # Always resolves: file_path_str is necessarily a child of library_path,
-            # since rglob() only yields files physically nested under it.
-            relative_path = compute_relative_path(library_root.path, file_path_str)
-            key = (library_root.id, relative_path)
-            existing = existing_by_key.get(key)
-
-            # --- CONTAINER RECONCILIATION ---
-            # This runs for EVERY file, but the logic inside ensures it only
-            # performs the disk-check once per folder.
-            self._reconcile_sidecars(file_path, existing, library_root.path)
-
-            scanned_keys.add(key)
-
-            file_mtime = os.path.getmtime(file_path)
-
-            if existing:
-                # unchanged file -> skip unless force=True
-                if not force and existing.file_modified_at and existing.file_modified_at >= file_mtime:
-                    skipped += 1
+        for library_root, library_path in root_paths:
+            for file_path in library_path.rglob("*"):
+                if file_path.suffix.lower() not in self.supported_extensions:
                     continue
 
-                # changed file -> update
-                tasks.append(file_path_str)
-            else:
-                # new file -> import
-                tasks.append(file_path_str)
+                file_path_str = str(file_path)
+                # Always resolves: file_path_str is necessarily a child of this
+                # library_path, since rglob() only yields files physically nested under it.
+                relative_path = compute_relative_path(library_root.path, file_path_str)
+                key = (library_root.id, relative_path)
+                existing = existing_by_key.get(key)
+
+                # --- CONTAINER RECONCILIATION ---
+                # This runs for EVERY file, but the logic inside ensures it only
+                # performs the disk-check once per folder.
+                self._reconcile_sidecars(file_path, existing, library_root.path)
+
+                scanned_keys.add(key)
+
+                file_mtime = os.path.getmtime(file_path)
+
+                if existing:
+                    # unchanged file -> skip unless force=True
+                    if not force and existing.file_modified_at and existing.file_modified_at >= file_mtime:
+                        skipped += 1
+                        continue
+
+                    # changed file -> update
+                    tasks.append({
+                        "file_path": file_path_str,
+                        "library_root_id": library_root.id,
+                        "library_root_path": library_root.path,
+                    })
+                else:
+                    # new file -> import
+                    tasks.append({
+                        "file_path": file_path_str,
+                        "library_root_id": library_root.id,
+                        "library_root_path": library_root.path,
+                    })
 
         # Persist any sidecar reconciliation updates found during discovery.
         self.db.commit()
@@ -216,7 +227,11 @@ class LibraryScanner:
         self.collection_service.cleanup_empty_collections()
 
         # Update library scan time
-        self.library.last_scanned = datetime.now(timezone.utc)
+        scanned_at = datetime.now(timezone.utc)
+        self.library.last_scanned = scanned_at
+        for library_root in library_roots:
+            library_root.last_scanned_at = scanned_at
+            library_root.last_scan_error = None
         self.db.commit()
 
         elapsed = round(time.time() - start_time, 2)

--- a/app/services/startup_diagnostics.py
+++ b/app/services/startup_diagnostics.py
@@ -114,7 +114,13 @@ def _detect_runtime_mode(
     if comics_root_exists:
         return RUNTIME_MODE_CONTAINER
 
-    if any(_looks_like_container_library_path(item.get("path", "")) for item in library_sample):
+    library_paths = []
+    for item in library_sample:
+        if item.get("path"):
+            library_paths.append(item["path"])
+        library_paths.extend(root.get("path", "") for root in item.get("roots", []))
+
+    if any(_looks_like_container_library_path(path) for path in library_paths):
         return RUNTIME_MODE_CONTAINER
 
     return RUNTIME_MODE_LOCAL
@@ -215,10 +221,22 @@ def collect_startup_diagnostics(
     ):
         active_root = library.active_root
         root_path = active_root.path if active_root else None
+        roots = [
+            {
+                "id": root.id,
+                "path": root.path,
+                "is_active": root.is_active,
+                "path_exists": _safe_path_exists(root.path),
+            }
+            for root in sorted(library.roots, key=lambda row: row.id)
+        ]
         library_sample.append({
             "name": library.name,
             "path": root_path,
             "path_exists": _safe_path_exists(root_path),
+            "root_count": len(roots),
+            "active_root_count": sum(1 for root in roots if root["is_active"]),
+            "roots": roots,
         })
 
     comics_root_exists = comics_root.exists()

--- a/app/services/watcher.py
+++ b/app/services/watcher.py
@@ -105,7 +105,7 @@ class LibraryWatcher:
 
         self.logger = logging.getLogger(__name__)
         self.observer = Observer()
-        self.watches = {}  # Map library_id -> watch_object
+        self.watches = {}  # Map (library_id, root_id) -> (watch_object, handler)
         self.is_running = False
         self._initialized = True
 
@@ -136,8 +136,13 @@ class LibraryWatcher:
                 .filter(Library.watch_mode == True)
                 .all()
             )
-            active_ids = {lib.id for lib in libraries}
-            current_ids = set(self.watches.keys())
+            active_roots = {
+                (lib.id, root.id): (lib, root)
+                for lib in libraries
+                for root in lib.active_roots
+            }
+            active_keys = set(active_roots.keys())
+            current_keys = set(self.watches.keys())
 
             # Fetch Dynamic Setting (Default 600s if missing)
             # We fetch it once per refresh so all new watches use the updated value.
@@ -146,34 +151,36 @@ class LibraryWatcher:
 
             # 2. Add new watches
             for lib in libraries:
-                if lib.id not in self.watches:
-                    active_root = lib.active_root
-                    if active_root is None:
-                        self.logger.error(f"Library {lib.id} ('{lib.name}') has no active root; skipping watch")
-                        continue
+                if not lib.active_roots:
+                    self.logger.error(f"Library {lib.id} ('{lib.name}') has no active roots; skipping watch")
 
-                    try:
-                        self.logger.info(f"Starting watch for: {active_root.path}")
-                        handler = LibraryEventHandler(lib.id, int(batch_window))
-                        watch = self.observer.schedule(handler, active_root.path, recursive=True)
+            for key, (lib, active_root) in active_roots.items():
+                if key in self.watches:
+                    continue
 
-                        # Store both so we can cancel the handler later
-                        self.watches[lib.id] = (watch, handler)
-                    except Exception as e:
-                        self.logger.error(f"Failed to watch {active_root.path}: {e}")
+                try:
+                    self.logger.info(f"Starting watch for: {active_root.path}")
+                    handler = LibraryEventHandler(lib.id, int(batch_window))
+                    watch = self.observer.schedule(handler, active_root.path, recursive=True)
+
+                    # Store both so we can cancel the handler later
+                    self.watches[key] = (watch, handler)
+                except Exception as e:
+                    self.logger.error(f"Failed to watch {active_root.path}: {e}")
 
             # 3. Remove old watches (if disabled in DB)
-            for lib_id in current_ids:
-                if lib_id not in active_ids:
-                    self.logger.info(f"Stopping watch for Library {lib_id}")
-                    watch, handler = self.watches[lib_id]
+            for key in current_keys:
+                if key not in active_keys:
+                    lib_id, root_id = key
+                    self.logger.info(f"Stopping watch for Library {lib_id} root {root_id}")
+                    watch, handler = self.watches[key]
 
                     # Cancel any pending timer
                     handler.stop()
 
                     # Unschedule from watchdog
                     self.observer.unschedule(watch)
-                    del self.watches[lib_id]
+                    del self.watches[key]
 
         finally:
             db.close()

--- a/app/services/workers/metadata_worker.py
+++ b/app/services/workers/metadata_worker.py
@@ -1,9 +1,24 @@
 from pathlib import Path
 
-def metadata_worker(file_path) -> dict:
+def _worker_context(file_input) -> tuple[str, dict]:
+    if isinstance(file_input, dict):
+        file_path = file_input["file_path"]
+        context = {
+            key: file_input[key]
+            for key in ("library_root_id", "library_root_path")
+            if key in file_input
+        }
+        return file_path, context
+
+    return file_input, {}
+
+
+def metadata_worker(file_input) -> dict:
     from app.services.archive import ComicArchive
     from app.services.metadata import parse_comicinfo
     import os
+
+    file_path, context = _worker_context(file_input)
 
     try:
         path = Path(file_path)
@@ -14,7 +29,12 @@ def metadata_worker(file_path) -> dict:
         with ComicArchive(path) as archive:
             pages = archive.get_pages()
             if not isinstance(pages, list) or len(pages) == 0:
-                return {"file_path": file_path, "error": True, "message": "No valid pages found (archive unreadable)"}
+                return {
+                    "file_path": file_path,
+                    "error": True,
+                    "message": "No valid pages found (archive unreadable)",
+                    **context,
+                }
 
             xml = archive.get_comicinfo()
 
@@ -23,7 +43,8 @@ def metadata_worker(file_path) -> dict:
                 return {
                     "file_path": file_path,
                     "error": True,
-                    "message": "Missing ComicInfo.xml"
+                    "message": "Missing ComicInfo.xml",
+                    **context,
                 }
 
             # 1. Establish Physical Truth of page count
@@ -46,8 +67,9 @@ def metadata_worker(file_path) -> dict:
             "size": size,
             "metadata": metadata,
             "error": False,
+            **context,
         }
 
     except Exception as e:
         #print(e)
-        return {"file_path": file_path, "error": True, "message": str(e)}
+        return {"file_path": file_path, "error": True, "message": str(e), **context}

--- a/app/services/workers/metadata_writer.py
+++ b/app/services/workers/metadata_writer.py
@@ -1,3 +1,33 @@
+def _item_root_context(
+    item,
+    *,
+    default_library_root_id,
+    default_library_root_path,
+    root_paths_by_id,
+):
+    library_root_id = item.get("library_root_id", default_library_root_id)
+    library_root_path = item.get("library_root_path")
+
+    if library_root_id is not None:
+        try:
+            library_root_id = int(library_root_id)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Metadata item has invalid library root identity") from exc
+
+    if root_paths_by_id and library_root_id is not None:
+        library_root_path = root_paths_by_id.get(library_root_id)
+        if library_root_path is None:
+            raise ValueError("Metadata item references unknown library root")
+
+    if library_root_path is None:
+        library_root_path = default_library_root_path
+
+    if library_root_id is None or library_root_path is None:
+        raise ValueError("Metadata item is missing library root identity")
+
+    return library_root_id, library_root_path
+
+
 def _apply_metadata_batch(
     db,
     batch,
@@ -8,8 +38,9 @@ def _apply_metadata_batch(
     credit_service,
     reading_list_service,
     collection_service,
-    library_root_id,
-    library_root_path,
+    library_root_id=None,
+    library_root_path=None,
+    root_paths_by_id=None,
     parse_reading_lists=True,
     parse_collections=True,
     parse_story_arcs=True,
@@ -19,6 +50,7 @@ def _apply_metadata_batch(
     from app.models.comic import Comic
     from app.core.path_utils import compute_relative_path
     from datetime import datetime, timezone
+    from inspect import Parameter, signature
     import json
 
     def _normalize_number(number: str) -> str:
@@ -45,6 +77,29 @@ def _apply_metadata_batch(
         except (TypeError, ValueError):
             return 1
 
+    def _accepts_file_path_arg(func) -> bool:
+        try:
+            parameters = list(signature(func).parameters.values())
+        except (TypeError, ValueError):
+            return True
+
+        if any(parameter.kind == Parameter.VAR_POSITIONAL for parameter in parameters):
+            return True
+
+        positional_parameters = [
+            parameter
+            for parameter in parameters
+            if parameter.kind in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+        return len(positional_parameters) >= 2
+
+    get_or_create_series_accepts_path = _accepts_file_path_arg(get_or_create_series)
+
+    def _get_or_create_series(name: str, file_path: str):
+        if get_or_create_series_accepts_path:
+            return get_or_create_series(name, file_path)
+        return get_or_create_series(name)
+
     imported = 0
     updated = 0
     errors = 0
@@ -66,11 +121,33 @@ def _apply_metadata_batch(
         mtime = item["mtime"]
         size = item["size"]
         updated_at = datetime.now(timezone.utc)
+        try:
+            item_library_root_id, item_library_root_path = _item_root_context(
+                item,
+                default_library_root_id=library_root_id,
+                default_library_root_path=library_root_path,
+                root_paths_by_id=root_paths_by_id,
+            )
+        except ValueError as exc:
+            errors += 1
+            error_details.append({
+                "file_path": file_path,
+                "message": str(exc),
+            })
+            continue
 
-        # Always resolves: the scanner only ever sends paths physically nested
-        # under the library's active root.
-        relative_path = compute_relative_path(library_root_path, file_path)
-        existing = existing_by_key.get((library_root_id, relative_path))
+        # Always resolves for scanner-provided tasks: the scanner only sends
+        # paths physically nested under the selected library root.
+        relative_path = compute_relative_path(item_library_root_path, file_path)
+        if relative_path is None:
+            errors += 1
+            error_details.append({
+                "file_path": file_path,
+                "message": "File is not under its assigned library root",
+            })
+            continue
+
+        existing = existing_by_key.get((item_library_root_id, relative_path))
 
         # --- Determine Import vs Update ---
         if existing:
@@ -84,14 +161,14 @@ def _apply_metadata_batch(
         # Robust 'Unknown' handling for Series Name to prevent NOT NULL errors
         # If metadata['series'] is None or "", default to "Unknown Series"
         series_name = metadata.get("series") or "Unknown Series"
-        series = get_or_create_series(series_name)
+        series = _get_or_create_series(series_name, file_path)
 
         # Get or create volume (Uses Cache)
         volume_num = _normalize_volume_number(metadata.get("volume"))
         volume = get_or_create_volume(series, volume_num, file_path)
         comic.volume_id = volume.id
 
-        comic.library_root_id = library_root_id
+        comic.library_root_id = item_library_root_id
         comic.relative_path = relative_path
 
         # --- Basic fields ---
@@ -175,7 +252,7 @@ def _apply_metadata_batch(
         if action == "import":
             comic.is_dirty = True
             imported += 1
-            existing_by_key[(library_root_id, relative_path)] = comic
+            existing_by_key[(item_library_root_id, relative_path)] = comic
 
         elif action == "update":
             # If the scanner sent it, we *know* it changed (or force=True)
@@ -214,26 +291,37 @@ def metadata_writer(
         from app.services.credits import CreditService
         from app.services.reading_list import ReadingListService
         from app.services.collection import CollectionService
+        from app.core.path_utils import compute_relative_path
         from app.services.sidecar_service import SidecarService
         from pathlib import Path
 
         engine.dispose()
         db = SessionLocal()
 
-        # Get library path for sidecars
+        # Get library roots for physical identity and sidecar boundaries.
         library = db.get(Library, library_id)
 
-        library_root = (
+        library_roots = (
             db.query(LibraryRoot)
             .filter(LibraryRoot.library_id == library_id, LibraryRoot.is_active == True)
-            .first()
+            .order_by(LibraryRoot.id)
+            .all()
         )
-        if library_root is None:
+        if not library_roots:
             raise ValueError(f"Library '{library.name}' has no active root configured")
 
-        library_root_id = library_root.id
-        library_root_path = library_root.path
-        lib_path = Path(library_root.path)
+        root_paths_by_id = {root.id: root.path for root in library_roots}
+        root_paths_for_matching = sorted(root_paths_by_id.values(), key=len, reverse=True)
+        default_root = library_roots[0] if len(library_roots) == 1 else None
+        default_library_root_id = default_root.id if default_root else None
+        default_library_root_path = default_root.path if default_root else None
+
+        def root_path_for_file(file_path_str: str) -> Path:
+            for root_path in root_paths_for_matching:
+                if compute_relative_path(root_path, file_path_str) is not None:
+                    return Path(root_path)
+
+            return Path(default_library_root_path or root_paths_for_matching[0])
 
         # Preload existing comics
         existing_comics = (
@@ -256,7 +344,7 @@ def metadata_writer(
 
         batch = []
 
-        def get_or_create_series(name: str):
+        def get_or_create_series(name: str, file_path_str: str | None = None):
             """Get existing series or create new one with Caching"""
 
             # 1. Check local cache
@@ -272,6 +360,7 @@ def metadata_writer(
 
                 # Boundary Protection: Don't check root or "Unknown"
                 if name != "Unknown Series":
+                    lib_path = root_path_for_file(file_path_str) if file_path_str else Path(default_library_root_path or root_paths_for_matching[0])
                     series_path = lib_path / name
                     # Physical Guard: Ensure it's a valid subfolder, not the root
                     if series_path != lib_path and lib_path in series_path.parents:
@@ -302,7 +391,9 @@ def metadata_writer(
                 # --- BOUNDARY PROTECTION ---
                 folder_path = Path(file_path_str).parent
 
-                # Only look for a sidecar if the folder is NOT the library root
+                lib_path = root_path_for_file(file_path_str)
+
+                # Only look for a sidecar if the folder is NOT the containing library root.
                 if folder_path != lib_path:
                     v.summary_override = SidecarService.get_summary_from_disk(folder_path, "volume")
 
@@ -331,8 +422,9 @@ def metadata_writer(
                     parse_reading_lists=parse_reading_lists,
                     parse_collections=parse_collections,
                     parse_story_arcs=parse_story_arcs,
-                    library_root_id=library_root_id,
-                    library_root_path=library_root_path,
+                    library_root_id=default_library_root_id,
+                    library_root_path=default_library_root_path,
+                    root_paths_by_id=root_paths_by_id,
                 )
                 for key in ("imported", "updated", "errors", "skipped"):
                     processed[key] += stats.get(key, 0)
@@ -350,8 +442,9 @@ def metadata_writer(
                     parse_reading_lists=parse_reading_lists,
                     parse_collections=parse_collections,
                     parse_story_arcs=parse_story_arcs,
-                    library_root_id=library_root_id,
-                    library_root_path=library_root_path,
+                    library_root_id=default_library_root_id,
+                    library_root_path=default_library_root_path,
+                    root_paths_by_id=root_paths_by_id,
             )
             for key in ("imported", "updated", "errors", "skipped"):
                 processed[key] += stats.get(key, 0)

--- a/app/services/workers/metadata_writer.py
+++ b/app/services/workers/metadata_writer.py
@@ -77,7 +77,7 @@ def _apply_metadata_batch(
         except (TypeError, ValueError):
             return 1
 
-    def _accepts_file_path_arg(func) -> bool:
+    def _accepts_positional_args(func, count: int) -> bool:
         try:
             parameters = list(signature(func).parameters.values())
         except (TypeError, ValueError):
@@ -91,14 +91,20 @@ def _apply_metadata_batch(
             for parameter in parameters
             if parameter.kind in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
         ]
-        return len(positional_parameters) >= 2
+        return len(positional_parameters) >= count
 
-    get_or_create_series_accepts_path = _accepts_file_path_arg(get_or_create_series)
+    get_or_create_series_accepts_root_path = _accepts_positional_args(get_or_create_series, 2)
+    get_or_create_volume_accepts_root_path = _accepts_positional_args(get_or_create_volume, 4)
 
-    def _get_or_create_series(name: str, file_path: str):
-        if get_or_create_series_accepts_path:
-            return get_or_create_series(name, file_path)
+    def _get_or_create_series(name: str, item_library_root_path: str):
+        if get_or_create_series_accepts_root_path:
+            return get_or_create_series(name, item_library_root_path)
         return get_or_create_series(name)
+
+    def _get_or_create_volume(series, volume_num: int, file_path: str, item_library_root_path: str):
+        if get_or_create_volume_accepts_root_path:
+            return get_or_create_volume(series, volume_num, file_path, item_library_root_path)
+        return get_or_create_volume(series, volume_num, file_path)
 
     imported = 0
     updated = 0
@@ -161,11 +167,11 @@ def _apply_metadata_batch(
         # Robust 'Unknown' handling for Series Name to prevent NOT NULL errors
         # If metadata['series'] is None or "", default to "Unknown Series"
         series_name = metadata.get("series") or "Unknown Series"
-        series = _get_or_create_series(series_name, file_path)
+        series = _get_or_create_series(series_name, item_library_root_path)
 
         # Get or create volume (Uses Cache)
         volume_num = _normalize_volume_number(metadata.get("volume"))
-        volume = get_or_create_volume(series, volume_num, file_path)
+        volume = _get_or_create_volume(series, volume_num, file_path, item_library_root_path)
         comic.volume_id = volume.id
 
         comic.library_root_id = item_library_root_id
@@ -291,7 +297,6 @@ def metadata_writer(
         from app.services.credits import CreditService
         from app.services.reading_list import ReadingListService
         from app.services.collection import CollectionService
-        from app.core.path_utils import compute_relative_path
         from app.services.sidecar_service import SidecarService
         from pathlib import Path
 
@@ -311,17 +316,10 @@ def metadata_writer(
             raise ValueError(f"Library '{library.name}' has no active root configured")
 
         root_paths_by_id = {root.id: root.path for root in library_roots}
-        root_paths_for_matching = sorted(root_paths_by_id.values(), key=len, reverse=True)
         default_root = library_roots[0] if len(library_roots) == 1 else None
         default_library_root_id = default_root.id if default_root else None
         default_library_root_path = default_root.path if default_root else None
-
-        def root_path_for_file(file_path_str: str) -> Path:
-            for root_path in root_paths_for_matching:
-                if compute_relative_path(root_path, file_path_str) is not None:
-                    return Path(root_path)
-
-            return Path(default_library_root_path or root_paths_for_matching[0])
+        fallback_library_root_path = default_library_root_path or library_roots[0].path
 
         # Preload existing comics
         existing_comics = (
@@ -344,7 +342,7 @@ def metadata_writer(
 
         batch = []
 
-        def get_or_create_series(name: str, file_path_str: str | None = None):
+        def get_or_create_series(name: str, item_library_root_path: str | None = None):
             """Get existing series or create new one with Caching"""
 
             # 1. Check local cache
@@ -360,7 +358,7 @@ def metadata_writer(
 
                 # Boundary Protection: Don't check root or "Unknown"
                 if name != "Unknown Series":
-                    lib_path = root_path_for_file(file_path_str) if file_path_str else Path(default_library_root_path or root_paths_for_matching[0])
+                    lib_path = Path(item_library_root_path or fallback_library_root_path)
                     series_path = lib_path / name
                     # Physical Guard: Ensure it's a valid subfolder, not the root
                     if series_path != lib_path and lib_path in series_path.parents:
@@ -373,7 +371,7 @@ def metadata_writer(
             series_cache[name] = series
             return series
 
-        def get_or_create_volume(series, num, file_path_str: str):
+        def get_or_create_volume(series, num, file_path_str: str, item_library_root_path: str | None = None):
             """Get existing volume or create new one with Caching"""
 
             # Composite key for cache
@@ -391,7 +389,7 @@ def metadata_writer(
                 # --- BOUNDARY PROTECTION ---
                 folder_path = Path(file_path_str).parent
 
-                lib_path = root_path_for_file(file_path_str)
+                lib_path = Path(item_library_root_path or fallback_library_root_path)
 
                 # Only look for a sidecar if the folder is NOT the containing library root.
                 if folder_path != lib_path:

--- a/docs/multi-root-library-scope.md
+++ b/docs/multi-root-library-scope.md
@@ -1,334 +1,198 @@
 # Multi-Root Library Scope
 
-Status: Draft
+Status: Foundation in place, product surface pending
 
-This note captures a possible future enhancement where one Parker library can aggregate comics from multiple filesystem roots instead of a single configured folder.
+This note tracks Parker's path from one physical folder per library to one logical library with multiple configured filesystem roots.
 
 Related design note: `docs/library-relocation-scope.md`.
 
-Recommended sequencing: build graceful library-root relocation before full multi-root support. Relocation introduces the root identity and relative-path model that multi-root support should reuse.
-
-The goal is to document the likely impact area before real user demand exists, so the work can be evaluated intentionally later instead of being estimated from memory.
-
 ## Why This Exists
 
-Some users may eventually want one logical library to span more than one folder location.
-
-Examples:
+Some users may want one logical library to span more than one storage location:
 
 - comics split across multiple drives
 - NAS and local-storage hybrids
-- "active" and "archive" roots that should still appear as one library
+- active and archive folders that should still appear as one library
 - staged imports that should belong to an existing library instead of a second library tile
 
-This is not currently a known blocker for Parker adoption.
-It is mainly a parity observation against tools like Kavita and a reminder that Parker was originally designed around one library path per library.
+The useful framing is:
+
+- one logical library
+- many explicit storage roots
+
+Parker should not auto-discover arbitrary storage locations. Admins should intentionally attach each root to a library.
 
 ## Current System Shape
 
-Today Parker models one library as one root path.
+The relocation groundwork has already moved Parker away from `Library.path` as the physical identity:
 
-That assumption appears directly in several places:
+- `Library` is the logical library.
+- `LibraryRoot` represents a physical filesystem root.
+- `Library.roots` stores all configured roots.
+- `Library.active_root` remains a compatibility helper for single-root surfaces.
+- `Library.active_roots` returns every active root for services that can process multiple roots.
+- `Series.library_id` remains attached to the logical library.
+- `Comic.library_root_id` identifies the root containing the archive.
+- `Comic.relative_path` identifies the archive under that root.
 
-- `Library.path` is a single string field in `app/models/library.py`
-- library create/update validation checks one path and rejects overlapping library paths in `app/api/libraries.py`
-- library scans walk exactly one root with `Path(self.library.path).rglob("*")` in `app/services/scanner.py`
-- watch mode schedules one watchdog subscription per library in `app/services/watcher.py`
-- metadata-sidecar reconciliation uses the library path as a boundary in `app/services/scanner.py` and `app/services/workers/metadata_writer.py`
-- startup diagnostics sample one path per library in `app/services/startup_diagnostics.py`
+Physical file identity is:
 
-This means multi-root support is not just an admin-form change.
-It would change one of Parker's basic storage assumptions.
+- `(library_root_id, relative_path)`
 
-## Non-Goals
+That identity must remain the backbone for scanner cleanup, metadata writes, and future root lifecycle operations.
 
-Out of scope for an initial multi-root implementation:
+## Foundation Behavior
 
-- support for loose image reading outside Parker's existing archive model
-- merging separate libraries at the metadata/entity level
-- deduplicating identical comics by page/hash/content fingerprint
-- automatic unioning of arbitrary folders without admin configuration
-- changing user permissions from library-based access to root-based access
+The foundation layer should behave as if multiple active roots can already exist, even before the admin UI exposes full root management.
 
-## Product Framing
+Scanner behavior:
 
-If Parker adds this feature, the better framing is likely:
-
-- one logical library
-- many storage roots
-
-Not:
-
-- one library automatically discovers storage everywhere
-
-The admin should still explicitly decide which roots belong to a library.
-
-## Suggested Data Model
-
-Recommended direction: add a dedicated child table rather than overloading `Library.path`.
-
-This should align with the relocation design:
-
-- `Library` stays the logical library
-- `LibraryRoot` represents a physical filesystem root
-- `Series.library_id` remains attached to the logical library
-- `Comic.library_root_id` identifies the root containing the physical archive
-- `Comic.relative_path` identifies the archive under that root
-
-In other words, the hierarchy remains:
-
-- `Library -> Series -> Volume -> Comic`
-
-Storage roots sit beside that hierarchy:
-
-- `Library -> LibraryRoot`
-- `Comic -> LibraryRoot`
-
-Example shape:
-
-- keep `libraries` as the logical library record
-- add `library_roots`
-- each root belongs to one library
-- each root stores a normalized path string plus any root-specific metadata we eventually need
-
-Possible columns:
-
-- `id`
-- `library_id`
-- `path`
-- `created_at`
-- `updated_at`
-
-Optional future columns if needed:
-
-- `enabled`
-- `last_scan_error`
-- `last_seen_at`
-
-Why this is preferable:
-
-- preserves the existing meaning of `Library`
-- allows one-to-many roots cleanly
-- gives watcher/scanner code a first-class structure to target
-- avoids stuffing serialized path arrays into one column
-
-## Migration Strategy
-
-The least risky migration would be shared with the library relocation work:
-
-1. create `library_roots`
-2. backfill one root row from each existing `libraries.path`
-3. add `Comic.library_root_id` and `Comic.relative_path`
-4. backfill each comic's root and relative path
-5. keep `libraries.path` and `comics.file_path` temporarily for compatibility during the transition
-6. update application code to read roots from the new table
-7. remove or deprecate direct `Library.path` usage after the codebase is fully migrated
-
-The exact length of the compatibility period is a product decision.
-If the code churn is manageable, it may be cleaner to migrate quickly rather than support dual behavior for too long.
-
-## Scanner Impact
-
-The scanner is one of the main change points.
-
-Today `LibraryScanner.scan_parallel()` in `app/services/scanner.py`:
-
-- resolves one `library_path`
-- walks one root recursively
-- builds one set of `scanned_paths_on_disk`
-- treats any missing previously known file as deleted
-
-With multi-root support, Parker would likely need to:
-
-- resolve all roots for the library
-- scan each root recursively
-- compute `relative_path` under the current root for each archive
+- load all active roots for the library
+- verify every active root path exists before discovery or cleanup
+- walk each active root independently
+- compute `relative_path` under the root being scanned
 - match existing comics by `(library_root_id, relative_path)`
-- preserve one cleanup pass that understands root identity
+- pass root context into metadata worker jobs
+- cleanup only after all active roots were reachable
+- mark each active root with the completed scan timestamp
 
-Important nuance:
+Metadata behavior:
 
-- cleanup should treat a file as missing only within the root that owns that comic
-- moving a file between roots is a different operation from a normal scan and should require a deliberate relocation or reconciliation flow
+- preserve scanner-provided root context through worker results
+- write comics using the item root identity
+- use the matching physical root as the sidecar boundary
+- allow the same `relative_path` to exist under different roots
 
-## Watcher Impact
+Watcher behavior:
 
-Watch mode would also need a structural change.
+- schedule one watchdog subscription per active root
+- key watch bookkeeping by `(library_id, root_id)`
+- keep queueing scan jobs by `library_id`
+- let existing scan coalescing handle events from multiple roots
 
-Today `LibraryWatcher` in `app/services/watcher.py` effectively keeps:
+Diagnostics behavior:
 
-- one library id
-- one scheduled watch
-- one event handler
+- report root counts
+- include per-root path, active state, and existence checks
+- retain the legacy primary `path`/`path_exists` fields while single-root admin surfaces still depend on them
 
-Multi-root support would likely require:
+Janitor cleanup behavior:
 
-- one library id
-- many scheduled watch objects
-- possibly one handler per root, all queueing the same library scan
+- resolve physical comic paths from `library_root_id` plus `relative_path`
+- verify active roots for the cleanup scope before deleting missing-file records
+- abort missing-file cleanup if any active root in that scope is unreachable
 
-Recommended behavior:
+## Safety Rules
 
-- keep queueing scans by `library_id`, not by root
-- let multiple root events coalesce into the same existing batch-window behavior
+An active root that is offline is different from a deleted comic.
 
-The bookkeeping changes are not conceptually hard, but they are easy to get subtly wrong.
-
-## Sidecar Boundary Impact
-
-Parker currently uses the library root as a boundary when reconciling series and volume sidecars.
-
-Relevant code lives in:
-
-- `app/services/scanner.py`
-- `app/services/workers/metadata_writer.py`
-
-This means multi-root support should define:
-
-- sidecars only apply within the root that contains the file being processed
-- parent walking stops at that specific root boundary, not a generic library-wide virtual boundary
-
-That is probably the cleanest rule and stays close to current behavior.
-
-## Admin API And UI Impact
-
-The admin library flows in `app/api/libraries.py` currently assume:
-
-- one path on create
-- one path on edit
-- overlap validation against other libraries using one candidate path
-
-Multi-root support would need:
-
-- create/edit APIs that expose a collection of roots
-- explicit root actions such as add, relocate, disable, and remove
-- root add/remove/update UI
-- validation that checks every candidate root against every existing root in the system
-
-Recommended guardrails:
-
-- reject roots that overlap one another, even inside the same library
-- reject roots that overlap another library's roots
-- normalize path comparisons before validating
-- avoid silently changing root paths through a generic library edit form
-
-This keeps the mental model simple and avoids ambiguous ownership of the same subtree.
-
-## Duplicate Policy
-
-Duplicate imports are not unique to multi-root libraries.
-They can already happen today when the same archive exists in different subfolders under one root.
-
-What multi-root changes is the importance of defining the policy clearly across all scanned paths.
-
-Questions Parker should answer before implementation:
-
-- if the same file appears in two configured roots, should both imports be allowed?
-- should Parker warn only, or block overlapping/duplicate-looking roots up front?
-- should Parker eventually detect likely duplicates by normalized file path, filename, size, archive hash, or not at all?
-
-Recommended initial stance:
-
-- do not attempt content-level deduplication as part of the first multi-root release
-- keep prevention focused on root-overlap validation
-- treat broader duplicate detection as a separate problem
-- use `(library_root_id, relative_path)` as the physical file identity, not absolute path alone
-
-## Diagnostics And Support Impact
-
-Startup and support diagnostics currently report one path per library in `app/services/startup_diagnostics.py`.
-
-Multi-root support would likely need:
-
-- library root counts
-- a per-root sample instead of one path string
-- per-root existence checks
-- clearer support messaging when only some roots are reachable
-
-This matters because "library exists but one root is offline" becomes a valid operational state.
-
-## Permissions And User Access
-
-The current permission model is library-based, not path-based.
-
-That is a strength here.
-Parker likely should not introduce root-level permissions in an MVP.
+Scanner and janitor missing-file cleanup should fail safely if any active root in scope is unreachable. They should not prune comics from reachable roots or unreachable roots during that run, because the missing root may be an offline drive, unmounted share, or temporary permissions issue.
 
 Recommended rule:
 
-- if a user can access the library, they can access content imported from any of that library's configured roots
+- all active roots reachable: scan and cleanup normally
+- any active root in scope unreachable: fail before cleanup and leave database rows untouched
 
-This keeps the feature focused on storage aggregation rather than access-control redesign.
+This is intentionally conservative. It protects users from accidental mass deletes caused by partial storage availability.
 
-## Background Jobs And Fairness
+## Sidecar Boundary Rule
 
-Multi-root support should continue to behave like one library from the job scheduler's perspective.
+Sidecars apply within the physical root containing the file being processed.
 
-That means:
+For a comic in root A, parent walking stops at root A. For a comic in root B, parent walking stops at root B. There is no virtual library-wide filesystem boundary across every root.
 
-- scan jobs are still queued per library
+This keeps multi-root behavior close to existing single-root behavior.
+
+## Permissions
+
+Parker's access model remains library-based.
+
+Recommended MVP rule:
+
+- if a user can access the library, they can access content imported from any active root attached to that library
+
+Root-level permissions are out of scope for the initial multi-root feature.
+
+## Non-Goals
+
+Out of scope for initial multi-root support:
+
+- loose image reading outside Parker's existing archive model
+- metadata/entity-level merging of separate libraries
+- root-level user permissions
+- automatic discovery of arbitrary folders
+- content-hash deduplication
+- automatic file moves between roots
+
+## Remaining Product Work
+
+The foundation does not complete multi-root as an admin-facing feature.
+
+Remaining work:
+
+- add root management API actions
+- add admin UI for listing roots
+- add explicit add, disable, relocate, and remove flows
+- validate new roots against every configured root in the system
+- reject overlapping roots within the same library
+- reject overlapping roots across libraries
+- decide whether zero-root libraries are allowed during editing
+- define what happens to comics when a root is disabled or removed
+- update support/admin views so partial root failures are understandable
+
+Root lifecycle actions should be explicit. A generic library edit form should not silently change or remove storage roots.
+
+## Duplicate Policy
+
+Duplicate-looking comics can already exist inside one root. Multi-root support makes the policy more visible but does not require content-level deduplication.
+
+Recommended MVP stance:
+
+- prevent root overlap up front
+- treat `(library_root_id, relative_path)` as the physical file identity
+- allow the same relative path under different non-overlapping roots
+- do not attempt archive hash or page hash deduplication in the first release
+- consider duplicate reporting later if users need it
+
+## Background Jobs
+
+Multi-root libraries should still behave like one library to the scheduler:
+
+- scan jobs are queued per library
 - thumbnail jobs remain library-scoped
 - metadata rehydrate remains library-scoped
 
-The nuance is performance fairness:
-
-- a library with many large roots may become heavier than a single-root library
-- this is mostly an operational concern, not a reason to block the feature
-
-It may eventually justify better scan progress reporting or per-root progress visibility, but that should not be required for an MVP.
-
-## Suggested MVP
-
-The smallest useful implementation would likely be:
-
-- support multiple configured roots per library
-- update scanner to walk all roots and union results
-- update watcher to monitor all roots and still queue by library
-- update admin create/edit flows for multiple roots
-- update diagnostics to surface roots clearly
-- keep permissions library-based
-- keep duplicate handling conservative and simple
-
-This MVP assumes the relocation groundwork exists first. If it does not, the MVP should begin by introducing `library_roots`, `Comic.library_root_id`, and `Comic.relative_path` before adding multiple roots to the UI.
-
-## Open Questions
-
-- Should an empty library be allowed to exist temporarily with zero roots during editing?
-- Should root ordering matter in the UI or for future diagnostics?
-- Should Parker allow disabling one root without removing it?
-- Should the library detail API continue to expose one legacy `path` field during transition, or move directly to `roots`?
-- How much backward compatibility is worth carrying for older clients or templates that expect `library.path`?
+A library with several large roots may be operationally heavier than a small single-root library. That may eventually justify better scan progress reporting, but it should not block the MVP.
 
 ## Recommended Implementation Order
 
-If Parker ever decides to build this, a safe order would likely be:
+1. Keep the relocation/root-identity foundation in place.
+2. Make scanner, metadata writer, watcher, diagnostics, and janitor cleanup root-list aware.
+3. Add root management API actions.
+4. Add admin UI for root list and root lifecycle operations.
+5. Add overlap validation across all roots.
+6. Decide disable/remove/offline root policy.
+7. Improve diagnostics and support messaging for partial root failures.
+8. Add broader browser coverage once the UI exists.
 
-1. implement safe single-root relocation as described in `docs/library-relocation-scope.md`
-2. keep one root per library until scanner, reader, watcher, and diagnostics understand root identity
-3. add admin UI/API support for adding more roots to an existing library
-4. update scanner cleanup behavior across root identities
-5. update watcher scheduling/bookkeeping
-6. update diagnostics and support surfaces
-7. add regression coverage
+Items 1 and 2 are the service foundation. Items 3 through 8 are the remaining product feature.
 
 ## Testing Notes
 
-Minimum coverage should include:
+Foundation coverage should include:
 
-- migration/backfill behavior from one path to one root row
-- scanner imports across multiple roots in one library
-- cleanup only deleting comics absent from all roots
-- watcher refresh registering and unregistering multiple watches for one library
-- sidecar reconciliation stopping at the correct root boundary
-- admin validation rejecting overlapping roots
+- scanner imports and cleanup across multiple active roots
+- scanner failing before cleanup when any active root is unreachable
+- janitor missing-file cleanup failing before deletion when any active root in scope is unreachable
+- metadata worker preserving root context
+- metadata writer importing the same relative path under different roots
+- sidecar resolution stopping at the current physical root
+- watcher registering and unregistering one watch per active root
+- diagnostics reporting root counts and per-root existence checks
 
-## Effort Estimate
+Product/UI coverage should later include:
 
-This looks like a medium-to-large feature rather than a quick enhancement.
-
-Rough estimate:
-
-- MVP: moderate project with several touching systems
-- polished release: larger due to migration, watcher edge cases, admin UX, diagnostics, and regression coverage
-
-In practical terms, this is probably best treated as a deliberate feature project with a design pass first, not something to casually slip into a small release.
+- root add/disable/remove APIs
+- overlap validation against same-library and cross-library roots
+- admin root list rendering
+- browser coverage for expected root lifecycle flows

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -29,6 +29,7 @@ from app.models.saved_search import SavedSearch
 from app.models.series import Series
 from app.models.tags import Character
 from app.models.user import User
+from app.routers import pages as pages_router
 
 from tests.factories import create_library_with_root
 
@@ -239,6 +240,16 @@ def browser_server(browser_db_factory, browser_seed_data, monkeypatch_session):
             session.close()
 
     monkeypatch_session.setattr("app.api.reader.ImageService", BrowserImageService)
+    original_get_cached_setting = pages_router.get_cached_setting
+
+    def browser_get_cached_setting(key: str, default: Any = None) -> Any:
+        # This setting helper bypasses dependency overrides, so keep the
+        # browser server isolated from whatever the local app database contains.
+        if key == "ui.auto_redirect_single_volume_series":
+            return False
+        return original_get_cached_setting(key, default)
+
+    monkeypatch_session.setattr(pages_router, "get_cached_setting", browser_get_cached_setting)
 
     app.dependency_overrides[get_db] = override_get_db
     app.dependency_overrides[get_current_user] = override_get_current_user

--- a/tests/services/test_maintenance_service.py
+++ b/tests/services/test_maintenance_service.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
 from app.models.activity_log import ActivityLog
 from app.models.collection import Collection, CollectionItem
 from app.models.comic import Comic, Volume
@@ -20,7 +22,9 @@ def _create_library(db, name: str, tmp_path: Path) -> Library:
     lib = Library(name=name)
     db.add(lib)
     db.flush()
-    root = LibraryRoot(library_id=lib.id, path=str(tmp_path / name), is_active=True)
+    root_path = tmp_path / name
+    root_path.mkdir(parents=True, exist_ok=True)
+    root = LibraryRoot(library_id=lib.id, path=str(root_path), is_active=True)
     db.add(root)
     db.flush()
     return lib
@@ -267,6 +271,39 @@ def test_cleanup_missing_files_reconstructs_path_from_root_instead_of_stale_file
     assert deleted_ids == [truly_missing.id]
     assert db.get(Comic, healthy.id) is not None
     assert db.get(Comic, truly_missing.id) is None
+
+
+def test_cleanup_missing_files_scoped_aborts_when_active_root_missing(db, tmp_path, monkeypatch):
+    lib = _create_library(db, "maint-missing-active-root", tmp_path)
+    missing = _create_comic(db, lib, "missing", "stale-location/gone.cbz")
+    db.add(LibraryRoot(library_id=lib.id, path=str(tmp_path / "offline-root"), is_active=True))
+    db.commit()
+
+    service = MaintenanceService(db)
+    original_commit = db.commit
+    commit_spy = MagicMock(side_effect=original_commit)
+    monkeypatch.setattr(db, "commit", commit_spy)
+
+    with pytest.raises(FileNotFoundError, match="Janitor cleanup aborted"):
+        service.cleanup_missing_files(library_id=lib.id)
+
+    assert db.get(Comic, missing.id) is not None
+    commit_spy.assert_not_called()
+
+
+def test_cleanup_missing_files_global_aborts_when_any_active_root_missing(db, tmp_path):
+    healthy_lib = _create_library(db, "maint-global-healthy-root", tmp_path)
+    offline_lib = _create_library(db, "maint-global-offline-root", tmp_path)
+    missing = _create_comic(db, healthy_lib, "missing", "stale-location/gone.cbz")
+    offline_lib.active_root.path = str(tmp_path / "offline-global-root")
+    db.commit()
+
+    service = MaintenanceService(db)
+
+    with pytest.raises(FileNotFoundError, match="Janitor cleanup aborted"):
+        service.cleanup_missing_files()
+
+    assert db.get(Comic, missing.id) is not None
 
 
 def test_cleanup_missing_files_deletes_user_ratings_and_activity_log(db, tmp_path):

--- a/tests/services/test_metadata_worker.py
+++ b/tests/services/test_metadata_worker.py
@@ -41,6 +41,40 @@ def test_metadata_worker_success_overrides_xml_page_count(monkeypatch, tmp_path)
     assert payload["size"] == file_path.stat().st_size
 
 
+def test_metadata_worker_preserves_library_root_context(monkeypatch, tmp_path):
+    file_path = _write_comic_file(tmp_path, name="root-context.cbz")
+
+    class ArchiveWithXml:
+        def __init__(self, _path):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get_pages(self):
+            return ["p1"]
+
+        def get_comicinfo(self):
+            return "<xml/>"
+
+    monkeypatch.setattr("app.services.archive.ComicArchive", ArchiveWithXml)
+    monkeypatch.setattr("app.services.metadata.parse_comicinfo", lambda _xml: {"title": "Parsed"})
+
+    payload = metadata_worker_module.metadata_worker({
+        "file_path": str(file_path),
+        "library_root_id": 42,
+        "library_root_path": "/library/root",
+    })
+
+    assert payload["error"] is False
+    assert payload["file_path"] == str(file_path)
+    assert payload["library_root_id"] == 42
+    assert payload["library_root_path"] == "/library/root"
+
+
 def test_metadata_worker_returns_error_when_pages_missing(monkeypatch, tmp_path):
     file_path = _write_comic_file(tmp_path, name="no-pages.cbz")
 

--- a/tests/services/test_metadata_writer.py
+++ b/tests/services/test_metadata_writer.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from app.models.comic import Comic, Volume
+from app.models.library_root import LibraryRoot
 from app.models.series import Series
 import app.database as database_module
 import app.services.workers.metadata_writer as metadata_writer_module
@@ -46,10 +47,15 @@ class _FakeQuery:
     def filter_by(self, **_kwargs):
         return self
 
+    def order_by(self, *_args, **_kwargs):
+        return self
+
     def first(self):
         return self.library_root_obj
 
     def all(self):
+        if getattr(self.model, "__name__", "") == "LibraryRoot":
+            return [self.library_root_obj]
         return []
 
 
@@ -279,6 +285,144 @@ def test_apply_metadata_batch_matches_existing_comic_by_identity_when_path_diffe
     db.refresh(existing_comic)
     assert existing_comic.title == "Renamed On Disk"
     assert db.query(Comic).count() == 1
+
+
+def test_apply_metadata_batch_uses_item_root_identity(db, tmp_path):
+    first_root_path = tmp_path / "first"
+    second_root_path = tmp_path / "second"
+    first_root_path.mkdir()
+    second_root_path.mkdir()
+
+    library, first_root = _seed_library_with_root(db, "writer-multi-root-lib", str(first_root_path))
+    second_root = LibraryRoot(library_id=library.id, path=str(second_root_path), is_active=True)
+    db.add(second_root)
+    db.flush()
+
+    def get_or_create_series(name: str, _file_path: str):
+        series = db.query(Series).filter_by(name=name, library_id=library.id).first()
+        if not series:
+            series = Series(name=name, library_id=library.id)
+            db.add(series)
+            db.flush()
+        return series
+
+    def get_or_create_volume(series, volume_num: int, _file_path: str):
+        volume = db.query(Volume).filter_by(series_id=series.id, volume_number=volume_num).first()
+        if not volume:
+            volume = Volume(series_id=series.id, volume_number=volume_num)
+            db.add(volume)
+            db.flush()
+        return volume
+
+    tag_service = SimpleNamespace(
+        get_or_create_characters=MagicMock(return_value=[]),
+        get_or_create_teams=MagicMock(return_value=[]),
+        get_or_create_locations=MagicMock(return_value=[]),
+        get_or_create_genres=MagicMock(return_value=[]),
+    )
+    credit_service = SimpleNamespace(add_credits_to_comic=MagicMock())
+    reading_list_service = SimpleNamespace(update_comic_reading_lists=MagicMock())
+    collection_service = SimpleNamespace(update_comic_collections=MagicMock())
+
+    batch = [
+        {
+            "file_path": str(first_root_path / "Shared" / "issue.cbz"),
+            "mtime": 1.0,
+            "size": 100,
+            "metadata": _metadata(series="Shared Series", volume="1", number="1"),
+            "error": False,
+            "library_root_id": first_root.id,
+            "library_root_path": str(first_root_path),
+        },
+        {
+            "file_path": str(second_root_path / "Shared" / "issue.cbz"),
+            "mtime": 2.0,
+            "size": 200,
+            "metadata": _metadata(series="Shared Series", volume="1", number="2"),
+            "error": False,
+            "library_root_id": second_root.id,
+            "library_root_path": str(second_root_path),
+        },
+    ]
+
+    stats = metadata_writer_module._apply_metadata_batch(
+        db,
+        batch,
+        {},
+        get_or_create_series,
+        get_or_create_volume,
+        tag_service,
+        credit_service,
+        reading_list_service,
+        collection_service,
+        root_paths_by_id={
+            first_root.id: str(first_root_path),
+            second_root.id: str(second_root_path),
+        },
+    )
+
+    first_comic = db.query(Comic).filter_by(
+        library_root_id=first_root.id,
+        relative_path="Shared/issue.cbz",
+    ).first()
+    second_comic = db.query(Comic).filter_by(
+        library_root_id=second_root.id,
+        relative_path="Shared/issue.cbz",
+    ).first()
+
+    assert stats["imported"] == 2
+    assert stats["updated"] == 0
+    assert stats["errors"] == 0
+    assert first_comic is not None
+    assert second_comic is not None
+    assert first_comic.number == "1"
+    assert second_comic.number == "2"
+
+
+def test_apply_metadata_batch_reports_unknown_item_root(db, tmp_path):
+    library, root = _seed_library_with_root(db, "writer-unknown-root-lib", str(tmp_path))
+
+    get_or_create_series = MagicMock()
+    get_or_create_volume = MagicMock()
+    tag_service = SimpleNamespace(
+        get_or_create_characters=MagicMock(return_value=[]),
+        get_or_create_teams=MagicMock(return_value=[]),
+        get_or_create_locations=MagicMock(return_value=[]),
+        get_or_create_genres=MagicMock(return_value=[]),
+    )
+    credit_service = SimpleNamespace(add_credits_to_comic=MagicMock())
+    reading_list_service = SimpleNamespace(update_comic_reading_lists=MagicMock())
+    collection_service = SimpleNamespace(update_comic_collections=MagicMock())
+
+    stats = metadata_writer_module._apply_metadata_batch(
+        db,
+        [{
+            "file_path": str(tmp_path / "issue.cbz"),
+            "mtime": 1.0,
+            "size": 100,
+            "metadata": _metadata(),
+            "error": False,
+            "library_root_id": root.id + 1000,
+        }],
+        {},
+        get_or_create_series,
+        get_or_create_volume,
+        tag_service,
+        credit_service,
+        reading_list_service,
+        collection_service,
+        root_paths_by_id={root.id: str(tmp_path)},
+    )
+
+    assert stats["imported"] == 0
+    assert stats["updated"] == 0
+    assert stats["errors"] == 1
+    assert stats["error_details"] == [{
+        "file_path": str(tmp_path / "issue.cbz"),
+        "message": "Metadata item references unknown library root",
+    }]
+    get_or_create_series.assert_not_called()
+    get_or_create_volume.assert_not_called()
 
 
 def test_apply_metadata_batch_disables_optional_metadata_flows(db):
@@ -699,3 +843,109 @@ def test_metadata_writer_populates_library_root_and_relative_path(monkeypatch, d
     assert new_comic is not None
     assert new_comic.library_root_id == root_id
     assert new_comic.relative_path == "Fresh/fresh.cbz"
+
+
+def test_metadata_writer_imports_multiple_roots_from_item_context(monkeypatch, db, tmp_path):
+    first_root_path = tmp_path / "writer-root-a"
+    second_root_path = tmp_path / "writer-root-b"
+    first_root_path.mkdir(parents=True, exist_ok=True)
+    second_root_path.mkdir(parents=True, exist_ok=True)
+
+    library, first_root = _seed_library_with_root(db, "writer-context-multi-root", str(first_root_path))
+    second_root = LibraryRoot(library_id=library.id, path=str(second_root_path), is_active=True)
+    db.add(second_root)
+    db.commit()
+    library_id = library.id
+    first_root_id = first_root.id
+    second_root_id = second_root.id
+
+    class DummyTagService:
+        def __init__(self, _db):
+            pass
+
+        def get_or_create_characters(self, _vals):
+            return []
+
+        def get_or_create_teams(self, _vals):
+            return []
+
+        def get_or_create_locations(self, _vals):
+            return []
+
+        def get_or_create_genres(self, _vals):
+            return []
+
+    class DummyCreditService:
+        def __init__(self, _db):
+            pass
+
+        def add_credits_to_comic(self, comic, _metadata):
+            return comic
+
+    class DummyReadingListService:
+        def __init__(self, _db):
+            pass
+
+        def update_comic_reading_lists(self, comic, _alt_series, _alt_number):
+            return comic
+
+    class DummyCollectionService:
+        def __init__(self, _db):
+            pass
+
+        def update_comic_collections(self, comic, _series_group):
+            return comic
+
+    monkeypatch.setattr(database_module.engine, "dispose", MagicMock())
+    monkeypatch.setattr(database_module, "SessionLocal", lambda: db)
+    monkeypatch.setattr("app.services.tags.TagService", DummyTagService)
+    monkeypatch.setattr("app.services.credits.CreditService", DummyCreditService)
+    monkeypatch.setattr("app.services.reading_list.ReadingListService", DummyReadingListService)
+    monkeypatch.setattr("app.services.collection.CollectionService", DummyCollectionService)
+    monkeypatch.setattr(
+        "app.services.sidecar_service.SidecarService.get_summary_from_disk",
+        MagicMock(return_value=None),
+    )
+
+    relative_path = "Shared/issue.cbz"
+    result_queue = _ReadQueue([
+        {
+            "file_path": str(first_root_path / relative_path),
+            "mtime": 1.0,
+            "size": 100,
+            "metadata": _metadata(series="Shared Series", volume="1", number="1"),
+            "error": False,
+            "library_root_id": first_root_id,
+            "library_root_path": str(first_root_path),
+        },
+        {
+            "file_path": str(second_root_path / relative_path),
+            "mtime": 2.0,
+            "size": 200,
+            "metadata": _metadata(series="Shared Series", volume="1", number="2"),
+            "error": False,
+            "library_root_id": second_root_id,
+            "library_root_path": str(second_root_path),
+        },
+        None,
+    ])
+    stats_queue = _WriteQueue()
+
+    metadata_writer_module.metadata_writer(result_queue, stats_queue, library_id=library_id, batch_size=50)
+
+    summary = stats_queue.items[-1]
+    first_comic = db.query(Comic).filter_by(
+        library_root_id=first_root_id,
+        relative_path=relative_path,
+    ).first()
+    second_comic = db.query(Comic).filter_by(
+        library_root_id=second_root_id,
+        relative_path=relative_path,
+    ).first()
+
+    assert summary["summary"] is True
+    assert summary["imported"] == 2
+    assert summary["updated"] == 0
+    assert summary["errors"] == 0
+    assert first_comic is not None
+    assert second_comic is not None

--- a/tests/services/test_metadata_writer.py
+++ b/tests/services/test_metadata_writer.py
@@ -949,3 +949,98 @@ def test_metadata_writer_imports_multiple_roots_from_item_context(monkeypatch, d
     assert summary["errors"] == 0
     assert first_comic is not None
     assert second_comic is not None
+
+
+def test_metadata_writer_uses_assigned_root_for_sidecar_boundary(monkeypatch, db, tmp_path):
+    outer_root_path = tmp_path / "writer-overlap-root"
+    nested_root_path = outer_root_path / "Shared"
+    nested_root_path.mkdir(parents=True, exist_ok=True)
+
+    library, outer_root = _seed_library_with_root(db, "writer-overlap-boundary", str(outer_root_path))
+    nested_root = LibraryRoot(library_id=library.id, path=str(nested_root_path), is_active=True)
+    db.add(nested_root)
+    db.commit()
+    library_id = library.id
+    outer_root_id = outer_root.id
+
+    class DummyTagService:
+        def __init__(self, _db):
+            pass
+
+        def get_or_create_characters(self, _vals):
+            return []
+
+        def get_or_create_teams(self, _vals):
+            return []
+
+        def get_or_create_locations(self, _vals):
+            return []
+
+        def get_or_create_genres(self, _vals):
+            return []
+
+    class DummyCreditService:
+        def __init__(self, _db):
+            pass
+
+        def add_credits_to_comic(self, comic, _metadata):
+            return comic
+
+    class DummyReadingListService:
+        def __init__(self, _db):
+            pass
+
+        def update_comic_reading_lists(self, comic, _alt_series, _alt_number):
+            return comic
+
+    class DummyCollectionService:
+        def __init__(self, _db):
+            pass
+
+        def update_comic_collections(self, comic, _series_group):
+            return comic
+
+    sidecar_lookup = MagicMock(side_effect=lambda path, entity: f"{entity}:{Path(path).name}")
+
+    monkeypatch.setattr(database_module.engine, "dispose", MagicMock())
+    monkeypatch.setattr(database_module, "SessionLocal", lambda: db)
+    monkeypatch.setattr("app.services.tags.TagService", DummyTagService)
+    monkeypatch.setattr("app.services.credits.CreditService", DummyCreditService)
+    monkeypatch.setattr("app.services.reading_list.ReadingListService", DummyReadingListService)
+    monkeypatch.setattr("app.services.collection.CollectionService", DummyCollectionService)
+    monkeypatch.setattr("app.services.sidecar_service.SidecarService.get_summary_from_disk", sidecar_lookup)
+
+    result_queue = _ReadQueue([
+        {
+            "file_path": str(nested_root_path / "issue.cbz"),
+            "mtime": 1.0,
+            "size": 100,
+            "metadata": _metadata(series="Overlap Series", volume="1", number="1"),
+            "error": False,
+            "library_root_id": outer_root_id,
+            "library_root_path": str(outer_root_path),
+        },
+        None,
+    ])
+    stats_queue = _WriteQueue()
+
+    metadata_writer_module.metadata_writer(result_queue, stats_queue, library_id=library_id, batch_size=50)
+
+    summary = stats_queue.items[-1]
+    created_volume = (
+        db.query(Volume)
+        .join(Series)
+        .filter(Series.library_id == library_id, Series.name == "Overlap Series")
+        .one()
+    )
+    volume_sidecar_paths = [
+        Path(call.args[0])
+        for call in sidecar_lookup.call_args_list
+        if call.args[1] == "volume"
+    ]
+
+    assert summary["summary"] is True
+    assert summary["imported"] == 1
+    assert summary["errors"] == 0
+    assert created_volume.summary_override == "volume:Shared"
+    assert volume_sidecar_paths == [nested_root_path]

--- a/tests/services/test_scanner.py
+++ b/tests/services/test_scanner.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.models.comic import Comic, Volume
+from app.models.library_root import LibraryRoot
 from app.models.series import Series
 from app.services.scanner import LibraryScanner
 import app.services.scanner as scanner_module
@@ -27,6 +28,92 @@ def test_scan_parallel_raises_when_library_path_missing(db, tmp_path):
 
     with pytest.raises(FileNotFoundError):
         scanner.scan_parallel()
+
+
+def test_scan_parallel_raises_before_cleanup_when_any_active_root_missing(db, tmp_path):
+    first_root_path = tmp_path / "first"
+    missing_root_path = tmp_path / "missing"
+    first_root_path.mkdir()
+
+    scanner, library = _build_scanner(db, first_root_path, name="scanner-missing-root-lib")
+    db.add(LibraryRoot(library_id=library.id, path=str(missing_root_path), is_active=True))
+    db.commit()
+
+    scanner._cleanup_missing_files = MagicMock()
+
+    with pytest.raises(FileNotFoundError, match="Library path does not exist"):
+        scanner.scan_parallel()
+
+    scanner._cleanup_missing_files.assert_not_called()
+
+
+def test_scan_parallel_cleans_up_missing_files_across_all_active_roots(db, tmp_path):
+    first_root_path = tmp_path / "first"
+    second_root_path = tmp_path / "second"
+    first_root_path.mkdir()
+    second_root_path.mkdir()
+
+    scanner, library = _build_scanner(db, first_root_path, name="scanner-multi-root-lib")
+    first_root = library.active_root
+    second_root = LibraryRoot(library_id=library.id, path=str(second_root_path), is_active=True)
+    db.add(second_root)
+    db.flush()
+
+    series = Series(name="Multi Root Cleanup", library_id=library.id)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    first_file = first_root_path / "first.cbz"
+    second_file = second_root_path / "second.cbz"
+    first_file.write_bytes(b"first")
+    second_file.write_bytes(b"second")
+
+    future_mtime = max(first_file.stat().st_mtime, second_file.stat().st_mtime) + 60
+    first_comic = create_comic(
+        db,
+        volume,
+        first_root,
+        "first.cbz",
+        number="1",
+        filename="first.cbz",
+        file_modified_at=future_mtime,
+        page_count=10,
+    )
+    second_comic = create_comic(
+        db,
+        volume,
+        second_root,
+        "second.cbz",
+        number="2",
+        filename="second.cbz",
+        file_modified_at=future_mtime,
+        page_count=10,
+    )
+    missing_comic = create_comic(
+        db,
+        volume,
+        second_root,
+        "missing.cbz",
+        number="3",
+        filename="missing.cbz",
+        file_modified_at=future_mtime,
+        page_count=10,
+    )
+    db.commit()
+
+    result = scanner.scan_parallel(force=False, worker_limit=1)
+
+    assert result["skipped"] == 2
+    assert result["deleted"] == 1
+    assert db.get(Comic, first_comic.id) is not None
+    assert db.get(Comic, second_comic.id) is not None
+    assert db.get(Comic, missing_comic.id) is None
+
+    db.refresh(first_root)
+    db.refresh(second_root)
+    assert first_root.last_scanned_at is not None
+    assert second_root.last_scanned_at is not None
 
 
 def test_cleanup_missing_files_deletes_and_commits(db, tmp_path):

--- a/tests/services/test_scanner_parallel.py
+++ b/tests/services/test_scanner_parallel.py
@@ -13,6 +13,7 @@ from app.models import (
     Collection,
     CollectionItem,
     Comic,
+    LibraryRoot,
     ReadingList,
     ReadingListItem,
     Series,
@@ -23,9 +24,10 @@ from tests.factories import create_comic, create_library_with_root
 
 
 class DummyQuery:
-    def __init__(self, existing, library_root):
+    def __init__(self, model, existing, library_roots):
+        self._model = model
         self._existing = existing
-        self._library_root = library_root
+        self._library_roots = library_roots
 
     def join(self, *_args, **_kwargs):
         return self
@@ -33,21 +35,31 @@ class DummyQuery:
     def filter(self, *_args, **_kwargs):
         return self
 
+    def order_by(self, *_args, **_kwargs):
+        return self
+
     def all(self):
+        if self._model is LibraryRoot:
+            return list(self._library_roots)
         return list(self._existing)
 
     def first(self):
-        return self._library_root
+        return self._library_roots[0] if self._library_roots else None
 
 
 class DummyDB:
     def __init__(self, existing, library_root=None):
         self._existing = existing
-        self._library_root = library_root
+        if library_root is None:
+            self._library_roots = []
+        elif isinstance(library_root, list):
+            self._library_roots = library_root
+        else:
+            self._library_roots = [library_root]
         self.commit_calls = 0
 
-    def query(self, *_args, **_kwargs):
-        return DummyQuery(self._existing, self._library_root)
+    def query(self, model, *_args, **_kwargs):
+        return DummyQuery(model, self._existing, self._library_roots)
 
     def commit(self):
         self.commit_calls += 1
@@ -121,13 +133,25 @@ class TimeoutQueue(FakeQueue):
         raise Empty()
 
 
-def fake_worker(file_path):
+def fake_worker(file_input):
+    if isinstance(file_input, dict):
+        file_path = file_input["file_path"]
+        context = {
+            key: file_input[key]
+            for key in ("library_root_id", "library_root_path")
+            if key in file_input
+        }
+    else:
+        file_path = file_input
+        context = {}
+
     return {
         "file_path": file_path,
         "mtime": 1.0,
         "size": 123,
         "metadata": {"page_count": 1, "raw_metadata": {}},
         "error": False,
+        **context,
     }
 
 
@@ -180,7 +204,7 @@ def test_scan_parallel_orchestrates_pool_writer_and_summary(monkeypatch, tmp_pat
     library_path = tmp_path / "library"
     unchanged = _create_file(library_path / "unchanged.cbz")
     changed = _create_file(library_path / "changed.cbz")
-    _create_file(library_path / "new.cbz")
+    new_file = _create_file(library_path / "new.cbz")
 
     library_root = SimpleNamespace(id=1, path=str(library_path))
     existing = [
@@ -235,6 +259,9 @@ def test_scan_parallel_orchestrates_pool_writer_and_summary(monkeypatch, tmp_pat
 
     queued_payloads = [item for item in result_queue.put_items if item is not None]
     assert len(queued_payloads) == 2
+    assert {payload["file_path"] for payload in queued_payloads} == {str(changed), str(new_file)}
+    assert {payload["library_root_id"] for payload in queued_payloads} == {1}
+    assert {payload["library_root_path"] for payload in queued_payloads} == {str(library_path)}
     assert result_queue.put_items[-1] is None
 
 

--- a/tests/services/test_startup_diagnostics.py
+++ b/tests/services/test_startup_diagnostics.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from app.models.comic import Comic, Volume
+from app.models.library_root import LibraryRoot
 from app.models.series import Series
 from app.models.user import User
 from tests.factories import create_library_with_root
@@ -101,11 +102,7 @@ def test_log_startup_diagnostics_logs_populated_database_summary(db, caplog, tmp
     )
 
     assert any("status=healthy counts users=1 libraries=1 series=1 comics=1" in record.message for record in caplog.records)
-    assert any(
-        "library_sample=[{'name': 'Main Library', 'path': '/comics/main', 'path_exists': False}]"
-        in record.message
-        for record in caplog.records
-    )
+    assert any("Main Library" in record.message and "root_count" in record.message for record in caplog.records)
     assert not any(
         "active database has no libraries configured" in record.message
         for record in caplog.records
@@ -250,3 +247,28 @@ def test_collect_startup_diagnostics_tracks_library_path_existence(db, tmp_path)
     assert by_name["Existing"]["path_exists"] is True
     assert by_name["Missing"]["path_exists"] is False
     assert diagnostics["database"]["size_display"] == "2.0 KB"
+
+
+def test_collect_startup_diagnostics_reports_multiple_library_roots(db, tmp_path):
+    first_root = tmp_path / "First"
+    second_root = tmp_path / "Second"
+    first_root.mkdir()
+
+    library = create_library_with_root(db, "Multi Root", str(first_root))
+    db.add(LibraryRoot(library_id=library.id, path=str(second_root), is_active=True))
+    db.commit()
+
+    db_path = tmp_path / "comics.db"
+    db_path.write_bytes(b"x" * 128)
+
+    diagnostics = collect_startup_diagnostics(
+        db,
+        database_url=f"sqlite:///{db_path.as_posix()}",
+        comics_root=tmp_path / "probe",
+    )
+
+    sample = diagnostics["library_sample"][0]
+    assert sample["name"] == "Multi Root"
+    assert sample["root_count"] == 2
+    assert sample["active_root_count"] == 2
+    assert [root["path_exists"] for root in sample["roots"]] == [True, False]

--- a/tests/services/test_watcher_service.py
+++ b/tests/services/test_watcher_service.py
@@ -1,6 +1,6 @@
 import time
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 from watchdog.observers import Observer
@@ -153,9 +153,9 @@ def test_refresh_watches_adds_and_removes_and_closes_session(monkeypatch):
 
     old_watch = object()
     old_handler = MagicMock()
-    inst.watches = {1: (old_watch, old_handler)}
+    inst.watches = {(1, 10): (old_watch, old_handler)}
 
-    lib = SimpleNamespace(id=2, active_root=SimpleNamespace(path="/library/two"))
+    lib = SimpleNamespace(id=2, active_roots=[SimpleNamespace(id=20, path="/library/two")])
 
     db = MagicMock()
     q = db.query.return_value
@@ -178,15 +178,15 @@ def test_refresh_watches_adds_and_removes_and_closes_session(monkeypatch):
     inst.observer.schedule.assert_called_once_with(new_handler, "/library/two", recursive=True)
     old_handler.stop.assert_called_once()
     inst.observer.unschedule.assert_called_once_with(old_watch)
-    assert 1 not in inst.watches
-    assert 2 in inst.watches
+    assert (1, 10) not in inst.watches
+    assert (2, 20) in inst.watches
     db.close.assert_called_once()
 
 
 def test_refresh_watches_clamps_batch_window_to_minimum(monkeypatch):
     inst = _watcher_instance()
 
-    lib = SimpleNamespace(id=14, active_root=SimpleNamespace(path="/library/minimum"))
+    lib = SimpleNamespace(id=14, active_roots=[SimpleNamespace(id=140, path="/library/minimum")])
 
     db = MagicMock()
     q = db.query.return_value
@@ -218,17 +218,52 @@ def test_refresh_watches_clamps_batch_window_to_minimum(monkeypatch):
     db.close.assert_called_once()
 
 
-def test_refresh_watches_keeps_existing_watch_without_reschedule(monkeypatch):
+def test_refresh_watches_schedules_all_active_roots_for_library(monkeypatch):
     inst = _watcher_instance()
-    keep_watch = object()
-    keep_handler = MagicMock()
-    inst.watches = {9: (keep_watch, keep_handler)}
+
+    lib = SimpleNamespace(
+        id=21,
+        active_roots=[
+            SimpleNamespace(id=210, path="/library/root-a"),
+            SimpleNamespace(id=211, path="/library/root-b"),
+        ],
+    )
 
     db = MagicMock()
     q = db.query.return_value
     q.options.return_value = q
     q.filter.return_value = q
-    q.all.return_value = [SimpleNamespace(id=9, active_root=SimpleNamespace(path="/library/nine"))]
+    q.all.return_value = [lib]
+    monkeypatch.setattr(watcher, "SessionLocal", lambda: db)
+    monkeypatch.setattr(watcher, "get_cached_setting", lambda key, default: 60)
+
+    handlers = [MagicMock(), MagicMock()]
+    handler_ctor = MagicMock(side_effect=handlers)
+    monkeypatch.setattr(watcher, "LibraryEventHandler", handler_ctor)
+    inst.observer.schedule.side_effect = ["watch-a", "watch-b"]
+
+    inst.refresh_watches()
+
+    assert handler_ctor.call_args_list == [call(21, 60), call(21, 60)]
+    assert inst.observer.schedule.call_args_list == [
+        call(handlers[0], "/library/root-a", recursive=True),
+        call(handlers[1], "/library/root-b", recursive=True),
+    ]
+    assert set(inst.watches.keys()) == {(21, 210), (21, 211)}
+    db.close.assert_called_once()
+
+
+def test_refresh_watches_keeps_existing_watch_without_reschedule(monkeypatch):
+    inst = _watcher_instance()
+    keep_watch = object()
+    keep_handler = MagicMock()
+    inst.watches = {(9, 90): (keep_watch, keep_handler)}
+
+    db = MagicMock()
+    q = db.query.return_value
+    q.options.return_value = q
+    q.filter.return_value = q
+    q.all.return_value = [SimpleNamespace(id=9, active_roots=[SimpleNamespace(id=90, path="/library/nine")])]
 
     monkeypatch.setattr(watcher, "SessionLocal", lambda: db)
     monkeypatch.setattr(watcher, "get_cached_setting", lambda key, default: 600)
@@ -238,7 +273,7 @@ def test_refresh_watches_keeps_existing_watch_without_reschedule(monkeypatch):
     inst.observer.schedule.assert_not_called()
     inst.observer.unschedule.assert_not_called()
     keep_handler.stop.assert_not_called()
-    assert 9 in inst.watches
+    assert (9, 90) in inst.watches
 
 
 def test_refresh_watches_logs_schedule_errors(monkeypatch):
@@ -248,7 +283,7 @@ def test_refresh_watches_logs_schedule_errors(monkeypatch):
     q = db.query.return_value
     q.options.return_value = q
     q.filter.return_value = q
-    q.all.return_value = [SimpleNamespace(id=12, active_root=SimpleNamespace(path="/library/bad"))]
+    q.all.return_value = [SimpleNamespace(id=12, active_roots=[SimpleNamespace(id=120, path="/library/bad")])]
 
     monkeypatch.setattr(watcher, "SessionLocal", lambda: db)
     monkeypatch.setattr(watcher, "get_cached_setting", lambda key, default: 10)


### PR DESCRIPTION

Adds the multi-root library service foundation. Parker still exposes a mostly single-root admin surface, but the backend services now understand multiple active `LibraryRoot` rows safely.  This paves the way for the final actual work to display multi root surfaces in the admin area.

**Changed**

- Made scanner discovery and cleanup root-list aware.
- Passed `library_root_id` / `library_root_path` through metadata worker results.
- Updated metadata writer to use per-item root identity for imports, updates, relative paths, and sidecar boundaries.
- Updated watcher bookkeeping to schedule one watch per active root.
- Updated startup diagnostics to report root counts and per-root path status.
- Hardened janitor missing-file cleanup to abort before deletion when an active root in scope is unreachable.

**Validation**

- `.\.venv\Scripts\python.exe -m pytest tests/services/test_metadata_worker.py tests/services/test_metadata_writer.py tests/services/test_scanner.py tests/services/test_scanner_parallel.py tests/services/test_sidecar_reconciliation.py tests/services/test_watcher_service.py tests/services/test_startup_diagnostics.py tests/services/test_maintenance_service.py tests/services/test_scan_manager.py`
- Result: `109 passed`
- `git diff --check` passed with only Windows line-ending warnings.

**Notes**

This does not add the admin UI or API for adding/removing multiple roots yet.

