### PR TITLE
Add multi-root library lifecycle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ https://github.com/parker-server/parker/wiki/Getting-Started
   - Hierarchy: `Library → Series → Volume → Comic`
   - Rich metadata (credits, tags, page counts, colors)
   - Admin folder browser for selecting server-side library paths under `COMICS_PATH`
+  - Multi-root libraries with explicit add, disable, relocate, and remove controls
   - Reading Lists, Collections, Story Arcs, Stacks, Smart Lists
   - Volume-level `Following` for future issue tracking by run
   - Optional single-volume series shortcut to open the volume detail page directly
@@ -192,7 +193,6 @@ Known client behavior:
 - Enhanced WebP transcoding pipeline (JXL, AVIF to WebP)
 - Additional unit test coverage
 - Migration tooling improvements
-- Support multiple folder locations per library
 - Light metadata editing with file writeback (Tentative)
 
 ## 🤝 Contributing

--- a/TODO.md
+++ b/TODO.md
@@ -40,9 +40,3 @@ This file captures follow-up work that should not get lost between releases.
   Context: Full pytest coverage currently emits `DeprecationWarning` from `colorthief==0.2.1` because it calls Pillow's deprecated `Image.Image.getdata`, which is scheduled for removal in Pillow 14 on 2027-10-15.
   Follow-up goal: Decide whether to replace ColorThief, patch/vendor the small palette extraction path, or move Parker's palette generation to a maintained Pillow-based quantization approach before upgrading to Pillow 14.
   Guardrail: This is not a `0.1.24` release blocker while Parker remains pinned to Pillow 12.x and tests pass.
-
-- Finish product support for multi-root libraries.
-  Context: The relocation/root-identity groundwork exists: Parker has `library_roots`, comics are identified by `Comic.library_root_id` plus `Comic.relative_path`, and the scanner/writer/watcher/diagnostics/janitor foundation is multi-root-aware. The admin/API surface still largely treats one active root as the editable path for a library.
-  Scope risk: The remaining work is still product-facing and needs careful root lifecycle policy, validation, and UX rather than just another scanner change.
-  Follow-up goal: Add explicit root add/disable/remove flows, decide the inaccessible/offline root policy, validate overlapping roots across all libraries, and update admin/UI surfaces to manage multiple roots intentionally.
-  Design note: `docs/multi-root-library-scope.md`

--- a/app/api/libraries.py
+++ b/app/api/libraries.py
@@ -22,6 +22,7 @@ from app.services.library_relocation import (
     DEFAULT_SAMPLE_LIMIT,
     LibraryRelocationError,
     confirm_library_root_relocation,
+    ensure_library_root_changes_allowed,
     preview_library_root_relocation,
 )
 from app.services.watcher import library_watcher
@@ -31,12 +32,21 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 LIBRARY_NAME_REQUIRED_MESSAGE = "Library name is required"
+LIBRARY_ROOT_PATH_REQUIRED_MESSAGE = "Library root path is required"
+LIBRARY_ROOT_SCAN_ACTIVE_MESSAGE = "Library roots cannot be changed while a scan is queued or running"
 
 
 def _normalize_library_name(value: str) -> str:
     normalized = value.strip()
     if not normalized:
         raise ValueError(LIBRARY_NAME_REQUIRED_MESSAGE)
+    return normalized
+
+
+def _normalize_library_root_path(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(LIBRARY_ROOT_PATH_REQUIRED_MESSAGE)
     return normalized
 
 
@@ -53,21 +63,45 @@ def _find_library_by_name(
     return query.first()
 
 
+def _find_overlapping_root(
+        db,
+        candidate_path: str,
+        *,
+        exclude_root_id: Optional[int] = None,
+        exclude_library_id: Optional[int] = None,
+) -> Optional[LibraryRoot]:
+    query = db.query(LibraryRoot).join(Library)
+    if exclude_root_id is not None:
+        query = query.filter(LibraryRoot.id != exclude_root_id)
+    if exclude_library_id is not None:
+        query = query.filter(LibraryRoot.library_id != exclude_library_id)
+
+    for root in query.all():
+        if paths_overlap(candidate_path, root.path):
+            return root
+
+    return None
+
+
 def _find_overlapping_library(
         db,
         candidate_path: str,
         *,
         exclude_library_id: Optional[int] = None,
 ) -> Optional[Library]:
-    query = db.query(LibraryRoot).join(Library)
-    if exclude_library_id is not None:
-        query = query.filter(LibraryRoot.library_id != exclude_library_id)
-
-    for root in query.all():
-        if paths_overlap(candidate_path, root.path):
-            return root.library
+    root = _find_overlapping_root(db, candidate_path, exclude_library_id=exclude_library_id)
+    if root is not None:
+        return root.library
 
     return None
+
+
+def _root_overlap_detail(root: LibraryRoot, library: Library) -> str:
+    library_name = root.library.name if root.library else "unknown"
+    if root.library_id == library.id:
+        return f"Library root path overlaps with existing root for library '{library_name}'"
+
+    return f"Library root path overlaps with existing library '{library_name}'"
 
 
 def _has_library_access(library_id: int, current_user: CurrentUser) -> bool:
@@ -82,12 +116,58 @@ def _has_library_access(library_id: int, current_user: CurrentUser) -> bool:
     return True
 
 
-def _library_payload(lib: Library, *, pinned: bool = False, stats: Optional[dict] = None) -> dict:
+def _library_root_payload(root: LibraryRoot, *, comic_count: Optional[int] = None) -> dict:
+    payload = {
+        "id": root.id,
+        "library_id": root.library_id,
+        "path": root.path,
+        "is_active": root.is_active,
+        "last_scanned_at": root.last_scanned_at,
+        "last_scan_error": root.last_scan_error,
+        "created_at": root.created_at,
+        "updated_at": root.updated_at,
+    }
+
+    if comic_count is not None:
+        payload["comic_count"] = comic_count
+
+    return payload
+
+
+def _root_comic_counts(db, roots: list[LibraryRoot]) -> dict[int, int]:
+    root_ids = [root.id for root in roots if root.id is not None]
+    if not root_ids:
+        return {}
+
+    return dict(
+        db.query(Comic.library_root_id, func.count(Comic.id))
+        .filter(Comic.library_root_id.in_(root_ids))
+        .group_by(Comic.library_root_id)
+        .all()
+    )
+
+
+def _library_payload(
+        lib: Library,
+        *,
+        pinned: bool = False,
+        stats: Optional[dict] = None,
+        root_comic_counts: Optional[dict[int, int]] = None,
+) -> dict:
     active_root = lib.active_root
+    roots = sorted(lib.roots, key=lambda root: root.id)
     payload = {
         "id": lib.id,
         "name": lib.name,
         "path": active_root.path if active_root else None,
+        "roots": [
+            _library_root_payload(
+                root,
+                comic_count=root_comic_counts.get(root.id, 0) if root_comic_counts is not None else None,
+            )
+            for root in roots
+        ],
+        "active_root_count": sum(1 for root in roots if root.is_active),
         "scan_on_startup": lib.scan_on_startup,
         "watch_mode": lib.watch_mode,
         "parse_reading_lists": lib.parse_reading_lists,
@@ -103,6 +183,82 @@ def _library_payload(lib: Library, *, pinned: bool = False, stats: Optional[dict
         payload["stats"] = stats
 
     return payload
+
+
+def _get_admin_library(db, library_id: int) -> Library:
+    library = (
+        db.query(Library)
+        .options(selectinload(Library.roots))
+        .filter(Library.id == library_id)
+        .first()
+    )
+    if not library:
+        raise HTTPException(status_code=404, detail="Library not found")
+
+    return library
+
+
+def _get_library_root(library: Library, root_id: int) -> LibraryRoot:
+    root = next((candidate for candidate in library.roots if candidate.id == root_id), None)
+    if root is None:
+        raise HTTPException(status_code=404, detail="Library root not found")
+
+    return root
+
+
+def _ensure_library_roots_mutable(db, library: Library) -> None:
+    try:
+        ensure_library_root_changes_allowed(
+            db,
+            library,
+            message=LIBRARY_ROOT_SCAN_ACTIVE_MESSAGE,
+        )
+    except LibraryRelocationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _delete_comics_for_root(db, root: LibraryRoot) -> dict:
+    comics = db.query(Comic).filter(Comic.library_root_id == root.id).all()
+    volume_ids = {comic.volume_id for comic in comics}
+    series_ids = {
+        series_id
+        for series_id, in db.query(Volume.series_id).filter(Volume.id.in_(volume_ids)).all()
+    } if volume_ids else set()
+
+    for comic in comics:
+        db.delete(comic)
+
+    db.flush()
+
+    deleted_volumes = 0
+    if volume_ids:
+        empty_volumes = db.query(Volume).filter(
+            Volume.id.in_(volume_ids),
+            ~Volume.comics.any(),
+        ).all()
+        deleted_volumes = len(empty_volumes)
+        for volume in empty_volumes:
+            db.delete(volume)
+
+    db.flush()
+
+    deleted_series = 0
+    if series_ids:
+        empty_series = db.query(Series).filter(
+            Series.id.in_(series_ids),
+            ~Series.volumes.any(),
+        ).all()
+        deleted_series = len(empty_series)
+        for series in empty_series:
+            db.delete(series)
+
+    db.flush()
+
+    return {
+        "deleted_comics": len(comics),
+        "deleted_volumes": deleted_volumes,
+        "deleted_series": deleted_series,
+    }
 
 
 def _resolve_library_browser_path(path: Optional[str] = None) -> tuple[FsPath, FsPath]:
@@ -146,6 +302,10 @@ async def list_libraries(db: SessionDep,
         return []
 
     lib_ids = [lib.id for lib in libs]
+    root_comic_counts = _root_comic_counts(
+        db,
+        [root for lib in libs for root in lib.roots],
+    )
     pinned_ids = {
         row.library_id
         for row in db.query(UserLibraryPin.library_id)
@@ -189,6 +349,7 @@ async def list_libraries(db: SessionDep,
         results.append(_library_payload(
             lib,
             pinned=lib.id in pinned_ids,
+            root_comic_counts=root_comic_counts,
             stats={
                 "series": series_counts.get(lib.id, 0),
                 "issues": issue_counts.get(lib.id, 0)
@@ -253,7 +414,11 @@ async def get_library(library: LibraryDep, db: SessionDep, current_user: Current
         UserLibraryPin.library_id == library.id,
     ).first()
 
-    return _library_payload(library, pinned=pin is not None)
+    return _library_payload(
+        library,
+        pinned=pin is not None,
+        root_comic_counts=_root_comic_counts(db, library.roots),
+    )
 
 
 @router.post("/{library_id}/pin", name="pin")
@@ -527,6 +692,19 @@ class LibraryUpdate(BaseModel):
         return _normalize_library_name(value)
 
 
+class LibraryRootCreate(BaseModel):
+    path: str
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        return _normalize_library_root_path(value)
+
+
+class LibraryRootUpdate(BaseModel):
+    is_active: Optional[bool] = None
+
+
 class LibraryRelocationRequest(BaseModel):
     path: str
     root_id: Optional[int] = None
@@ -610,6 +788,135 @@ async def update_library(
         response["rehydration"] = rehydration_result
 
     return response
+
+
+@router.get("/{library_id}/roots", tags=["admin"], name="roots")
+async def list_library_roots(
+        library_id: int,
+        db: SessionDep,
+        admin_user: AdminUser,
+):
+    """List all roots configured for a library."""
+    library = _get_admin_library(db, library_id)
+    counts = _root_comic_counts(db, library.roots)
+
+    return [
+        _library_root_payload(root, comic_count=counts.get(root.id, 0))
+        for root in sorted(library.roots, key=lambda row: row.id)
+    ]
+
+
+@router.post("/{library_id}/roots", tags=["admin"], name="roots_create")
+async def add_library_root(
+        library_id: int,
+        root_in: LibraryRootCreate,
+        db: SessionDep,
+        admin_user: AdminUser,
+):
+    """Attach a new active filesystem root to a library without starting a scan."""
+    library = _get_admin_library(db, library_id)
+    _ensure_library_roots_mutable(db, library)
+
+    overlapping_root = _find_overlapping_root(db, root_in.path)
+    if overlapping_root is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=_root_overlap_detail(overlapping_root, library),
+        )
+
+    root = LibraryRoot(library_id=library.id, path=root_in.path, is_active=True)
+    db.add(root)
+    db.commit()
+    db.refresh(root)
+
+    if library.watch_mode:
+        library_watcher.refresh_watches()
+
+    return _library_root_payload(root, comic_count=0)
+
+
+@router.patch("/{library_id}/roots/{root_id}", tags=["admin"], name="roots_update")
+async def update_library_root(
+        library_id: int,
+        root_id: int,
+        updates: LibraryRootUpdate,
+        db: SessionDep,
+        admin_user: AdminUser,
+):
+    """Enable or disable a library root without changing existing comic rows."""
+    library = _get_admin_library(db, library_id)
+    root = _get_library_root(library, root_id)
+    _ensure_library_roots_mutable(db, library)
+
+    changed = False
+    if updates.is_active is not None and updates.is_active != root.is_active:
+        if updates.is_active:
+            overlapping_root = _find_overlapping_root(db, root.path, exclude_root_id=root.id)
+            if overlapping_root is not None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=_root_overlap_detail(overlapping_root, library),
+                )
+
+        root.is_active = updates.is_active
+        changed = True
+
+    if changed:
+        db.commit()
+        db.refresh(root)
+        if library.watch_mode:
+            library_watcher.refresh_watches()
+
+    comic_count = db.query(func.count(Comic.id)).filter(Comic.library_root_id == root.id).scalar() or 0
+    return _library_root_payload(root, comic_count=comic_count)
+
+
+@router.delete("/{library_id}/roots/{root_id}", tags=["admin"], name="roots_delete")
+async def remove_library_root(
+        library_id: int,
+        root_id: int,
+        db: SessionDep,
+        admin_user: AdminUser,
+        delete_comics: Annotated[
+            bool,
+            Query(description="Delete comic records tied to this root before removing it"),
+        ] = False,
+):
+    """Remove a library root. Roots with comics require delete_comics=true."""
+    library = _get_admin_library(db, library_id)
+    root = _get_library_root(library, root_id)
+    _ensure_library_roots_mutable(db, library)
+
+    comic_count = db.query(func.count(Comic.id)).filter(Comic.library_root_id == root.id).scalar() or 0
+    if comic_count and not delete_comics:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Library root has {comic_count} comic records. "
+                "Pass delete_comics=true to remove the root and delete those records."
+            ),
+        )
+
+    delete_stats = {
+        "deleted_comics": 0,
+        "deleted_volumes": 0,
+        "deleted_series": 0,
+    }
+    if delete_comics:
+        delete_stats = _delete_comics_for_root(db, root)
+
+    db.delete(root)
+    db.commit()
+
+    if library.watch_mode:
+        library_watcher.refresh_watches()
+
+    return {
+        "library_id": library_id,
+        "root_id": root_id,
+        "removed": True,
+        **delete_stats,
+    }
 
 
 @router.post("/{library_id}/relocation/preview", tags=["admin"], name="relocation_preview")

--- a/app/services/library_relocation.py
+++ b/app/services/library_relocation.py
@@ -17,6 +17,8 @@ NO_RELOCATION_MATCHES_MESSAGE = (
     "No existing comics were found at the new path. Move the library files first, "
     "preserving the same folder structure, then preview again."
 )
+ROOT_CHANGE_BLOCKING_JOB_TYPES = (JobType.SCAN, JobType.THUMBNAIL, JobType.CLEANUP)
+ROOT_CHANGE_BLOCKING_JOB_STATUSES = (JobStatus.PENDING, JobStatus.RUNNING)
 
 
 class LibraryRelocationError(ValueError):
@@ -104,7 +106,7 @@ def preview_library_root_relocation(
     root_id: int | None = None,
     sample_limit: int = DEFAULT_SAMPLE_LIMIT,
 ) -> LibraryRootRelocationPreview:
-    _ensure_library_not_scanning(db, library)
+    ensure_library_root_changes_allowed(db, library)
 
     selected_root = _select_relocation_root(library, root_id)
     resolved_proposed_path = _resolve_proposed_path(proposed_path)
@@ -211,7 +213,7 @@ def confirm_library_root_relocation(
     if preview.confirm_blocked:
         raise LibraryRelocationError(NO_RELOCATION_MATCHES_MESSAGE)
 
-    _ensure_library_not_scanning(db, library)
+    ensure_library_root_changes_allowed(db, library)
 
     selected_root = _select_relocation_root(library, preview.root_id)
     selected_root.path = preview.proposed_path
@@ -229,21 +231,26 @@ def confirm_library_root_relocation(
     )
 
 
-def _ensure_library_not_scanning(db: Session, library: Library) -> None:
+def ensure_library_root_changes_allowed(
+    db: Session,
+    library: Library,
+    *,
+    message: str = LIBRARY_SCAN_ACTIVE_MESSAGE,
+) -> None:
     if library.is_scanning:
-        raise LibraryRelocationError(LIBRARY_SCAN_ACTIVE_MESSAGE)
+        raise LibraryRelocationError(message)
 
     active_scan_job = (
         db.query(ScanJob)
         .filter(
             ScanJob.library_id == library.id,
-            ScanJob.job_type.in_([JobType.SCAN, JobType.THUMBNAIL, JobType.CLEANUP]),
-            ScanJob.status.in_([JobStatus.PENDING, JobStatus.RUNNING]),
+            ScanJob.job_type.in_(ROOT_CHANGE_BLOCKING_JOB_TYPES),
+            ScanJob.status.in_(ROOT_CHANGE_BLOCKING_JOB_STATUSES),
         )
         .first()
     )
     if active_scan_job is not None:
-        raise LibraryRelocationError(LIBRARY_SCAN_ACTIVE_MESSAGE)
+        raise LibraryRelocationError(message)
 
 
 def _select_relocation_root(library: Library, root_id: int | None) -> LibraryRoot:

--- a/app/services/maintenance.py
+++ b/app/services/maintenance.py
@@ -132,6 +132,14 @@ class MaintenanceService:
         for comic in comics:
             if comic.library_root_id not in root_paths:
                 root = self.db.get(LibraryRoot, comic.library_root_id)
+                if root is not None and not root.is_active:
+                    self.logger.info(
+                        "Janitor: Skipping inactive library root for %s (%s)",
+                        comic.filename,
+                        root.path,
+                    )
+                    continue
+
                 root_paths[comic.library_root_id] = root.path if root else None
 
             root_path = root_paths[comic.library_root_id]

--- a/app/services/scanner.py
+++ b/app/services/scanner.py
@@ -66,13 +66,17 @@ class LibraryScanner:
 
         start_time = time.time()
 
-        # 0. Prefetch existing comics (same as old scan)
+        # 0. Prefetch existing comics for roots this scan can actually see.
         self.logger.debug("Pre-fetching existing file list for parallel scan...")
+        active_root_ids = [library_root.id for library_root in library_roots]
         db_comics = (
             self.db.query(Comic)
             .join(Volume)
             .join(Series)
-            .filter(Series.library_id == self.library.id)
+            .filter(
+                Series.library_id == self.library.id,
+                Comic.library_root_id.in_(active_root_ids),
+            )
             .all()
         )
 

--- a/app/templates/admin/libraries.html
+++ b/app/templates/admin/libraries.html
@@ -18,8 +18,8 @@
             <thead class="bg-gray-900 text-gray-400 uppercase text-xs">
                 <tr>
                     <th class="px-6 py-3">Name</th>
-                    <th class="px-6 py-3">Path</th>
-                    <th class="px-6 py-3">Status</th>
+                    <th class="px-6 py-3">Storage</th>
+                    <th class="px-6 py-3">Last Scanned</th>
                     <th class="px-6 py-3 text-right">Actions</th>
                 </tr>
             </thead>
@@ -29,7 +29,14 @@
                         <td class="px-6 py-4 font-bold text-white">
                             <a :href="window.parker.route('pages.library_detail', { library_id: lib.id })" class="hover:text-blue-400 transition-colors" x-text="lib.name"></a>
                         </td>
-                        <td class="px-6 py-4 text-sm text-gray-400 font-mono" x-text="lib.path"></td>
+                        <td class="px-6 py-4 text-sm text-gray-400">
+                            <div class="font-mono break-all" x-text="libraryPrimaryPath(lib)"></div>
+                            <div
+                                x-show="(lib.roots || []).length !== 1"
+                                class="mt-1 text-xs text-gray-500"
+                                x-text="rootSummary(lib)"
+                            ></div>
+                        </td>
                         <td class="px-6 py-4 text-sm text-gray-400">
                             <div x-show="lib.is_scanning" class="flex items-center text-blue-400 text-xs font-bold animate-pulse">
                                 <span class="mr-2">↻</span> Working...
@@ -56,14 +63,7 @@
 
                             <div class="h-4 w-px bg-gray-700 mx-1"></div>
 
-                            <button
-                                x-on:click="openRelocateModal(lib)"
-                                class="text-amber-300 hover:text-white text-sm font-medium px-2 disabled:opacity-30 disabled:cursor-not-allowed"
-                                :disabled="lib.is_scanning"
-                                title="Relocate library path"
-                            >
-                                Relocate
-                            </button>
+                            <button x-on:click="openRootsModal(lib)" class="text-purple-300 hover:text-white text-sm font-medium px-2">Roots</button>
                             <button x-on:click="openEditModal(lib)" class="text-blue-400 hover:text-white text-sm font-medium px-2">Edit</button>
                             <button x-on:click="deleteLibrary(lib)" class="text-red-400 hover:text-white text-sm font-medium px-2">Delete</button>
                         </td>
@@ -87,13 +87,12 @@
                     <label class="block text-sm text-gray-400 mb-1">Name</label>
                     <input type="text" x-model.trim="form.name" required class="w-full bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none" placeholder="e.g. DC Comics">
                 </div>
-                <div>
+                <div x-show="!isEditing">
                     <label class="block text-sm text-gray-400 mb-1">Folder Path</label>
                     <div class="flex gap-2">
-                        <input type="text" x-model="form.path" :disabled="isEditing" :class="isEditing ? 'opacity-60 cursor-not-allowed' : ''" class="flex-1 bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none" placeholder="/comics/dc">
+                        <input type="text" x-model="form.path" class="flex-1 bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none" placeholder="/comics/dc">
                         <button
                             type="button"
-                            x-show="!isEditing"
                             x-on:click="openDirectoryBrowser()"
                             class="bg-gray-700 hover:bg-gray-600 text-white px-3 py-2 rounded transition-colors text-sm font-medium"
                         >
@@ -101,65 +100,46 @@
                         </button>
                     </div>
                     <p class="text-xs text-gray-500 mt-1">Server-side path where files are located.</p>
-                    <div x-show="isEditing" class="mt-2 rounded border border-amber-500/30 bg-amber-950/30 px-3 py-2 text-xs text-amber-100" style="display: none;">
-                        Use Relocate to change this library's path safely.
-                    </div>
 
-                    <div x-show="!isEditing && pathBrowser.open" class="mt-3 border border-gray-700 rounded bg-gray-900 overflow-hidden" style="display: none;">
-                        <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-gray-700">
-                            <div class="min-w-0">
-                                <p class="text-[10px] uppercase tracking-wide text-gray-500">Browsing</p>
-                                <p class="text-xs text-gray-300 font-mono truncate" x-text="pathBrowser.current || 'Loading...'"></p>
-                            </div>
-                            <button
-                                type="button"
-                                x-on:click="closeDirectoryBrowser()"
-                                class="text-gray-500 hover:text-white text-sm"
-                            >
-                                Close
-                            </button>
-                        </div>
-
-                        <div x-show="pathBrowser.error" class="px-3 py-3 text-sm text-red-300 bg-red-950/30 border-b border-red-900/50" x-text="pathBrowser.error"></div>
-                        <div x-show="pathBrowser.notice" class="px-3 py-3 text-sm text-amber-200 bg-amber-950/30 border-b border-amber-900/50" x-text="pathBrowser.notice"></div>
-                        <div x-show="pathBrowser.loading" class="px-3 py-4 text-sm text-gray-400">Loading folders...</div>
-
-                        <div x-show="!pathBrowser.loading && !pathBrowser.error" class="max-h-64 overflow-y-auto">
-                            <button
-                                type="button"
-                                x-show="pathBrowser.parent"
-                                x-on:click="browseDirectory(pathBrowser.parent)"
-                                class="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-800 border-b border-gray-800"
-                            >
-                                ../
-                            </button>
-
-                            <template x-for="entry in pathBrowser.entries" :key="entry.path">
+                    <template x-if="!isEditing && pathBrowser.open && pathBrowser.target === 'form'">
+                        <div class="mt-3 border border-gray-700 rounded bg-gray-900 overflow-hidden">
+                            <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-gray-700">
+                                <div class="min-w-0">
+                                    <p class="text-[10px] uppercase tracking-wide text-gray-500">Browsing</p>
+                                    <p class="text-xs text-gray-300 font-mono truncate" x-text="pathBrowser.current || 'Loading...'"></p>
+                                </div>
                                 <button
                                     type="button"
-                                    x-on:click="browseDirectory(entry.path)"
-                                    class="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-800 border-b border-gray-800 last:border-b-0"
+                                    x-on:click="closeDirectoryBrowser()"
+                                    class="text-gray-500 hover:text-white text-sm"
                                 >
-                                    <span class="text-blue-300 mr-2">/</span><span x-text="entry.name"></span>
+                                    Close
                                 </button>
-                            </template>
+                            </div>
 
-                            <div x-show="pathBrowser.entries.length === 0" class="px-3 py-4 text-sm text-gray-500">
-                                No subfolders found.
+                            <div x-show="pathBrowser.error" class="px-3 py-3 text-sm text-red-300 bg-red-950/30 border-b border-red-900/50" x-text="pathBrowser.error"></div>
+                            <div x-show="pathBrowser.notice" class="px-3 py-3 text-sm text-amber-200 bg-amber-950/30 border-b border-amber-900/50" x-text="pathBrowser.notice"></div>
+                            <div x-show="pathBrowser.loading" class="px-3 py-4 text-sm text-gray-400">Loading folders...</div>
+
+                            <div
+                                x-show="!pathBrowser.loading && !pathBrowser.error"
+                                class="max-h-64 overflow-y-auto"
+                                x-on:click="handleDirectoryBrowserClick($event)"
+                                x-html="pathBrowserRowsHtml()"
+                            ></div>
+
+                            <div class="flex justify-end gap-2 px-3 py-2 border-t border-gray-700 bg-gray-950/50">
+                                <button
+                                    type="button"
+                                    x-on:click="useBrowsedDirectory()"
+                                    class="bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 rounded text-sm transition-colors"
+                                    :disabled="!pathBrowser.current"
+                                >
+                                    Use This Folder
+                                </button>
                             </div>
                         </div>
-
-                        <div class="flex justify-end gap-2 px-3 py-2 border-t border-gray-700 bg-gray-950/50">
-                            <button
-                                type="button"
-                                x-on:click="useBrowsedDirectory()"
-                                class="bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 rounded text-sm transition-colors"
-                                :disabled="!pathBrowser.current"
-                            >
-                                Use This Folder
-                            </button>
-                        </div>
-                    </div>
+                    </template>
                 </div>
                 <div>
                     <label class="flex items-center gap-2 cursor-pointer">
@@ -169,8 +149,8 @@
                             class="rounded bg-gray-900 border-gray-700 text-blue-600 focus:ring-blue-500 w-5 h-5"
                         >
                         <div>
-                            <span class="block text-sm text-gray-300">Watch Folder</span>
-                            <span class="block text-xs text-gray-500">Automatically scan when files are added or changed.</span>
+                            <span class="block text-sm text-gray-300">Watch Library</span>
+                            <span class="block text-xs text-gray-500">Automatically scan active roots when files are added or changed.</span>
                         </div>
                     </label>
                 </div>
@@ -218,6 +198,132 @@
         </div>
     </div>
 
+    <div x-show="showRootsModal" class="fixed inset-0 bg-black/80 flex items-center justify-center z-50 px-4" style="display: none;" x-transition.opacity>
+        <div class="bg-gray-800 p-6 rounded-lg w-full max-w-3xl max-h-[90vh] overflow-y-auto border border-gray-700 shadow-2xl">
+            <div class="flex items-start justify-between gap-4 mb-5">
+                <div class="min-w-0">
+                    <h2 class="text-xl font-bold text-white">Library Roots</h2>
+                    <p class="text-sm text-gray-400 truncate" x-text="roots.library?.name"></p>
+                </div>
+                <button x-on:click="closeRootsModal()" class="text-gray-500 hover:text-white text-sm">Close</button>
+            </div>
+
+            <div class="space-y-4">
+                <div class="space-y-2">
+                    <template x-for="root in roots.library?.roots || []" :key="root.id">
+                        <div data-testid="library-root-row" class="border border-gray-700 rounded bg-gray-900/60 px-3 py-3">
+                            <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                                <div class="min-w-0">
+                                    <div class="flex flex-wrap items-center gap-2 mb-1">
+                                        <span
+                                            class="rounded px-2 py-0.5 text-[10px] font-bold uppercase"
+                                            :class="root.is_active ? 'bg-green-900/60 text-green-200' : 'bg-gray-700 text-gray-300'"
+                                            x-text="root.is_active ? 'Active' : 'Disabled'"
+                                        ></span>
+                                        <span class="text-xs text-gray-500" x-text="rootComicLabel(root)"></span>
+                                    </div>
+                                    <p class="font-mono text-sm text-gray-200 break-all" x-text="root.path"></p>
+                                </div>
+                                <div class="flex flex-wrap items-center gap-2 shrink-0">
+                                    <button
+                                        x-on:click="toggleRoot(root)"
+                                        class="bg-gray-700 hover:bg-gray-600 text-white text-xs px-3 py-1.5 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                        :disabled="roots.busyRootId === root.id || roots.library?.is_scanning"
+                                        x-text="root.is_active ? 'Disable' : 'Enable'"
+                                    ></button>
+                                    <button
+                                        x-on:click="openRelocateModal(roots.library, root)"
+                                        class="text-amber-300 hover:text-white text-xs font-medium px-2 disabled:opacity-30 disabled:cursor-not-allowed"
+                                        :disabled="roots.library?.is_scanning"
+                                    >
+                                        Relocate
+                                    </button>
+                                    <button
+                                        x-on:click="removeRoot(root)"
+                                        class="text-red-400 hover:text-white text-xs font-medium px-2 disabled:opacity-30 disabled:cursor-not-allowed"
+                                        :disabled="roots.busyRootId === root.id || roots.library?.is_scanning"
+                                    >
+                                        Remove
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                    <div x-show="(roots.library?.roots || []).length === 0" class="rounded border border-gray-700 bg-gray-900/60 px-3 py-4 text-sm text-gray-500">
+                        No roots configured.
+                    </div>
+                </div>
+
+                <div class="border-t border-gray-700 pt-4">
+                    <label class="block text-sm text-gray-400 mb-1">Add Root</label>
+                    <div class="flex flex-col gap-2 sm:flex-row">
+                        <input
+                            type="text"
+                            x-model="roots.path"
+                            class="flex-1 bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none"
+                            placeholder="/comics/archive"
+                        >
+                        <button
+                            type="button"
+                            x-on:click="openDirectoryBrowser('root')"
+                            class="bg-gray-700 hover:bg-gray-600 text-white px-3 py-2 rounded transition-colors text-sm font-medium"
+                        >
+                            Browse
+                        </button>
+                        <button
+                            x-on:click="addRoot()"
+                            class="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded transition-colors shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                            :disabled="roots.library?.is_scanning || roots.adding || !String(roots.path || '').trim()"
+                        >
+                            <span x-text="roots.adding ? 'Adding...' : 'Add Root'"></span>
+                        </button>
+                    </div>
+                    <div x-show="roots.error" class="mt-3 rounded border border-red-900/60 bg-red-950/30 px-3 py-2 text-sm text-red-200" x-text="roots.error"></div>
+
+                    <template x-if="pathBrowser.open && pathBrowser.target === 'root'">
+                        <div class="mt-3 border border-gray-700 rounded bg-gray-900 overflow-hidden">
+                            <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-gray-700">
+                                <div class="min-w-0">
+                                    <p class="text-[10px] uppercase tracking-wide text-gray-500">Browsing</p>
+                                    <p class="text-xs text-gray-300 font-mono truncate" x-text="pathBrowser.current || 'Loading...'"></p>
+                                </div>
+                                <button
+                                    type="button"
+                                    x-on:click="closeDirectoryBrowser()"
+                                    class="text-gray-500 hover:text-white text-sm"
+                                >
+                                    Close
+                                </button>
+                            </div>
+
+                            <div x-show="pathBrowser.error" class="px-3 py-3 text-sm text-red-300 bg-red-950/30 border-b border-red-900/50" x-text="pathBrowser.error"></div>
+                            <div x-show="pathBrowser.notice" class="px-3 py-3 text-sm text-amber-200 bg-amber-950/30 border-b border-amber-900/50" x-text="pathBrowser.notice"></div>
+                            <div x-show="pathBrowser.loading" class="px-3 py-4 text-sm text-gray-400">Loading folders...</div>
+
+                            <div
+                                x-show="!pathBrowser.loading && !pathBrowser.error"
+                                class="max-h-64 overflow-y-auto"
+                                x-on:click="handleDirectoryBrowserClick($event)"
+                                x-html="pathBrowserRowsHtml()"
+                            ></div>
+
+                            <div class="flex justify-end gap-2 px-3 py-2 border-t border-gray-700 bg-gray-950/50">
+                                <button
+                                    type="button"
+                                    x-on:click="useBrowsedDirectory()"
+                                    class="bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 rounded text-sm transition-colors"
+                                    :disabled="!pathBrowser.current"
+                                >
+                                    Use This Folder
+                                </button>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div x-show="showRelocationModal" class="fixed inset-0 bg-black/80 flex items-center justify-center z-50 px-4" style="display: none;" x-transition.opacity>
         <div class="bg-gray-800 p-6 rounded-lg w-full max-w-3xl max-h-[90vh] overflow-y-auto border border-gray-700 shadow-2xl">
             <div class="flex items-start justify-between gap-4 mb-5">
@@ -255,61 +361,45 @@
                     </div>
                 </div>
 
-                <div x-show="pathBrowser.open && pathBrowser.target === 'relocation'" class="border border-gray-700 rounded bg-gray-900 overflow-hidden" style="display: none;">
-                    <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-gray-700">
-                        <div class="min-w-0">
-                            <p class="text-[10px] uppercase tracking-wide text-gray-500">Browsing</p>
-                            <p class="text-xs text-gray-300 font-mono truncate" x-text="pathBrowser.current || 'Loading...'"></p>
-                        </div>
-                        <button
-                            type="button"
-                            x-on:click="closeDirectoryBrowser()"
-                            class="text-gray-500 hover:text-white text-sm"
-                        >
-                            Close
-                        </button>
-                    </div>
-
-                    <div x-show="pathBrowser.error" class="px-3 py-3 text-sm text-red-300 bg-red-950/30 border-b border-red-900/50" x-text="pathBrowser.error"></div>
-                    <div x-show="pathBrowser.notice" class="px-3 py-3 text-sm text-amber-200 bg-amber-950/30 border-b border-amber-900/50" x-text="pathBrowser.notice"></div>
-                    <div x-show="pathBrowser.loading" class="px-3 py-4 text-sm text-gray-400">Loading folders...</div>
-
-                    <div x-show="!pathBrowser.loading && !pathBrowser.error" class="max-h-64 overflow-y-auto">
-                        <button
-                            type="button"
-                            x-show="pathBrowser.parent"
-                            x-on:click="browseDirectory(pathBrowser.parent)"
-                            class="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-800 border-b border-gray-800"
-                        >
-                            ../
-                        </button>
-
-                        <template x-for="entry in pathBrowser.entries" :key="entry.path">
+                <template x-if="pathBrowser.open && pathBrowser.target === 'relocation'">
+                    <div class="border border-gray-700 rounded bg-gray-900 overflow-hidden">
+                        <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-gray-700">
+                            <div class="min-w-0">
+                                <p class="text-[10px] uppercase tracking-wide text-gray-500">Browsing</p>
+                                <p class="text-xs text-gray-300 font-mono truncate" x-text="pathBrowser.current || 'Loading...'"></p>
+                            </div>
                             <button
                                 type="button"
-                                x-on:click="browseDirectory(entry.path)"
-                                class="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-800 border-b border-gray-800 last:border-b-0"
+                                x-on:click="closeDirectoryBrowser()"
+                                class="text-gray-500 hover:text-white text-sm"
                             >
-                                <span class="text-blue-300 mr-2">/</span><span x-text="entry.name"></span>
+                                Close
                             </button>
-                        </template>
+                        </div>
 
-                        <div x-show="pathBrowser.entries.length === 0" class="px-3 py-4 text-sm text-gray-500">
-                            No subfolders found.
+                        <div x-show="pathBrowser.error" class="px-3 py-3 text-sm text-red-300 bg-red-950/30 border-b border-red-900/50" x-text="pathBrowser.error"></div>
+                        <div x-show="pathBrowser.notice" class="px-3 py-3 text-sm text-amber-200 bg-amber-950/30 border-b border-amber-900/50" x-text="pathBrowser.notice"></div>
+                        <div x-show="pathBrowser.loading" class="px-3 py-4 text-sm text-gray-400">Loading folders...</div>
+
+                        <div
+                            x-show="!pathBrowser.loading && !pathBrowser.error"
+                            class="max-h-64 overflow-y-auto"
+                            x-on:click="handleDirectoryBrowserClick($event)"
+                            x-html="pathBrowserRowsHtml()"
+                        ></div>
+
+                        <div class="flex justify-end gap-2 px-3 py-2 border-t border-gray-700 bg-gray-950/50">
+                            <button
+                                type="button"
+                                x-on:click="useBrowsedDirectory()"
+                                class="bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 rounded text-sm transition-colors"
+                                :disabled="!pathBrowser.current"
+                            >
+                                Use This Folder
+                            </button>
                         </div>
                     </div>
-
-                    <div class="flex justify-end gap-2 px-3 py-2 border-t border-gray-700 bg-gray-950/50">
-                        <button
-                            type="button"
-                            x-on:click="useBrowsedDirectory()"
-                            class="bg-blue-600 hover:bg-blue-500 text-white px-3 py-1.5 rounded text-sm transition-colors"
-                            :disabled="!pathBrowser.current"
-                        >
-                            Use This Folder
-                        </button>
-                    </div>
-                </div>
+                </template>
 
                 <div x-show="relocation.error" class="rounded border border-red-900/60 bg-red-950/30 px-3 py-2 text-sm text-red-200" x-text="relocation.error"></div>
 
@@ -429,6 +519,7 @@ function libraryManager() {
     return {
         libraries: [],
         showModal: false,
+        showRootsModal: false,
         showRelocationModal: false,
         isEditing: false,
         form: {
@@ -442,6 +533,7 @@ function libraryManager() {
         },
         relocation: {
             library: null,
+            rootId: null,
             path: '',
             preview: null,
             confirmation: null,
@@ -450,9 +542,17 @@ function libraryManager() {
             confirming: false,
             completed: false,
         },
+        roots: {
+            library: null,
+            path: '',
+            error: '',
+            adding: false,
+            busyRootId: null,
+        },
         pathBrowser: {
             open: false,
             target: 'form',
+            requestId: 0,
             loading: false,
             error: '',
             notice: '',
@@ -479,8 +579,51 @@ function libraryManager() {
         async loadLibraries() {
             try {
                 const res = await fetch(window.parker.route('libraries.list'));
-                if (res.ok) this.libraries = await res.json();
+                if (res.ok) {
+                    this.libraries = await res.json();
+                    this.syncOpenLibraryRefs();
+                }
             } catch(e) { console.error(e); }
+        },
+
+        syncOpenLibraryRefs() {
+            if (this.roots.library) {
+                const updated = this.libraries.find((lib) => lib.id === this.roots.library.id);
+                if (updated) this.roots.library = updated;
+            }
+
+            if (this.relocation.library) {
+                const updated = this.libraries.find((lib) => lib.id === this.relocation.library.id);
+                if (updated) this.relocation.library = updated;
+            }
+        },
+
+        activeRoots(lib) {
+            return (lib?.roots || []).filter((root) => root.is_active);
+        },
+
+        libraryPrimaryPath(lib) {
+            if (lib?.path) return lib.path;
+            if ((lib?.roots || []).length > 0) return 'No active roots';
+            return 'No roots configured';
+        },
+
+        rootSummary(lib) {
+            const roots = lib?.roots || [];
+            if (roots.length === 0) return 'No roots configured';
+
+            const activeCount = this.activeRoots(lib).length;
+            if (activeCount === 0) {
+                return `0 active of ${roots.length} ${roots.length === 1 ? 'root' : 'roots'}`;
+            }
+
+            const additionalRootCount = roots.length - 1;
+            return `Primary root shown + ${additionalRootCount} more`;
+        },
+
+        rootComicLabel(root) {
+            const count = Number(root?.comic_count || 0);
+            return `${count.toLocaleString()} ${count === 1 ? 'comic' : 'comics'}`;
         },
 
         openAddModal() {
@@ -516,6 +659,7 @@ function libraryManager() {
         resetRelocationState() {
             this.relocation = {
                 library: null,
+                rootId: null,
                 path: '',
                 preview: null,
                 confirmation: null,
@@ -526,12 +670,21 @@ function libraryManager() {
             };
         },
 
-        openRelocateModal(lib) {
+        openRelocateModal(lib, root = null) {
+            const roots = this.activeRoots(lib);
+            const selectedRoot = root || (roots.length === 1 ? roots[0] : null);
+            if (!selectedRoot) {
+                this.openRootsModal(lib);
+                return;
+            }
+
             this.showModal = false;
+            this.showRootsModal = false;
             this.closeDirectoryBrowser();
             this.relocation = {
                 library: lib,
-                path: lib.path || '',
+                rootId: selectedRoot.id,
+                path: selectedRoot.path || '',
                 preview: null,
                 confirmation: null,
                 error: '',
@@ -555,12 +708,151 @@ function libraryManager() {
             this.relocation.completed = false;
         },
 
+        openRootsModal(lib) {
+            this.showModal = false;
+            this.showRelocationModal = false;
+            this.closeDirectoryBrowser();
+            const updated = this.libraries.find((candidate) => candidate.id === lib.id) || lib;
+            this.roots = {
+                library: updated,
+                path: '',
+                error: '',
+                adding: false,
+                busyRootId: null,
+            };
+            this.showRootsModal = true;
+        },
+
+        closeRootsModal() {
+            this.showRootsModal = false;
+            this.closeDirectoryBrowser();
+            this.roots = {
+                library: null,
+                path: '',
+                error: '',
+                adding: false,
+                busyRootId: null,
+            };
+        },
+
+        async addRoot() {
+            if (!this.roots.library || !String(this.roots.path || '').trim()) return;
+
+            this.roots.adding = true;
+            this.roots.error = '';
+
+            try {
+                const res = await fetch(
+                    window.parker.route('libraries.roots_create', { library_id: this.roots.library.id }),
+                    {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ path: String(this.roots.path || '').trim() })
+                    }
+                );
+                const payload = await res.json();
+
+                if (!res.ok) {
+                    throw new Error(payload.detail || 'Unable to add root');
+                }
+
+                this.roots.path = '';
+                await this.loadLibraries();
+                window.parker.showToast('Root added', 'success');
+            } catch (e) {
+                console.error(e);
+                this.roots.error = e.message || 'Unable to add root';
+            } finally {
+                this.roots.adding = false;
+            }
+        },
+
+        async toggleRoot(root) {
+            if (!this.roots.library || !root) return;
+
+            const nextActive = !root.is_active;
+            this.roots.busyRootId = root.id;
+            this.roots.error = '';
+
+            try {
+                const res = await fetch(
+                    window.parker.route('libraries.roots_update', {
+                        library_id: this.roots.library.id,
+                        root_id: root.id,
+                    }),
+                    {
+                        method: 'PATCH',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ is_active: nextActive })
+                    }
+                );
+                const payload = await res.json();
+
+                if (!res.ok) {
+                    throw new Error(payload.detail || 'Unable to update root');
+                }
+
+                await this.loadLibraries();
+                window.parker.showToast(nextActive ? 'Root enabled' : 'Root disabled', 'success');
+            } catch (e) {
+                console.error(e);
+                this.roots.error = e.message || 'Unable to update root';
+            } finally {
+                this.roots.busyRootId = null;
+            }
+        },
+
+        async removeRoot(root) {
+            if (!this.roots.library || !root) return;
+
+            const comicCount = Number(root.comic_count || 0);
+            const confirmed = await window.parker.dialog.confirm(
+                `Remove Root?`,
+                comicCount > 0
+                    ? `This removes the root and deletes ${comicCount.toLocaleString()} comic records from the database. Files remain intact.`
+                    : 'This removes the root from the library. Files remain intact.',
+                { isDestructive: true, confirmText: comicCount > 0 ? 'Delete Comics and Remove' : 'Remove Root' }
+            );
+
+            if (!confirmed) return;
+
+            this.roots.busyRootId = root.id;
+            this.roots.error = '';
+
+            try {
+                const query = comicCount > 0 ? 'delete_comics=true' : '';
+                const res = await fetch(
+                    window.parker.route('libraries.roots_delete', {
+                        library_id: this.roots.library.id,
+                        root_id: root.id,
+                    }, query),
+                    { method: 'DELETE' }
+                );
+                const payload = await res.json();
+
+                if (!res.ok) {
+                    throw new Error(payload.detail || 'Unable to remove root');
+                }
+
+                await this.loadLibraries();
+                window.parker.showToast('Root removed', 'success');
+            } catch (e) {
+                console.error(e);
+                this.roots.error = e.message || 'Unable to remove root';
+            } finally {
+                this.roots.busyRootId = null;
+            }
+        },
+
         async openDirectoryBrowser(target = 'form') {
             this.pathBrowser.target = target;
             this.pathBrowser.open = true;
-            const requestedPath = target === 'relocation'
-                ? (this.relocation.path || this.relocation.library?.path || null)
-                : (this.form.path || null);
+            let requestedPath = this.form.path || null;
+            if (target === 'relocation') {
+                requestedPath = this.relocation.path || this.relocation.library?.path || null;
+            } else if (target === 'root') {
+                requestedPath = this.roots.path || this.roots.library?.path || null;
+            }
             const openedRequestedPath = await this.browseDirectory(requestedPath);
 
             if (!openedRequestedPath && requestedPath) {
@@ -573,6 +865,7 @@ function libraryManager() {
         },
 
         closeDirectoryBrowser() {
+            this.pathBrowser.requestId += 1;
             this.pathBrowser.open = false;
             this.pathBrowser.target = 'form';
             this.pathBrowser.loading = false;
@@ -580,7 +873,54 @@ function libraryManager() {
             this.pathBrowser.notice = '';
         },
 
+        escapePathBrowserText(value) {
+            const replacements = {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;',
+            };
+            return String(value ?? '').replace(/[&<>"']/g, (char) => replacements[char]);
+        },
+
+        pathBrowserButtonHtml(label, path, isFolder = false) {
+            const safeLabel = this.escapePathBrowserText(label);
+            const safePath = this.escapePathBrowserText(path);
+            const prefix = isFolder ? '<span class="text-blue-300 mr-2">/</span>' : '';
+            return `<button type="button" data-browser-path="${safePath}" class="w-full text-left px-3 py-2 text-sm text-gray-300 hover:bg-gray-800 border-b border-gray-800 last:border-b-0">${prefix}<span>${safeLabel}</span></button>`;
+        },
+
+        pathBrowserRowsHtml() {
+            const rows = [];
+            if (this.pathBrowser.parent) {
+                rows.push(this.pathBrowserButtonHtml('../', this.pathBrowser.parent));
+            }
+
+            for (const entry of this.pathBrowser.entries || []) {
+                rows.push(this.pathBrowserButtonHtml(entry.name, entry.path, true));
+            }
+
+            if (rows.length === 0) {
+                return '<div class="px-3 py-4 text-sm text-gray-500">No subfolders found.</div>';
+            }
+
+            return rows.join('');
+        },
+
+        handleDirectoryBrowserClick(event) {
+            const button = event.target.closest('button[data-browser-path]');
+            if (!button) return;
+
+            const path = button.getAttribute('data-browser-path');
+            if (path) {
+                this.browseDirectory(path);
+            }
+        },
+
         async browseDirectory(path) {
+            const requestId = this.pathBrowser.requestId + 1;
+            this.pathBrowser.requestId = requestId;
             this.pathBrowser.loading = true;
             this.pathBrowser.error = '';
             this.pathBrowser.notice = '';
@@ -594,18 +934,32 @@ function libraryManager() {
                     throw new Error(payload.detail || 'Unable to browse folders');
                 }
 
+                if (requestId !== this.pathBrowser.requestId) {
+                    return false;
+                }
+
+                const entries = Array.isArray(payload.entries) ? payload.entries : [];
                 this.pathBrowser.root = payload.root;
                 this.pathBrowser.current = payload.current;
                 this.pathBrowser.parent = payload.parent;
-                this.pathBrowser.entries = payload.entries || [];
+                this.pathBrowser.entries = entries.map((entry) => ({
+                    name: entry.name,
+                    path: entry.path,
+                }));
                 return true;
             } catch (e) {
+                if (requestId !== this.pathBrowser.requestId) {
+                    return false;
+                }
+
                 console.error(e);
                 this.pathBrowser.error = e.message || 'Unable to browse folders';
                 this.pathBrowser.entries = [];
                 return false;
             } finally {
-                this.pathBrowser.loading = false;
+                if (requestId === this.pathBrowser.requestId) {
+                    this.pathBrowser.loading = false;
+                }
             }
         },
 
@@ -614,6 +968,8 @@ function libraryManager() {
             if (this.pathBrowser.target === 'relocation') {
                 this.relocation.path = this.pathBrowser.current;
                 this.resetRelocationPreview();
+            } else if (this.pathBrowser.target === 'root') {
+                this.roots.path = this.pathBrowser.current;
             } else {
                 this.form.path = this.pathBrowser.current;
             }
@@ -704,7 +1060,7 @@ function libraryManager() {
                     {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ path: this.relocation.path })
+                        body: JSON.stringify({ path: this.relocation.path, root_id: this.relocation.rootId })
                     }
                 );
                 const payload = await res.json();
@@ -768,7 +1124,7 @@ function libraryManager() {
                     {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ path: this.relocation.path })
+                        body: JSON.stringify({ path: this.relocation.path, root_id: this.relocation.rootId })
                     }
                 );
                 const payload = await res.json();
@@ -782,10 +1138,15 @@ function libraryManager() {
                 this.relocation.preview = payload;
                 this.relocation.completed = true;
                 this.relocation.path = payload.current_path;
-                this.relocation.library.path = payload.current_path;
+                const relocatedRoot = (this.relocation.library.roots || []).find((root) => root.id === payload.root_id);
+                if (relocatedRoot) relocatedRoot.path = payload.current_path;
 
                 const updated = this.libraries.find((lib) => lib.id === payload.library_id);
-                if (updated) updated.path = payload.current_path;
+                if (updated) {
+                    const updatedRoot = (updated.roots || []).find((root) => root.id === payload.root_id);
+                    if (updatedRoot) updatedRoot.path = payload.current_path;
+                    updated.path = this.activeRoots(updated)[0]?.path || null;
+                }
 
                 await this.loadLibraries();
                 window.parker.showToast('Library relocated', 'success');

--- a/docs/multi-root-library-scope.md
+++ b/docs/multi-root-library-scope.md
@@ -1,6 +1,6 @@
 # Multi-Root Library Scope
 
-Status: Foundation in place, product surface pending
+Status: Root lifecycle product surface in place
 
 This note tracks Parker's path from one physical folder per library to one logical library with multiple configured filesystem roots.
 
@@ -39,11 +39,11 @@ Physical file identity is:
 
 - `(library_root_id, relative_path)`
 
-That identity must remain the backbone for scanner cleanup, metadata writes, and future root lifecycle operations.
+That identity must remain the backbone for scanner cleanup, metadata writes, and root lifecycle operations.
 
 ## Foundation Behavior
 
-The foundation layer should behave as if multiple active roots can already exist, even before the admin UI exposes full root management.
+The foundation layer behaves as if multiple active roots can exist.
 
 Scanner behavior:
 
@@ -81,6 +81,7 @@ Janitor cleanup behavior:
 - resolve physical comic paths from `library_root_id` plus `relative_path`
 - verify active roots for the cleanup scope before deleting missing-file records
 - abort missing-file cleanup if any active root in that scope is unreachable
+- skip comics tied to inactive roots during missing-file cleanup
 
 ## Safety Rules
 
@@ -107,9 +108,9 @@ This keeps multi-root behavior close to existing single-root behavior.
 
 Parker's access model remains library-based.
 
-Recommended MVP rule:
+MVP rule:
 
-- if a user can access the library, they can access content imported from any active root attached to that library
+- if a user can access the library, they can access content imported from any root attached to that library
 
 Root-level permissions are out of scope for the initial multi-root feature.
 
@@ -124,23 +125,20 @@ Out of scope for initial multi-root support:
 - content-hash deduplication
 - automatic file moves between roots
 
-## Remaining Product Work
+## Root Lifecycle Policy
 
-The foundation does not complete multi-root as an admin-facing feature.
+Root lifecycle actions are explicit. A generic library edit form does not silently change or remove storage roots.
 
-Remaining work:
+Implemented admin/API behavior:
 
-- add root management API actions
-- add admin UI for listing roots
-- add explicit add, disable, relocate, and remove flows
-- validate new roots against every configured root in the system
-- reject overlapping roots within the same library
-- reject overlapping roots across libraries
-- decide whether zero-root libraries are allowed during editing
-- define what happens to comics when a root is disabled or removed
-- update support/admin views so partial root failures are understandable
+- Add root: creates a new active `LibraryRoot`, rejects overlap with any configured root in any library, preserves existing comics, and does not start a scan automatically.
+- Disable root: marks the root inactive for scanner and watcher discovery. Existing comics tied to that root remain in the database and remain visible through normal library access.
+- Enable root: marks a disabled root active again after validating that its stored path does not overlap another configured root.
+- Relocate root: updates one selected root path through the relocation preview/confirm flow. Existing comic records are preserved and no scan is started automatically.
+- Remove root: empty roots can be removed directly. Roots with comics are rejected unless `delete_comics=true`, which deletes those comic records and prunes now-empty volumes and series. Files on disk are never deleted.
+- Zero active roots: allowed. This lets an admin temporarily pause an offline or intentionally detached library without inventing a fake path.
 
-Root lifecycle actions should be explicit. A generic library edit form should not silently change or remove storage roots.
+Overlap validation applies to active and inactive roots so a disabled historical root cannot silently conflict with a future attachment.
 
 ## Duplicate Policy
 
@@ -164,18 +162,19 @@ Multi-root libraries should still behave like one library to the scheduler:
 
 A library with several large roots may be operationally heavier than a small single-root library. That may eventually justify better scan progress reporting, but it should not block the MVP.
 
-## Recommended Implementation Order
+## Implementation Status
 
-1. Keep the relocation/root-identity foundation in place.
-2. Make scanner, metadata writer, watcher, diagnostics, and janitor cleanup root-list aware.
-3. Add root management API actions.
-4. Add admin UI for root list and root lifecycle operations.
-5. Add overlap validation across all roots.
-6. Decide disable/remove/offline root policy.
-7. Improve diagnostics and support messaging for partial root failures.
-8. Add broader browser coverage once the UI exists.
+Completed:
 
-Items 1 and 2 are the service foundation. Items 3 through 8 are the remaining product feature.
+- relocation/root-identity foundation
+- scanner, metadata writer, watcher, diagnostics, and janitor cleanup root-list awareness
+- root management API actions
+- admin UI for root listing and lifecycle operations
+- overlap validation across active and inactive roots
+- disable/remove/offline root policy
+- browser coverage for relocation and root lifecycle flows
+
+Future refinements should be driven by real use, especially around duplicate reporting, scan progress for very large multi-root libraries, and support messaging for unusual partial-storage failures.
 
 ## Testing Notes
 
@@ -190,7 +189,7 @@ Foundation coverage should include:
 - watcher registering and unregistering one watch per active root
 - diagnostics reporting root counts and per-root existence checks
 
-Product/UI coverage should later include:
+Product/UI coverage includes:
 
 - root add/disable/remove APIs
 - overlap validation against same-library and cross-library roots

--- a/tests/api/test_libraries.py
+++ b/tests/api/test_libraries.py
@@ -659,6 +659,238 @@ def test_update_library_allows_unchanged_path(admin_client, db):
     assert response.json()["path"] == "/tmp/original"
 
 
+def test_library_payload_includes_roots_and_root_counts(admin_client, db):
+    library = create_library_with_root(db, "Root Payload", "/tmp/root-payload/active")
+    active_root = library.active_root
+    disabled_root = LibraryRoot(
+        library_id=library.id,
+        path="/tmp/root-payload/disabled",
+        is_active=False,
+    )
+    db.add(disabled_root)
+    series = Series(name="Root Payload Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    create_comic(db, volume, active_root, "active.cbz", filename="active.cbz")
+    create_comic(db, volume, disabled_root, "disabled.cbz", filename="disabled.cbz")
+    db.commit()
+
+    detail = admin_client.get(f"/api/libraries/{library.id}")
+
+    assert detail.status_code == 200
+    payload = detail.json()
+    assert payload["path"] == "/tmp/root-payload/active"
+    assert payload["active_root_count"] == 1
+    assert [(root["path"], root["is_active"], root["comic_count"]) for root in payload["roots"]] == [
+        ("/tmp/root-payload/active", True, 1),
+        ("/tmp/root-payload/disabled", False, 1),
+    ]
+
+    listed = admin_client.get("/api/libraries/").json()[0]
+    assert listed["roots"][0]["comic_count"] == 1
+    assert listed["roots"][1]["comic_count"] == 1
+
+
+def test_admin_can_add_library_root_without_queueing_scan(admin_client, db):
+    library = create_library_with_root(db, "Add Root", "/tmp/add-root/main", watch_mode=True)
+
+    with (
+        patch("app.api.libraries.library_watcher.refresh_watches") as mock_refresh,
+        patch("app.api.libraries.scan_manager.add_task") as mock_scan,
+    ):
+        response = admin_client.post(
+            f"/api/libraries/{library.id}/roots",
+            json={"path": "  /tmp/add-root/archive  "},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["library_id"] == library.id
+    assert payload["path"] == "/tmp/add-root/archive"
+    assert payload["is_active"] is True
+    assert payload["comic_count"] == 0
+    mock_refresh.assert_called_once()
+    mock_scan.assert_not_called()
+
+    roots = db.query(LibraryRoot).filter(LibraryRoot.library_id == library.id).order_by(LibraryRoot.id).all()
+    assert [root.path for root in roots] == ["/tmp/add-root/main", "/tmp/add-root/archive"]
+
+
+def test_add_library_root_rejects_same_library_overlap(admin_client, db):
+    library = create_library_with_root(db, "Same Library Overlap", "/tmp/same-overlap")
+
+    response = admin_client.post(
+        f"/api/libraries/{library.id}/roots",
+        json={"path": "/tmp/same-overlap/child"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Library root path overlaps with existing root for library 'Same Library Overlap'"
+    }
+
+
+def test_add_library_root_rejects_cross_library_overlap(admin_client, db):
+    create_library_with_root(db, "Other Library Overlap", "/tmp/cross-overlap")
+    target = create_library_with_root(db, "Target Library", "/tmp/target-overlap")
+
+    response = admin_client.post(
+        f"/api/libraries/{target.id}/roots",
+        json={"path": "/tmp/cross-overlap/child"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Library root path overlaps with existing library 'Other Library Overlap'"
+    }
+
+
+def test_disable_library_root_preserves_existing_comics(admin_client, db):
+    library = create_library_with_root(db, "Disable Root", "/tmp/disable-root/main", watch_mode=True)
+    second_root = LibraryRoot(library_id=library.id, path="/tmp/disable-root/archive", is_active=True)
+    db.add(second_root)
+    series = Series(name="Disable Root Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    comic = create_comic(db, volume, second_root, "archive.cbz", filename="archive.cbz")
+    db.commit()
+
+    with patch("app.api.libraries.library_watcher.refresh_watches") as mock_refresh:
+        response = admin_client.patch(
+            f"/api/libraries/{library.id}/roots/{second_root.id}",
+            json={"is_active": False},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["is_active"] is False
+    assert payload["comic_count"] == 1
+    mock_refresh.assert_called_once()
+
+    db.refresh(second_root)
+    assert second_root.is_active is False
+    assert db.get(Comic, comic.id) is not None
+
+
+def test_enable_library_root_rejects_legacy_overlap(admin_client, db):
+    library = create_library_with_root(db, "Enable Root Overlap", "/tmp/enable-root")
+    disabled_root = LibraryRoot(
+        library_id=library.id,
+        path="/tmp/enable-root/child",
+        is_active=False,
+    )
+    db.add(disabled_root)
+    db.commit()
+
+    response = admin_client.patch(
+        f"/api/libraries/{library.id}/roots/{disabled_root.id}",
+        json={"is_active": True},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Library root path overlaps with existing root for library 'Enable Root Overlap'"
+    }
+
+
+def test_remove_empty_library_root(admin_client, db):
+    library = create_library_with_root(db, "Remove Empty Root", "/tmp/remove-empty/main", watch_mode=True)
+    empty_root = LibraryRoot(library_id=library.id, path="/tmp/remove-empty/archive", is_active=True)
+    db.add(empty_root)
+    db.commit()
+
+    with patch("app.api.libraries.library_watcher.refresh_watches") as mock_refresh:
+        response = admin_client.delete(f"/api/libraries/{library.id}/roots/{empty_root.id}")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "library_id": library.id,
+        "root_id": empty_root.id,
+        "removed": True,
+        "deleted_comics": 0,
+        "deleted_volumes": 0,
+        "deleted_series": 0,
+    }
+    assert db.get(LibraryRoot, empty_root.id) is None
+    mock_refresh.assert_called_once()
+
+
+def test_remove_library_root_with_comics_requires_explicit_delete(admin_client, db):
+    library = create_library_with_root(db, "Remove Guard Root", "/tmp/remove-guard")
+    root = library.active_root
+    series = Series(name="Remove Guard Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+    create_comic(db, volume, root, "guard.cbz", filename="guard.cbz")
+    db.commit()
+
+    response = admin_client.delete(f"/api/libraries/{library.id}/roots/{root.id}")
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": (
+            "Library root has 1 comic records. "
+            "Pass delete_comics=true to remove the root and delete those records."
+        )
+    }
+    assert db.get(LibraryRoot, root.id) is not None
+
+
+def test_remove_library_root_with_delete_comics_prunes_empty_containers(admin_client, db):
+    library = create_library_with_root(db, "Remove Comics Root", "/tmp/remove-comics")
+    root = library.active_root
+    series = Series(name="Remove Comics Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    comic = create_comic(db, volume, root, "delete-me.cbz", filename="delete-me.cbz")
+    db.commit()
+
+    response = admin_client.delete(f"/api/libraries/{library.id}/roots/{root.id}?delete_comics=true")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "library_id": library.id,
+        "root_id": root.id,
+        "removed": True,
+        "deleted_comics": 1,
+        "deleted_volumes": 1,
+        "deleted_series": 1,
+    }
+    assert db.get(LibraryRoot, root.id) is None
+    assert db.get(Comic, comic.id) is None
+    assert db.get(Volume, volume.id) is None
+    assert db.get(Series, series.id) is None
+
+
+def test_root_lifecycle_rejects_scanning_library(admin_client, db):
+    library = create_library_with_root(db, "Busy Root", "/tmp/busy-root")
+    library.is_scanning = True
+    db.commit()
+
+    response = admin_client.post(
+        f"/api/libraries/{library.id}/roots",
+        json={"path": "/tmp/busy-root/archive"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Library roots cannot be changed while a scan is queued or running"}
+
+
+def test_library_root_endpoints_require_admin(auth_client, db):
+    library = create_library_with_root(db, "Root Admin Only", "/tmp/root-admin-only")
+
+    response = auth_client.get(f"/api/libraries/{library.id}/roots")
+
+    assert response.status_code == 400
+
+
 def test_preview_library_relocation_returns_counts_without_updating_root(admin_client, db, tmp_path):
     current_root_path = tmp_path / "api-current"
     proposed_root_path = tmp_path / "api-proposed"

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -141,7 +141,19 @@ def test_admin_libraries_page_exposes_folder_browser_route(admin_client):
     assert "Showing ${shown.toLocaleString()} of ${total.toLocaleString()}" in body
     assert "Scan Recommended" in body
     assert "startScan(scanLibrary, true)" in body
-    assert "Use Relocate to change this library's path safely." in body
+    assert "Watch Library" in body
+    assert "Automatically scan active roots when files are added or changed." in body
+    assert "Watch Folder" not in body
+    assert "Use Roots to relocate or manage this library's paths safely." not in body
+    assert "Library Roots" in body
+    assert "libraries.roots_create" in body
+    assert "libraries.roots_update" in body
+    assert "libraries.roots_delete" in body
+    assert "openRootsModal" in body
+    assert 'x-on:click="openRelocateModal(lib)"' not in body
+    assert "openRelocateModal(roots.library, root)" in body
+    assert "delete_comics=true" in body
+    assert "roots.library?.is_scanning || roots.adding" in body
 
 
 def test_search_widget_people_results_use_generic_creator_handoff(auth_client):

--- a/tests/browser/test_admin_library_relocation.py
+++ b/tests/browser/test_admin_library_relocation.py
@@ -50,37 +50,123 @@ def test_admin_library_relocation_preview_and_confirm_flow(page, browser_server,
 
         row = page.get_by_role("row").filter(has_text="Relocation UI Library").first
         row.wait_for()
-        row.get_by_role("button", name="Relocate").click()
+        row.get_by_role("button", name="Roots").click()
+        page.get_by_role("heading", name="Library Roots").wait_for()
+        page.get_by_test_id("library-root-row").first.get_by_role("button", name="Relocate").click()
 
-        page.get_by_role("heading", name="Relocate Library Path").wait_for()
-        page.get_by_role("button", name="Browse").click()
-        page.get_by_role("button", name="../").click()
-        page.get_by_role("button", name=f"/{proposed_root.name}").click()
-        page.get_by_role("button", name="Use This Folder").click()
-        path_input = page.get_by_placeholder("/comics/relocated")
+        relocation_modal = page.locator('[x-show="showRelocationModal"]')
+        relocation_modal.get_by_role("heading", name="Relocate Library Path").wait_for()
+        relocation_modal.get_by_role("button", name="Browse").click()
+        relocation_modal.get_by_role("button", name="../").click()
+        relocation_modal.get_by_role("button", name=f"/{proposed_root.name}").click()
+        relocation_modal.get_by_role("button", name="Use This Folder").click()
+        path_input = relocation_modal.get_by_placeholder("/comics/relocated")
         path_input.wait_for(state="visible")
         assert path_input.input_value() == proposed_root.resolve().as_posix()
-        page.get_by_role("button", name="Preview").click()
+        relocation_modal.get_by_role("button", name="Preview").click()
 
-        page.get_by_text("Matched Files").wait_for()
-        page.get_by_text("Alpha/one.cbz").wait_for()
-        page.get_by_text("Beta/two.cbz").wait_for()
-        page.get_by_text("Extra/three.cbz").wait_for()
+        relocation_modal.get_by_text("Matched Files").wait_for()
+        relocation_modal.get_by_text("Alpha/one.cbz").wait_for()
+        relocation_modal.get_by_text("Beta/two.cbz").wait_for()
+        relocation_modal.get_by_text("Extra/three.cbz").wait_for()
 
-        page.get_by_role("button", name="Confirm Relocation").click()
+        relocation_modal.get_by_role("button", name="Confirm Relocation").click()
         page.get_by_role("heading", name="Relocate Relocation UI Library?").wait_for()
         page.locator('[x-data="globalDialog()"]').get_by_role("button", name="Relocate").click()
 
         page.get_by_role("heading", name="Scan Recommended").wait_for()
         page.locator('[x-data="globalDialog()"]').get_by_role("button", name="Not Now").click()
-        page.get_by_text("Relocation complete. Scan recommended.").wait_for()
-        page.get_by_role("main").get_by_role("button", name="Run Force Scan").wait_for()
+        relocation_modal.get_by_text("Relocation complete. Scan recommended.").wait_for()
+        relocation_modal.get_by_role("button", name="Run Force Scan").wait_for()
         assert path_input.input_value() == proposed_root.resolve().as_posix()
 
         session = browser_server["db_factory"]()
         try:
             relocated_root = session.get(LibraryRoot, root_id)
             assert relocated_root.path == proposed_root.resolve().as_posix()
+        finally:
+            session.close()
+    finally:
+        settings.comics_path = original_comics_path
+        session = browser_server["db_factory"]()
+        try:
+            user = session.get(User, browser_server["seed"]["user_id"])
+            if user is not None:
+                user.is_superuser = False
+                session.commit()
+        finally:
+            session.close()
+
+
+@pytest.mark.browser
+def test_admin_library_root_lifecycle_flow(page, browser_server, tmp_path):
+    current_root = tmp_path / "roots-ui-current"
+    archive_root = tmp_path / "roots-ui-archive"
+    current_root.mkdir()
+    archive_root.mkdir()
+
+    session = browser_server["db_factory"]()
+    try:
+        user = session.get(User, browser_server["seed"]["user_id"])
+        user.is_superuser = True
+        library = create_library_with_root(session, "Roots UI Library", str(current_root))
+        session.commit()
+        library_id = library.id
+    finally:
+        session.close()
+
+    original_comics_path = settings.comics_path
+    settings.comics_path = tmp_path
+    browser_errors = []
+    page.on("pageerror", lambda exc: browser_errors.append(str(exc)))
+    page.on(
+        "console",
+        lambda msg: browser_errors.append(msg.text)
+        if "Cannot read properties of undefined" in msg.text
+        else None,
+    )
+    try:
+        page.goto(f"{browser_server['base_url']}/admin/libraries", wait_until="networkidle")
+
+        row = page.get_by_role("row").filter(has_text="Roots UI Library").first
+        row.wait_for()
+        row.get_by_role("button", name="Roots").click()
+
+        roots_modal = page.locator('[x-show="showRootsModal"]')
+        roots_modal.get_by_role("heading", name="Library Roots").wait_for()
+        archive_path = archive_root.resolve().as_posix()
+        roots_modal.get_by_role("button", name="Browse").click()
+        roots_modal.get_by_role("button", name="../").click()
+        roots_modal.get_by_role("button", name=f"/{current_root.name}").click()
+        roots_modal.get_by_role("button", name="../").click()
+        roots_modal.get_by_role("button", name=f"/{archive_root.name}").click()
+        roots_modal.get_by_role("button", name="Use This Folder").click()
+        assert roots_modal.get_by_placeholder("/comics/archive").input_value() == archive_path
+        assert browser_errors == []
+
+        roots_modal.get_by_role("button", name="Add Root").click()
+
+        archive_row = page.get_by_test_id("library-root-row").filter(has_text=archive_path)
+        archive_row.wait_for()
+        archive_row.get_by_role("button", name="Disable").click()
+        archive_row.get_by_text("Disabled").wait_for()
+
+        archive_row.get_by_role("button", name="Remove").click()
+        page.get_by_role("heading", name="Remove Root?").wait_for()
+        page.locator('[x-data="globalDialog()"]').get_by_role("button", name="Remove Root").click()
+        page.get_by_text(archive_path).wait_for(state="detached")
+
+        session = browser_server["db_factory"]()
+        try:
+            roots = (
+                session.query(LibraryRoot)
+                .filter(LibraryRoot.library_id == library_id)
+                .order_by(LibraryRoot.id)
+                .all()
+            )
+            assert len(roots) == 1
+            assert roots[0].path == str(current_root)
+            assert roots[0].is_active is True
         finally:
             session.close()
     finally:

--- a/tests/services/test_maintenance_service.py
+++ b/tests/services/test_maintenance_service.py
@@ -273,6 +273,39 @@ def test_cleanup_missing_files_reconstructs_path_from_root_instead_of_stale_file
     assert db.get(Comic, truly_missing.id) is None
 
 
+def test_cleanup_missing_files_skips_inactive_root_comics(db, tmp_path):
+    lib = _create_library(db, "maint-inactive-root", tmp_path)
+    inactive_root = LibraryRoot(
+        library_id=lib.id,
+        path=str(tmp_path / "offline-inactive-root"),
+        is_active=False,
+    )
+    db.add(inactive_root)
+    db.flush()
+
+    inactive_series = Series(name="inactive-root-series", library_id=lib.id)
+    inactive_volume = Volume(series=inactive_series, volume_number=1)
+    inactive_comic = Comic(
+        volume=inactive_volume,
+        number="1",
+        title="inactive-root-title",
+        filename="inactive-root.cbz",
+        library_root_id=inactive_root.id,
+        relative_path="offline/inactive-root.cbz",
+        page_count=12,
+    )
+    active_missing = _create_comic(db, lib, "active-missing", "missing/active.cbz")
+    db.add_all([inactive_series, inactive_volume, inactive_comic])
+    db.commit()
+
+    service = MaintenanceService(db)
+    deleted_ids = service.cleanup_missing_files(library_id=lib.id)
+
+    assert deleted_ids == [active_missing.id]
+    assert db.get(Comic, inactive_comic.id) is not None
+    assert db.get(Comic, active_missing.id) is None
+
+
 def test_cleanup_missing_files_scoped_aborts_when_active_root_missing(db, tmp_path, monkeypatch):
     lib = _create_library(db, "maint-missing-active-root", tmp_path)
     missing = _create_comic(db, lib, "missing", "stale-location/gone.cbz")

--- a/tests/services/test_scanner.py
+++ b/tests/services/test_scanner.py
@@ -116,6 +116,65 @@ def test_scan_parallel_cleans_up_missing_files_across_all_active_roots(db, tmp_p
     assert second_root.last_scanned_at is not None
 
 
+def test_scan_parallel_preserves_comics_on_disabled_roots(db, tmp_path):
+    active_root_path = tmp_path / "active"
+    disabled_root_path = tmp_path / "disabled"
+    active_root_path.mkdir()
+
+    scanner, library = _build_scanner(db, active_root_path, name="scanner-disabled-root-lib")
+    active_root = library.active_root
+    disabled_root = LibraryRoot(
+        library_id=library.id,
+        path=str(disabled_root_path),
+        is_active=False,
+    )
+    db.add(disabled_root)
+    db.flush()
+
+    series = Series(name="Disabled Root Cleanup", library_id=library.id)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    active_file = active_root_path / "active.cbz"
+    active_file.write_bytes(b"active")
+    future_mtime = active_file.stat().st_mtime + 60
+
+    active_comic = create_comic(
+        db,
+        volume,
+        active_root,
+        "active.cbz",
+        number="1",
+        filename="active.cbz",
+        file_modified_at=future_mtime,
+        page_count=10,
+    )
+    disabled_comic = create_comic(
+        db,
+        volume,
+        disabled_root,
+        "archived.cbz",
+        number="2",
+        filename="archived.cbz",
+        file_modified_at=future_mtime,
+        page_count=10,
+    )
+    db.commit()
+
+    result = scanner.scan_parallel(force=False, worker_limit=1)
+
+    assert result["skipped"] == 1
+    assert result["deleted"] == 0
+    assert db.get(Comic, active_comic.id) is not None
+    assert db.get(Comic, disabled_comic.id) is not None
+
+    db.refresh(active_root)
+    db.refresh(disabled_root)
+    assert active_root.last_scanned_at is not None
+    assert disabled_root.last_scanned_at is None
+
+
 def test_cleanup_missing_files_deletes_and_commits(db, tmp_path):
     scanner, library = _build_scanner(db, tmp_path, name="scanner-cleanup-lib")
     root = library.active_root


### PR DESCRIPTION

Adds the first product-facing multi-root library management layer. Libraries can now manage roots explicitly from the admin UI, including adding roots, disabling/enabling roots, relocating a specific root, and removing roots with an explicit comic deletion policy.

**Summary**
- Added library root lifecycle API support with overlap validation, scan-job mutation guards, root comic counts, and explicit remove behavior.
- Updated the admin Libraries page with a Roots modal, multi-root-aware Storage display, and clearer `Last Scanned` table labeling.
- Kept disabled roots preserved: scans and janitor cleanup now avoid pruning comics tied to inactive roots.
- Hardened the folder browser for large Windows roots by avoiding Alpine list diffing for directory entries.


**Validation**
- `.\.venv\Scripts\python.exe -m pytest tests\services\test_maintenance_service.py tests\api\test_libraries.py tests\api\test_pages.py::test_admin_libraries_page_exposes_folder_browser_route tests\browser\test_admin_library_relocation.py`
- `.\.venv\Scripts\python.exe -m pytest tests\services\test_library_relocation.py tests\api\test_libraries.py`
- `.\.venv\Scripts\python.exe -m pytest tests\services\test_scanner.py tests\services\test_scanner_parallel.py`
- `.\.venv\Scripts\python.exe -m pytest tests\browser\test_search_and_series_smoke.py`