### PR TITLE
Add Parker-managed CBL reading list support

### DIFF
--- a/alembic/versions/6601fdcd204e_add_cbl_sources.py
+++ b/alembic/versions/6601fdcd204e_add_cbl_sources.py
@@ -1,0 +1,69 @@
+"""add_cbl_sources
+
+Revision ID: 6601fdcd204e
+Revises: 97838fa89f89
+Create Date: 2026-07-27 19:09:36.918623
+
+Adds the cbl_sources table (managed .cbl files Parker has imported via
+upload, URL, catalog, or library-root discovery) and links reading_lists to
+the source that owns it, so a "cbl"-sourced reading list can be resynced or
+torn down alongside its managed file.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6601fdcd204e'
+down_revision: Union[str, None] = '97838fa89f89'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cbl_sources",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=False),
+        sa.Column("stored_path", sa.String(), nullable=False),
+        sa.Column("original_filename", sa.String(), nullable=True),
+        sa.Column("origin", sa.String(), nullable=False),
+        sa.Column("source_url", sa.String(), nullable=True),
+        sa.Column("catalog_provider", sa.String(), nullable=True),
+        sa.Column("catalog_path", sa.String(), nullable=True),
+        sa.Column("imported_at", sa.DateTime(), nullable=True),
+        sa.Column("last_refreshed_at", sa.DateTime(), nullable=True),
+        sa.Column("last_refresh_status", sa.String(), nullable=False),
+        sa.Column("fingerprint", sa.String(), nullable=False),
+        sa.Column("entry_count", sa.Integer(), nullable=True),
+        sa.Column("last_match_summary", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_cbl_sources_id"), "cbl_sources", ["id"])
+    op.create_index(op.f("ix_cbl_sources_origin"), "cbl_sources", ["origin"])
+    op.create_index(op.f("ix_cbl_sources_fingerprint"), "cbl_sources", ["fingerprint"])
+
+    with op.batch_alter_table("reading_lists", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("source_cbl_id", sa.Integer(), nullable=True))
+        batch_op.create_index(batch_op.f("ix_reading_lists_source_cbl_id"), ["source_cbl_id"])
+        batch_op.create_foreign_key(
+            "fk_reading_lists_source_cbl_id_cbl_sources",
+            "cbl_sources",
+            ["source_cbl_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("reading_lists", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_reading_lists_source_cbl_id_cbl_sources", type_="foreignkey")
+        batch_op.drop_index(batch_op.f("ix_reading_lists_source_cbl_id"))
+        batch_op.drop_column("source_cbl_id")
+
+    op.drop_index(op.f("ix_cbl_sources_fingerprint"), table_name="cbl_sources")
+    op.drop_index(op.f("ix_cbl_sources_origin"), table_name="cbl_sources")
+    op.drop_index(op.f("ix_cbl_sources_id"), table_name="cbl_sources")
+    op.drop_table("cbl_sources")

--- a/alembic/versions/97838fa89f89_add_reading_list_source.py
+++ b/alembic/versions/97838fa89f89_add_reading_list_source.py
@@ -1,0 +1,61 @@
+"""add_reading_list_source
+
+Revision ID: 97838fa89f89
+Revises: 9def8df8ed7c
+Create Date: 2026-07-27 19:09:36.391724
+
+Replaces the old auto_generated int flag with an explicit `source` field so
+reading lists can distinguish "manual" (user-owned), "comicinfo" (derived from
+embedded AlternateSeries/AlternateNumber), and -- in a follow-up migration --
+"cbl" (derived from a managed .cbl file) provenance. auto_generated=1 rows
+become "comicinfo", auto_generated=0 rows become "manual"; NULL is treated as
+"manual" conservatively, matching how the old integer flag defaulted callers
+that never set it explicitly.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '97838fa89f89'
+down_revision: Union[str, None] = '9def8df8ed7c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+reading_lists = sa.table(
+    "reading_lists",
+    sa.column("id", sa.Integer),
+    sa.column("auto_generated", sa.Integer),
+    sa.column("source", sa.String),
+)
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("reading_lists", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("source", sa.String(), nullable=True))
+
+    conn = op.get_bind()
+    conn.execute(reading_lists.update().where(reading_lists.c.auto_generated == 1).values(source="comicinfo"))
+    conn.execute(reading_lists.update().where(reading_lists.c.auto_generated != 1).values(source="manual"))
+    conn.execute(reading_lists.update().where(reading_lists.c.auto_generated.is_(None)).values(source="manual"))
+
+    with op.batch_alter_table("reading_lists", schema=None) as batch_op:
+        batch_op.alter_column("source", existing_type=sa.String(), nullable=False)
+        batch_op.create_index(batch_op.f("ix_reading_lists_source"), ["source"])
+        batch_op.drop_column("auto_generated")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("reading_lists", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("auto_generated", sa.Integer(), nullable=True))
+
+    conn = op.get_bind()
+    conn.execute(reading_lists.update().where(reading_lists.c.source == "comicinfo").values(auto_generated=1))
+    conn.execute(reading_lists.update().where(reading_lists.c.source != "comicinfo").values(auto_generated=0))
+
+    with op.batch_alter_table("reading_lists", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_reading_lists_source"))
+        batch_op.drop_column("source")

--- a/app/api/cbl_catalog.py
+++ b/app/api/cbl_catalog.py
@@ -1,0 +1,72 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.api.deps import AdminUser, SessionDep
+from app.services.cbl_catalog_service import (
+    CBLCatalogError,
+    CBLCatalogNotFoundError,
+    CBLCatalogService,
+    CBLCatalogUpstreamError,
+)
+from app.services.cbl_source_service import CBLSourceError, CBLSourceService
+
+router = APIRouter()
+
+
+class CBLCatalogImportRequest(BaseModel):
+    path: str
+
+
+@router.get("/browse", name="browse")
+async def browse_catalog(db: SessionDep, admin: AdminUser, path: str = "", force_refresh: bool = False):
+    service = CBLCatalogService(db)
+
+    try:
+        return await service.browse(path, force_refresh=force_refresh)
+    except CBLCatalogNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except CBLCatalogUpstreamError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+
+@router.get("/preview", name="preview")
+async def preview_catalog_file(db: SessionDep, admin: AdminUser, path: str):
+    service = CBLCatalogService(db)
+
+    try:
+        return await service.preview(path)
+    except CBLCatalogNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except CBLCatalogUpstreamError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except CBLCatalogError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/import", name="import_file")
+async def import_catalog_file(payload: CBLCatalogImportRequest, db: SessionDep, admin: AdminUser):
+    service = CBLCatalogService(db)
+
+    try:
+        source = await service.import_file(payload.path)
+        CBLSourceService(db).rebuild(source.id)
+        db.commit()
+    except CBLCatalogNotFoundError as exc:
+        db.rollback()
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except CBLCatalogUpstreamError as exc:
+        db.rollback()
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    except (CBLCatalogError, CBLSourceError) as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    db.refresh(source)
+    return {
+        "id": source.id,
+        "display_name": source.display_name,
+        "origin": source.origin,
+        "catalog_provider": source.catalog_provider,
+        "catalog_path": source.catalog_path,
+        "entry_count": source.entry_count,
+    }

--- a/app/api/cbl_sources.py
+++ b/app/api/cbl_sources.py
@@ -1,0 +1,131 @@
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.api.deps import AdminUser, SessionDep
+from app.models.cbl_source import CBLSource
+from app.models.reading_list import ReadingList
+from app.services.cbl_catalog_service import CBLCatalogService
+from app.services.cbl_source_service import CBLSourceError, CBLSourceService
+
+router = APIRouter()
+
+
+class CBLSourceUrlRequest(BaseModel):
+    url: str
+
+
+def _serialize(source: CBLSource, reading_list: ReadingList | None = None) -> dict:
+    return {
+        "id": source.id,
+        "display_name": source.display_name,
+        "original_filename": source.original_filename,
+        "origin": source.origin,
+        "source_url": source.source_url,
+        "catalog_provider": source.catalog_provider,
+        "catalog_path": source.catalog_path,
+        "imported_at": source.imported_at,
+        "last_refreshed_at": source.last_refreshed_at,
+        "last_refresh_status": source.last_refresh_status,
+        "entry_count": source.entry_count,
+        "last_match_summary": source.last_match_summary,
+        "reading_list_id": reading_list.id if reading_list else None,
+        "reading_list_name": reading_list.name if reading_list else None,
+    }
+
+
+def _reading_list_for(db: Session, source: CBLSource) -> ReadingList | None:
+    return db.query(ReadingList).filter(ReadingList.source_cbl_id == source.id).first()
+
+
+@router.get("/", name="list")
+async def list_cbl_sources(db: SessionDep, admin: AdminUser):
+    sources = db.query(CBLSource).order_by(CBLSource.imported_at.desc()).all()
+
+    reading_lists_by_source_id = {}
+    if sources:
+        reading_lists = db.query(ReadingList).filter(
+            ReadingList.source_cbl_id.in_([s.id for s in sources])
+        ).all()
+        reading_lists_by_source_id = {rl.source_cbl_id: rl for rl in reading_lists}
+
+    return {"items": [_serialize(s, reading_lists_by_source_id.get(s.id)) for s in sources]}
+
+
+@router.get("/{source_id}", name="detail")
+async def get_cbl_source(source_id: int, db: SessionDep, admin: AdminUser):
+    source = db.get(CBLSource, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="CBL source not found")
+    return _serialize(source, _reading_list_for(db, source))
+
+
+@router.post("/upload", name="upload")
+async def upload_cbl_source(db: SessionDep, admin: AdminUser, file: UploadFile = File(...)):
+    content = await file.read()
+    service = CBLSourceService(db)
+
+    try:
+        source = service.import_upload(content, file.filename or "upload.cbl")
+        service.rebuild(source.id)
+        db.commit()
+    except CBLSourceError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    db.refresh(source)
+    return _serialize(source, _reading_list_for(db, source))
+
+
+@router.post("/url", name="import_url")
+async def import_cbl_source_from_url(payload: CBLSourceUrlRequest, db: SessionDep, admin: AdminUser):
+    service = CBLSourceService(db)
+
+    try:
+        source = await service.import_url(payload.url)
+        service.rebuild(source.id)
+        db.commit()
+    except CBLSourceError as exc:
+        db.rollback()
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    db.refresh(source)
+    return _serialize(source, _reading_list_for(db, source))
+
+
+@router.post("/{source_id}/refresh", name="refresh")
+async def refresh_cbl_source(source_id: int, db: SessionDep, admin: AdminUser):
+    source = db.get(CBLSource, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail=f"CBL source {source_id} not found")
+
+    service = CBLSourceService(db)
+
+    try:
+        if source.origin == "catalog":
+            source = await CBLCatalogService(db).refresh_source(source_id)
+        else:
+            source = await service.refresh(source_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except CBLSourceError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    if source.last_refresh_status == "ok":
+        service.rebuild(source.id)
+
+    db.commit()
+    db.refresh(source)
+    return _serialize(source, _reading_list_for(db, source))
+
+
+@router.delete("/{source_id}", name="delete")
+async def delete_cbl_source(source_id: int, db: SessionDep, admin: AdminUser):
+    service = CBLSourceService(db)
+
+    try:
+        service.delete(source_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return {"message": "CBL source deleted"}

--- a/app/api/reading_lists.py
+++ b/app/api/reading_lists.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 from sqlalchemy.orm import joinedload, aliased
 from sqlalchemy import func, select, and_, or_, not_
 from typing import Annotated, List
 
-from app.api.deps import SessionDep, CurrentUser, PaginationParams, PaginatedResponse
+from app.api.deps import SessionDep, CurrentUser, AdminUser, PaginationParams, PaginatedResponse
 from app.core.comic_helpers import (get_aggregated_metadata,
                                     get_thumbnail_url, get_banned_comic_condition,
                                     check_container_restriction)
@@ -13,8 +14,23 @@ from app.models.library import Library
 from app.models.tags import Character, Team, Location
 from app.models.credits import Person, ComicCredit
 from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.cbl_source import CBLSource
 
 router = APIRouter()
+
+SOURCE_LABELS = {
+    "manual": "Manual",
+    "comicinfo": "Auto-Generated",
+    "cbl": "CBL Derived",
+}
+
+
+def _source_label(source: str) -> str:
+    return SOURCE_LABELS.get(source, source)
+
+
+class ReadingListRenameRequest(BaseModel):
+    name: str
 
 
 @router.get("/", response_model=PaginatedResponse, name="list")
@@ -82,7 +98,8 @@ async def list_reading_lists(db: SessionDep,
             "id": rl.id,
             "name": rl.name,
             "description": rl.description,
-            "auto_generated": bool(rl.auto_generated),
+            "source": rl.source,
+            "source_label": _source_label(rl.source),
             "comic_count": v_count,  # Use the SQL calculated count
             "created_at": rl.created_at,
             "updated_at": rl.updated_at
@@ -167,11 +184,12 @@ async def get_reading_list(list_id: int, db: SessionDep, current_user: CurrentUs
                                              allowed_library_ids=allowed_ids)
     }
 
-    return {
+    payload = {
         "id": reading_list.id,
         "name": reading_list.name,
         "description": reading_list.description,
-        "auto_generated": bool(reading_list.auto_generated),
+        "source": reading_list.source,
+        "source_label": _source_label(reading_list.source),
         "comic_count": len(comics),
         "comics": comics,
         "created_at": reading_list.created_at,
@@ -179,12 +197,81 @@ async def get_reading_list(list_id: int, db: SessionDep, current_user: CurrentUs
         "details": details
     }
 
+    if current_user.is_superuser and reading_list.source_cbl_id:
+        cbl_source = db.get(CBLSource, reading_list.source_cbl_id)
+        if cbl_source:
+            payload["cbl_source"] = {
+                "id": cbl_source.id,
+                "origin": cbl_source.origin,
+                "last_refresh_status": cbl_source.last_refresh_status,
+                "last_refreshed_at": cbl_source.last_refreshed_at,
+            }
+
+    return payload
+
+
+@router.patch("/{list_id}", name="rename")
+async def rename_reading_list(list_id: int, payload: ReadingListRenameRequest, db: SessionDep, admin: AdminUser):
+    """
+    Rename a reading list. Only CBL-derived lists can be renamed here --
+    ComicInfo-derived names are entirely driven by embedded metadata, so fixing
+    one means fixing the comic's ComicInfo.xml and rescanning, not editing the
+    derived list directly. Manual lists have no creation UI yet either, so
+    there's nothing to rename there today.
+    """
+    reading_list = db.query(ReadingList).filter(ReadingList.id == list_id).first()
+    if not reading_list:
+        raise HTTPException(status_code=404, detail="Reading list not found")
+
+    if reading_list.source != "cbl":
+        raise HTTPException(status_code=400, detail="Only CBL-derived reading lists can be renamed")
+
+    new_name = payload.name.strip()
+    if not new_name:
+        raise HTTPException(status_code=400, detail="Name cannot be empty")
+
+    existing = db.query(ReadingList).filter(
+        ReadingList.name == new_name, ReadingList.id != list_id
+    ).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="A reading list with that name already exists")
+
+    reading_list.name = new_name
+    db.commit()
+
+    return {
+        "id": reading_list.id,
+        "name": reading_list.name,
+        "source": reading_list.source,
+        "source_label": _source_label(reading_list.source),
+    }
+
 
 @router.delete("/{list_id}", name="delete")
-async def delete_reading_list(list_id: int, db: SessionDep, current_user: CurrentUser):
-    """Delete a reading list"""
+async def delete_reading_list(list_id: int, db: SessionDep, admin: AdminUser):
+    """Delete a reading list. Admin-only: there's no self-service reading-list
+    creation today, and comicinfo-derived lists are system-managed (deleting one
+    just gets it silently recreated the next time that comic's metadata is
+    reprocessed, so this was never a safe or durable action for a regular user).
+
+    CBL-derived lists can't be deleted here at all -- CBLSourceService.delete()
+    (DELETE /api/cbl-sources/{source_id}) is the only coherent lifecycle path:
+    it removes the managed file and CBLSource row along with the ReadingList,
+    instead of leaving an orphaned CBLSource that just gets rebuilt right back
+    on the next scan."""
     reading_list = db.query(ReadingList).filter(ReadingList.id == list_id).first()
     if not reading_list: raise HTTPException(status_code=404, detail="Reading list not found")
+
+    if reading_list.source == "cbl":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This is a CBL-derived reading list. Delete the CBL source instead "
+                f"(DELETE /api/cbl-sources/{reading_list.source_cbl_id}) to remove it "
+                "and its managed file together."
+            ),
+        )
+
     db.delete(reading_list)
     db.commit()
 

--- a/app/config.py
+++ b/app/config.py
@@ -56,6 +56,7 @@ class Settings(BaseSettings):
     cover_dir: Path = Path("storage/cover")
     backup_dir: Path = Path("storage/backup")
     avatar_dir: Path = Path("storage/avatars")
+    cbl_dir: Path = Path("storage/cbl")
     thumbnail_size: tuple[float, float] = (320, 455)
     avatar_size: tuple[float, float] = (400, 400)  # standard avatar box
 

--- a/app/core/comic_helpers.py
+++ b/app/core/comic_helpers.py
@@ -203,6 +203,17 @@ def check_container_restriction(db, user, item_model, fk_column, container_id: i
 
 
 
+def normalize_issue_number(number: str) -> str:
+    """Normalize weird comic numbers (e.g. the '½' / '1/2' half-issue glyph)."""
+    if not number:
+        return number
+
+    if number == "½" or number == "1/2":
+        return "0.5"
+
+    return number
+
+
 def get_format_filters():
     """
     Returns SQL expressions to categorize comics.

--- a/app/core/text_utils.py
+++ b/app/core/text_utils.py
@@ -1,0 +1,15 @@
+import re
+
+
+def normalize_title(text: str) -> str:
+    """
+    Normalize a title/series/event name for loose matching:
+    'The Infinity Gauntlet' -> 'infinity gauntlet'
+    """
+    if not text:
+        return ""
+    text = text.lower()
+    if text.startswith("the "):
+        text = text[4:]
+    text = re.sub(r'[^a-z0-9\s]', '', text)
+    return text.strip()

--- a/app/main.py
+++ b/app/main.py
@@ -33,7 +33,7 @@ from app.services.watcher import library_watcher
 
 # API Routes
 from app.api import libraries, comics, reader, progress, series, volumes, search, bookmarks
-from app.api import reading_lists, collections
+from app.api import reading_lists, collections, cbl_sources, cbl_catalog
 from app.api import auth, users, saved_searches, smart_lists
 from app.api import tasks, jobs, stats, settings as settings_api
 from app.api import pull_lists
@@ -72,6 +72,7 @@ async def lifespan(app: FastAPI):
     settings.cache_dir.mkdir(parents=True, exist_ok=True)
     settings.cover_dir.mkdir(parents=True, exist_ok=True)
     settings.avatar_dir.mkdir(parents=True, exist_ok=True)
+    settings.cbl_dir.mkdir(parents=True, exist_ok=True)
 
     # -- Init DB defaults when necessary (Safe, idempotent)
     db = SessionLocal()
@@ -256,6 +257,8 @@ app.include_router(tasks.router, prefix="/api/tasks", tags=["tasks", "admin"])
 app.include_router(stats.router, prefix="/api/stats", tags=["stats", "admin"])
 app.include_router(reports.router, prefix="/api/reports", tags=["reports", "admin"])
 app.include_router(migration.router, prefix="/api/migration", tags=["migration", "admin"])
+app.include_router(cbl_sources.router, prefix="/api/cbl-sources", tags=["cbl-sources", "admin"])
+app.include_router(cbl_catalog.router, prefix="/api/cbl-catalog", tags=["cbl-catalog", "admin"])
 
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.comic import Volume, Comic  # Both Volume and Comic are in comic
 from app.models.tags import Character, Team, Location, Genre
 from app.models.credits import Person, ComicCredit
 from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.cbl_source import CBLSource
 from app.models.collection import Collection, CollectionItem
 from app.models.reading_progress import ReadingProgress
 from app.models.bookmark import Bookmark
@@ -24,6 +25,7 @@ __all__ = [
     'Character', 'Team', 'Location', 'Genre',
     'Person', 'ComicCredit',
     'ReadingList', 'ReadingListItem',
+    'CBLSource',
     'Collection', 'CollectionItem',
     'ReadingProgress', 'ActivityLog', 'Bookmark',
     'ScanJob',

--- a/app/models/cbl_source.py
+++ b/app/models/cbl_source.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, Integer, String, Text, DateTime
+from datetime import datetime, timezone
+from app.database import Base
+
+
+class CBLSource(Base):
+    """A managed .cbl file Parker has imported (upload, URL, catalog, or library-root discovery)."""
+    __tablename__ = "cbl_sources"
+
+    id = Column(Integer, primary_key=True, index=True)
+    display_name = Column(String, nullable=False)
+    stored_path = Column(String, nullable=False)
+    original_filename = Column(String, nullable=True)
+
+    # "upload", "url", "catalog", or "library_import"
+    origin = Column(String, nullable=False, index=True)
+    source_url = Column(String, nullable=True)
+    catalog_provider = Column(String, nullable=True)
+    catalog_path = Column(String, nullable=True)
+
+    imported_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+    last_refreshed_at = Column(DateTime, nullable=True)
+    last_refresh_status = Column(String, nullable=False, default="never")
+
+    fingerprint = Column(String, nullable=False, index=True)
+    entry_count = Column(Integer, nullable=True)
+    last_match_summary = Column(Text, nullable=True)

--- a/app/models/reading_list.py
+++ b/app/models/reading_list.py
@@ -12,8 +12,10 @@ class ReadingList(Base):
     name = Column(String, unique=True, nullable=False, index=True)
     description = Column(Text)
 
-    # Track if this was auto-generated from AlternateSeries
-    auto_generated = Column(Integer, default=1)  # SQLite uses 1/0 for boolean
+    # Provenance: "manual" (user-created), "comicinfo" (derived from embedded
+    # AlternateSeries/AlternateNumber), or "cbl" (derived from a managed .cbl file).
+    source = Column(String, nullable=False, default="manual", index=True)
+    source_cbl_id = Column(Integer, ForeignKey("cbl_sources.id", ondelete="SET NULL"), nullable=True, index=True)
 
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -119,6 +119,12 @@ async def admin_migration_page(request: Request, admin_user: AdminUser):
     return templates.TemplateResponse(request=request, name="admin/migration.html")
 
 
+@router.get("/cbl-sources", response_class=HTMLResponse, name="cbl_sources", tags=['admin'])
+async def admin_cbl_sources_page(request: Request, admin_user: AdminUser):
+    """Serve the Admin CBL Reading Lists page"""
+    return templates.TemplateResponse(request=request, name="admin/cbl_sources.html")
+
+
 @router.get("/about", response_class=HTMLResponse, name="about", tags=['admin'])
 async def admin_about_page(request: Request, admin_user: AdminUser):
     """Serve the Admin About page"""

--- a/app/services/cbl_catalog_service.py
+++ b/app/services/cbl_catalog_service.py
@@ -6,7 +6,7 @@ import httpx
 from sqlalchemy.orm import Session
 
 from app.models.cbl_source import CBLSource
-from app.services.cbl_parser import parse_cbl
+from app.services.cbl_parser import CBLEntry, parse_cbl
 from app.services.cbl_source_service import MAX_CBL_SIZE_BYTES, CBLSourceError, CBLSourceService
 
 CATALOG_PROVIDER = "dieseltech"
@@ -14,11 +14,17 @@ GITHUB_API_BASE = "https://api.github.com/repos/DieselTech/CBL-ReadingLists"
 GITHUB_RAW_HOST = "raw.githubusercontent.com"
 FETCH_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)
 CACHE_TTL_SECONDS = 15 * 60
+PREVIEW_SAMPLE_SIZE = 10
 _REQUEST_HEADERS = {
     "Accept": "application/vnd.github+json",
     # GitHub's REST API 403s unauthenticated requests that omit a User-Agent.
     "User-Agent": "Parker-CBL-Catalog",
 }
+
+
+def _format_entry_summary(entry: CBLEntry) -> str:
+    label = f"{entry.series or 'Unknown Series'} #{entry.number}" if entry.number else (entry.series or "Unknown Series")
+    return f"{label} ({entry.year})" if entry.year else label
 
 
 class CBLCatalogError(Exception):
@@ -119,7 +125,17 @@ class CBLCatalogService:
     async def preview(self, path: str) -> dict:
         content, name = await self._get_file_bytes(path)
         parsed = parse_cbl(content, filename_stem=Path(name).stem)
-        return {"name": parsed.name, "entry_count": len(parsed.entries), "warnings": parsed.warnings}
+        return {
+            "name": parsed.name,
+            "entry_count": len(parsed.entries),
+            "warnings": parsed.warnings,
+            # Raw CBL order/metadata, not yet matched against the local library
+            # (matching only happens on import, via rebuild()) -- capped so a
+            # multi-hundred-entry "Master Reading Order" doesn't dump a wall of
+            # text into the preview.
+            "sample_entries": [_format_entry_summary(e) for e in parsed.entries[:PREVIEW_SAMPLE_SIZE]],
+            "sample_truncated": len(parsed.entries) > PREVIEW_SAMPLE_SIZE,
+        }
 
     async def import_file(self, path: str) -> CBLSource:
         content, name = await self._get_file_bytes(path)

--- a/app/services/cbl_catalog_service.py
+++ b/app/services/cbl_catalog_service.py
@@ -1,0 +1,152 @@
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.models.cbl_source import CBLSource
+from app.services.cbl_parser import parse_cbl
+from app.services.cbl_source_service import MAX_CBL_SIZE_BYTES, CBLSourceError, CBLSourceService
+
+CATALOG_PROVIDER = "dieseltech"
+GITHUB_API_BASE = "https://api.github.com/repos/DieselTech/CBL-ReadingLists"
+GITHUB_RAW_HOST = "raw.githubusercontent.com"
+FETCH_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)
+CACHE_TTL_SECONDS = 15 * 60
+_REQUEST_HEADERS = {
+    "Accept": "application/vnd.github+json",
+    # GitHub's REST API 403s unauthenticated requests that omit a User-Agent.
+    "User-Agent": "Parker-CBL-Catalog",
+}
+
+
+class CBLCatalogError(Exception):
+    """Base class for catalog browsing failures."""
+
+
+class CBLCatalogNotFoundError(CBLCatalogError):
+    """The requested path does not exist in the catalog repository."""
+
+
+class CBLCatalogUpstreamError(CBLCatalogError):
+    """GitHub is unreachable, rate-limited, or returned an unexpected response."""
+
+
+class CBLCatalogService:
+    """Browses the DieselTech/CBL-ReadingLists GitHub repo and imports files from
+    it into Parker-managed CBL storage. Single built-in provider for MVP, no
+    GitHub token required -- see docs/cbl-reading-list-support-scope.md."""
+
+    _cache: dict[str, tuple[float, dict]] = {}
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.source_service = CBLSourceService(db)
+
+    async def _get_contents(self, path: str):
+        url = f"{GITHUB_API_BASE}/contents/{path}".rstrip("/")
+        try:
+            async with httpx.AsyncClient(timeout=FETCH_TIMEOUT) as client:
+                response = await client.get(url, headers=_REQUEST_HEADERS)
+        except httpx.HTTPError as exc:
+            raise CBLCatalogUpstreamError(f"Failed to reach GitHub: {exc}") from exc
+
+        if response.status_code == 404:
+            raise CBLCatalogNotFoundError(f"Path not found in catalog repository: {path or '/'}")
+        if response.status_code in (403, 429):
+            raise CBLCatalogUpstreamError("GitHub API rate limit exceeded. Try again later.")
+        if response.status_code != 200:
+            raise CBLCatalogUpstreamError(f"GitHub API returned unexpected status {response.status_code}")
+
+        return response.json()
+
+    async def browse(self, path: str = "", force_refresh: bool = False) -> dict:
+        cache_key = path.strip("/")
+        now = time.monotonic()
+
+        if not force_refresh and cache_key in self._cache:
+            cached_at, payload = self._cache[cache_key]
+            if now - cached_at < CACHE_TTL_SECONDS:
+                return payload
+
+        data = await self._get_contents(cache_key)
+        if not isinstance(data, list):
+            raise CBLCatalogNotFoundError(f"Path is not a folder: {path}")
+
+        entries = []
+        for item in data:
+            if item.get("type") == "dir":
+                entries.append({"name": item["name"], "path": item["path"], "type": "dir"})
+            elif item.get("type") == "file" and item.get("name", "").lower().endswith(".cbl"):
+                entries.append({"name": item["name"], "path": item["path"], "type": "file"})
+
+        entries.sort(key=lambda e: (e["type"] != "dir", e["name"].lower()))
+
+        payload = {"path": cache_key, "entries": entries}
+        self._cache[cache_key] = (now, payload)
+        return payload
+
+    async def _fetch_raw_bytes(self, download_url: str) -> bytes:
+        host = urlparse(download_url).hostname
+        if host != GITHUB_RAW_HOST:
+            raise CBLCatalogError(f"Refusing to fetch from unexpected host: {host}")
+
+        content = bytearray()
+        try:
+            async with httpx.AsyncClient(timeout=FETCH_TIMEOUT, follow_redirects=False) as client:
+                async with client.stream("GET", download_url, headers=_REQUEST_HEADERS) as response:
+                    response.raise_for_status()
+                    async for chunk in response.aiter_bytes():
+                        content.extend(chunk)
+                        if len(content) > MAX_CBL_SIZE_BYTES:
+                            raise CBLCatalogError(
+                                f"Catalog file exceeds maximum size of {MAX_CBL_SIZE_BYTES // (1024 * 1024)}MB"
+                            )
+        except httpx.HTTPError as exc:
+            raise CBLCatalogUpstreamError(f"Failed to download catalog file: {exc}") from exc
+
+        return bytes(content)
+
+    async def _get_file_bytes(self, path: str) -> tuple[bytes, str]:
+        meta = await self._get_contents(path)
+        if isinstance(meta, list) or meta.get("type") != "file":
+            raise CBLCatalogNotFoundError(f"Path is not a file: {path}")
+
+        content = await self._fetch_raw_bytes(meta["download_url"])
+        return content, meta["name"]
+
+    async def preview(self, path: str) -> dict:
+        content, name = await self._get_file_bytes(path)
+        parsed = parse_cbl(content, filename_stem=Path(name).stem)
+        return {"name": parsed.name, "entry_count": len(parsed.entries), "warnings": parsed.warnings}
+
+    async def import_file(self, path: str) -> CBLSource:
+        content, name = await self._get_file_bytes(path)
+        return self.source_service.import_upload(
+            content, name, origin="catalog", catalog_provider=CATALOG_PROVIDER, catalog_path=path
+        )
+
+    async def refresh_source(self, source_id: int) -> CBLSource:
+        """
+        Refresh a catalog-origin CBLSource by re-resolving its file from GitHub
+        via `catalog_path` rather than a stored URL. GitHub's `download_url`
+        can shift if the repo restructures around a path (folder rename, file
+        move); re-resolving by path through the same Contents API lookup used
+        at import/preview time is more durable than caching a raw URL.
+        """
+        source = self.db.get(CBLSource, source_id)
+        if not source:
+            raise ValueError(f"CBL source {source_id} not found")
+
+        if source.origin != "catalog" or not source.catalog_path:
+            raise CBLSourceError("This CBL source has no catalog path to refresh from")
+
+        try:
+            content, _ = await self._get_file_bytes(source.catalog_path)
+            self.source_service.apply_refreshed_content(source, content)
+        except (CBLCatalogError, CBLSourceError) as exc:
+            self.source_service.mark_refresh_failed(source, exc)
+
+        self.db.flush()
+        return source

--- a/app/services/cbl_matching.py
+++ b/app/services/cbl_matching.py
@@ -1,0 +1,172 @@
+import json
+from dataclasses import dataclass, field
+
+from sqlalchemy.orm import Session
+
+from app.core.comic_helpers import normalize_issue_number
+from app.core.text_utils import normalize_title
+from app.models.comic import Comic, Volume
+from app.models.series import Series
+from app.services.cbl_parser import CBLEntry
+
+# ComicRack-style CBL <Book> entries carry only Series/Number/Volume/Year/Format --
+# no filesystem path or filename -- so path/filename matching tiers (mentioned as
+# optional in docs/cbl-reading-list-support-scope.md) have nothing to match against
+# for real-world CBL files and are intentionally not implemented here. Matching order:
+#
+# 1. series + number + volume + year -- only works when the library's Volume tagging
+#    convention agrees with the CBL file's (both usually mean "year the run started").
+# 2. series + number + year -- drops the volume comparison but keeps year. Needed
+#    because plenty of libraries tag Volume as a plain sequential index (1, 2, 3...)
+#    rather than a start year, which would otherwise never agree with a CBL file's
+#    Volume value and silently degrade every match to tier 3.
+# 3. series + number only, as a last resort when no year is available on either side.
+#
+# Each tier only ever uses values the tagger/CBL file actually asserted -- never an
+# inferred/derived one -- so a wrong guess is never mistaken for a confident match.
+
+
+@dataclass
+class CBLMatchedEntry:
+    entry: CBLEntry
+    comic_id: int
+    matched_by: str  # "metadata", "metadata_year", or "relaxed_metadata"
+
+
+@dataclass
+class CBLUnmatchedEntry:
+    entry: CBLEntry
+    reason: str  # "unmatched", "ambiguous", or "duplicate_target"
+
+
+@dataclass
+class CBLMatchResult:
+    matched: list[CBLMatchedEntry] = field(default_factory=list)
+    unmatched: list[CBLUnmatchedEntry] = field(default_factory=list)
+
+    @property
+    def ordered_comic_ids(self) -> list[int]:
+        return [m.comic_id for m in self.matched]
+
+    def summary_json(self) -> str:
+        counts = {"metadata": 0, "metadata_year": 0, "relaxed_metadata": 0}
+        for m in self.matched:
+            counts[m.matched_by] = counts.get(m.matched_by, 0) + 1
+
+        reasons = {"unmatched": 0, "ambiguous": 0, "duplicate_target": 0}
+        for u in self.unmatched:
+            reasons[u.reason] = reasons.get(u.reason, 0) + 1
+
+        sample = [
+            f"{u.entry.series or '?'} #{u.entry.number or '?'} ({u.reason})"
+            for u in self.unmatched[:10]
+        ]
+
+        return json.dumps({
+            "matched_by_metadata": counts["metadata"],
+            "matched_by_metadata_year": counts["metadata_year"],
+            "matched_by_relaxed_metadata": counts["relaxed_metadata"],
+            "unmatched": reasons["unmatched"],
+            "ambiguous": reasons["ambiguous"],
+            "duplicate_target": reasons["duplicate_target"],
+            "sample_unmatched": sample,
+        })
+
+
+def _entry_key_parts(entry: CBLEntry) -> tuple[str, str]:
+    return normalize_title(entry.series or ""), normalize_issue_number(entry.number or "") or ""
+
+
+def match_cbl_entries(db: Session, entries: list[CBLEntry]) -> CBLMatchResult:
+    """
+    Match parsed CBL entries against comics already in the database.
+
+    Never guesses: an entry with more than one candidate is reported as
+    "ambiguous" and skipped rather than picking one arbitrarily. The rest of
+    the list still comes back usable.
+    """
+    rows = (
+        db.query(
+            Comic.id,
+            Comic.number,
+            Comic.year,
+            Volume.volume_number,
+            Series.name.label("series_name"),
+        )
+        .select_from(Comic)
+        .join(Comic.volume)
+        .join(Volume.series)
+        .all()
+    )
+
+    strict_index: dict[tuple[str, str, str, str], set[int]] = {}
+    year_index: dict[tuple[str, str, str], set[int]] = {}
+    relaxed_index: dict[tuple[str, str], set[int]] = {}
+
+    for row in rows:
+        norm_series = normalize_title(row.series_name or "")
+        norm_number = normalize_issue_number(row.number or "") or ""
+        relaxed_key = (norm_series, norm_number)
+        relaxed_index.setdefault(relaxed_key, set()).add(row.id)
+
+        if row.year is not None:
+            year_key = (norm_series, norm_number, str(row.year))
+            year_index.setdefault(year_key, set()).add(row.id)
+
+            if row.volume_number is not None:
+                strict_key = (norm_series, norm_number, str(row.volume_number), str(row.year))
+                strict_index.setdefault(strict_key, set()).add(row.id)
+
+    result = CBLMatchResult()
+    used_comic_ids: set[int] = set()
+
+    for entry in entries:
+        norm_series, norm_number = _entry_key_parts(entry)
+        matched_comic_id = None
+        matched_by = None
+
+        if entry.volume and entry.year:
+            strict_key = (norm_series, norm_number, str(entry.volume).strip(), str(entry.year).strip())
+            strict_candidates = strict_index.get(strict_key, set())
+
+            if len(strict_candidates) == 1:
+                matched_comic_id = next(iter(strict_candidates))
+                matched_by = "metadata"
+            elif len(strict_candidates) > 1:
+                result.unmatched.append(CBLUnmatchedEntry(entry=entry, reason="ambiguous"))
+                continue
+
+        if matched_comic_id is None and entry.year:
+            year_key = (norm_series, norm_number, str(entry.year).strip())
+            year_candidates = year_index.get(year_key, set())
+
+            if len(year_candidates) == 1:
+                matched_comic_id = next(iter(year_candidates))
+                matched_by = "metadata_year"
+            elif len(year_candidates) > 1:
+                result.unmatched.append(CBLUnmatchedEntry(entry=entry, reason="ambiguous"))
+                continue
+
+        if matched_comic_id is None:
+            relaxed_key = (norm_series, norm_number)
+            relaxed_candidates = relaxed_index.get(relaxed_key, set())
+
+            if len(relaxed_candidates) == 1:
+                matched_comic_id = next(iter(relaxed_candidates))
+                matched_by = "relaxed_metadata"
+            elif len(relaxed_candidates) > 1:
+                result.unmatched.append(CBLUnmatchedEntry(entry=entry, reason="ambiguous"))
+                continue
+
+        if matched_comic_id is None:
+            result.unmatched.append(CBLUnmatchedEntry(entry=entry, reason="unmatched"))
+            continue
+
+        if matched_comic_id in used_comic_ids:
+            result.unmatched.append(CBLUnmatchedEntry(entry=entry, reason="duplicate_target"))
+            continue
+
+        used_comic_ids.add(matched_comic_id)
+        result.matched.append(CBLMatchedEntry(entry=entry, comic_id=matched_comic_id, matched_by=matched_by))
+
+    return result

--- a/app/services/cbl_parser.py
+++ b/app/services/cbl_parser.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from lxml import etree
+
+
+class CBLParseError(Exception):
+    """Raised when a .cbl file is not well-formed XML."""
+
+
+@dataclass
+class CBLEntry:
+    """One <Book> entry from a CBL file, as raw (unmatched) strings."""
+    series: Optional[str] = None
+    number: Optional[str] = None
+    volume: Optional[str] = None
+    year: Optional[str] = None
+    format: Optional[str] = None
+
+
+@dataclass
+class CBLParseResult:
+    name: str
+    description: Optional[str] = None
+    entries: list[CBLEntry] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def _hardened_xml_parser() -> etree.XMLParser:
+    # CBL files can arrive via upload, URL import, or a third-party catalog --
+    # unlike ComicInfo.xml (which only ever comes from the user's own archives),
+    # so we parse defensively: no external entity resolution.
+    return etree.XMLParser(resolve_entities=False, no_network=True, huge_tree=False)
+
+
+def parse_cbl(xml_content: bytes, filename_stem: str) -> CBLParseResult:
+    """
+    Parse a ComicRack-style .cbl file (XML: <ReadingList><Name/><Books><Book .../></Books></ReadingList>).
+
+    Unsupported/unknown attributes (Id, Database, matchers, etc.) are ignored.
+    Malformed XML raises CBLParseError; anything else recoverable is reported as
+    a warning on the result rather than raised, so one bad file doesn't need to
+    abort an entire import/scan batch.
+    """
+    try:
+        root = etree.fromstring(xml_content, parser=_hardened_xml_parser())
+    except etree.XMLSyntaxError as exc:
+        raise CBLParseError(f"Malformed CBL XML: {exc}") from exc
+
+    warnings: list[str] = []
+
+    name_el = root.find("Name")
+    name = name_el.text.strip() if name_el is not None and name_el.text else ""
+    if not name:
+        name = filename_stem
+
+    summary_el = root.find("Summary")
+    description = summary_el.text.strip() if summary_el is not None and summary_el.text else None
+    description = description or None
+
+    books_el = root.find("Books")
+    book_elements = books_el.findall("Book") if books_el is not None else root.findall("Book")
+
+    entries: list[CBLEntry] = []
+    for book_el in book_elements:
+        series = book_el.get("Series")
+        number = book_el.get("Number")
+        volume = book_el.get("Volume")
+        year = book_el.get("Year")
+        fmt = book_el.get("Format")
+
+        if not series and not number:
+            warnings.append("Skipped a <Book> entry with no Series or Number attribute")
+            continue
+
+        entries.append(CBLEntry(series=series, number=number, volume=volume, year=year, format=fmt))
+
+    if not entries:
+        warnings.append("CBL file contains no usable <Book> entries")
+
+    return CBLParseResult(name=name, description=description, entries=entries, warnings=warnings)

--- a/app/services/cbl_source_service.py
+++ b/app/services/cbl_source_service.py
@@ -1,0 +1,325 @@
+import asyncio
+import hashlib
+import ipaddress
+import json
+import logging
+import socket
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.cbl_source import CBLSource
+from app.models.reading_list import ReadingList
+from app.services.cbl_matching import match_cbl_entries
+from app.services.cbl_parser import CBLParseError, parse_cbl
+from app.services.reading_list import ReadingListService
+
+logger = logging.getLogger(__name__)
+
+MAX_CBL_SIZE_BYTES = 5 * 1024 * 1024  # 5MB -- CBL files are plain XML text lists
+ALLOWED_EXTENSIONS = (".cbl", ".xml")
+URL_FETCH_TIMEOUT = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=5.0)
+
+
+def _pin_url_to_address(url: str, address: str) -> str:
+    """
+    Rewrite `url`'s host to `address` (a pre-resolved, already-validated IP),
+    preserving scheme/port/path/query. Used together with the `sni_hostname`
+    request extension so the actual TCP connection targets a known-safe
+    address instead of letting the HTTP client re-resolve the hostname
+    independently (which would reopen a DNS-rebinding window between the
+    safety check and the real connection).
+    """
+    parsed = urlparse(url)
+    ip = ipaddress.ip_address(address)
+    host = f"[{address}]" if ip.version == 6 else address
+    netloc = f"{host}:{parsed.port}" if parsed.port else host
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+class CBLSourceError(Exception):
+    """Raised for invalid/unsafe CBL content or import requests (maps to a 4xx at the API layer)."""
+
+
+def _looks_like_cbl_xml(content: bytes) -> bool:
+    head = content[:512].lstrip()
+    return head.startswith(b"<?xml") or b"<ReadingList" in content[:2048]
+
+
+def _fingerprint(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+class CBLSourceService:
+    """Manages Parker's own copy of imported .cbl files (storage/cbl), independent
+    of whatever comic library roots exist -- see docs/cbl-reading-list-support-scope.md."""
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.logger = logging.getLogger(__name__)
+
+    def _validate_content(self, content: bytes, filename: str) -> None:
+        if not content:
+            raise CBLSourceError("File is empty")
+        if len(content) > MAX_CBL_SIZE_BYTES:
+            raise CBLSourceError(f"File too large. Maximum size is {MAX_CBL_SIZE_BYTES // (1024 * 1024)}MB.")
+        if not filename.lower().endswith(ALLOWED_EXTENSIONS):
+            raise CBLSourceError("File must have a .cbl or .xml extension")
+        if not _looks_like_cbl_xml(content):
+            raise CBLSourceError("File does not look like a CBL/XML reading list")
+
+    def _write_stored_file(self, content: bytes, fingerprint: str) -> Path:
+        settings.cbl_dir.mkdir(parents=True, exist_ok=True)
+        stored_path = settings.cbl_dir / f"{fingerprint}.cbl"
+        if not stored_path.exists():
+            stored_path.write_bytes(content)
+        return stored_path
+
+    def import_upload(
+        self,
+        content: bytes,
+        original_filename: str,
+        origin: str = "upload",
+        catalog_provider: str | None = None,
+        catalog_path: str | None = None,
+    ) -> CBLSource:
+        self._validate_content(content, original_filename)
+        fingerprint = _fingerprint(content)
+
+        existing = self.db.query(CBLSource).filter(CBLSource.fingerprint == fingerprint).first()
+        if existing:
+            raise CBLSourceError(f"This exact CBL file is already imported (source id {existing.id})")
+
+        stored_path = self._write_stored_file(content, fingerprint)
+
+        source = CBLSource(
+            display_name=Path(original_filename).stem,
+            stored_path=str(stored_path),
+            original_filename=original_filename,
+            origin=origin,
+            catalog_provider=catalog_provider,
+            catalog_path=catalog_path,
+            fingerprint=fingerprint,
+            last_refresh_status="never",
+        )
+        self.db.add(source)
+        self.db.flush()
+        return source
+
+    def _resolve_safe_addresses(self, host: str) -> list[str]:
+        """
+        Resolve `host` and validate every returned address is public. Returns
+        the resolved addresses (so the caller can pin the actual connection to
+        one of them) rather than just a pass/fail signal -- see _safe_fetch.
+        """
+        try:
+            infos = socket.getaddrinfo(host, None)
+        except socket.gaierror as exc:
+            raise CBLSourceError(f"Could not resolve host: {host}") from exc
+
+        addresses = []
+        for info in infos:
+            ip_str = info[4][0]
+            ip = ipaddress.ip_address(ip_str)
+            if (
+                ip.is_private
+                or ip.is_loopback
+                or ip.is_link_local
+                or ip.is_reserved
+                or ip.is_multicast
+                or ip.is_unspecified
+            ):
+                raise CBLSourceError(f"Refusing to fetch from a non-public address ({ip_str})")
+            addresses.append(ip_str)
+
+        if not addresses:
+            raise CBLSourceError(f"Could not resolve host: {host}")
+
+        return addresses
+
+    async def _safe_fetch(self, url: str) -> bytes:
+        """
+        Fetch `url`, pinning the actual connection to a pre-validated address
+        instead of letting httpx resolve the hostname a second time (which
+        would reopen the DNS-rebinding window between the safety check and
+        the real connection -- see _resolve_safe_addresses/_pin_url_to_address).
+        TLS SNI and certificate validation still target the real hostname via
+        the `sni_hostname` extension, so this doesn't affect cert validation.
+        """
+        parsed = urlparse(url)
+        if parsed.scheme != "https":
+            raise CBLSourceError("Only https:// URLs are supported")
+        if not parsed.hostname:
+            raise CBLSourceError("URL is missing a hostname")
+
+        hostname = parsed.hostname
+        addresses = await asyncio.to_thread(self._resolve_safe_addresses, hostname)
+        pinned_url = _pin_url_to_address(url, addresses[0])
+
+        content = bytearray()
+        try:
+            async with httpx.AsyncClient(timeout=URL_FETCH_TIMEOUT, follow_redirects=False) as client:
+                async with client.stream(
+                    "GET", pinned_url,
+                    headers={"Host": hostname},
+                    extensions={"sni_hostname": hostname},
+                ) as response:
+                    response.raise_for_status()
+                    async for chunk in response.aiter_bytes():
+                        content.extend(chunk)
+                        if len(content) > MAX_CBL_SIZE_BYTES:
+                            raise CBLSourceError(
+                                f"Remote file exceeds maximum size of {MAX_CBL_SIZE_BYTES // (1024 * 1024)}MB"
+                            )
+        except httpx.HTTPError as exc:
+            raise CBLSourceError(f"Failed to download CBL from URL: {exc}") from exc
+
+        return bytes(content)
+
+    async def import_url(self, url: str) -> CBLSource:
+        content_bytes = await self._safe_fetch(url)
+
+        parsed = urlparse(url)
+        filename = Path(parsed.path).name or "import.cbl"
+        self._validate_content(content_bytes, filename if "." in filename else f"{filename}.cbl")
+
+        fingerprint = _fingerprint(content_bytes)
+        existing = self.db.query(CBLSource).filter(CBLSource.fingerprint == fingerprint).first()
+        if existing:
+            raise CBLSourceError(f"This exact CBL file is already imported (source id {existing.id})")
+
+        stored_path = self._write_stored_file(content_bytes, fingerprint)
+
+        source = CBLSource(
+            display_name=Path(filename).stem,
+            stored_path=str(stored_path),
+            original_filename=filename,
+            origin="url",
+            source_url=url,
+            fingerprint=fingerprint,
+            last_refresh_status="never",
+        )
+        self.db.add(source)
+        self.db.flush()
+        return source
+
+    def apply_refreshed_content(self, source: CBLSource, content_bytes: bytes) -> None:
+        """
+        Update `source`'s stored file/fingerprint/status after a successful
+        refresh fetch. Shared by both the direct-URL refresh path (below) and
+        CBLCatalogService's catalog-path refresh, so "what do we do with newly
+        fetched bytes" stays in one place regardless of how they were fetched.
+
+        Parses the new content BEFORE touching stored_path/fingerprint/status --
+        "looks like CBL/XML" (a cheap prefix sniff, in _validate_content) is not
+        the same as "actually parses". A refresh that replaces the last good
+        file and reports last_refresh_status="ok" for content that then fails
+        to parse would be worse than just failing the refresh outright.
+        Only touches the file on disk if the content actually changed.
+        """
+        self._validate_content(content_bytes, source.original_filename or "refresh.cbl")
+
+        filename_stem = Path(source.original_filename or "refresh").stem
+        try:
+            parse_cbl(content_bytes, filename_stem=filename_stem)
+        except CBLParseError as exc:
+            raise CBLSourceError(f"Refreshed content failed to parse: {exc}") from exc
+
+        new_fingerprint = _fingerprint(content_bytes)
+        if new_fingerprint != source.fingerprint:
+            old_path = Path(source.stored_path)
+            new_path = self._write_stored_file(content_bytes, new_fingerprint)
+            source.stored_path = str(new_path)
+            source.fingerprint = new_fingerprint
+            if old_path.exists() and old_path != new_path:
+                try:
+                    old_path.unlink()
+                except OSError:
+                    pass
+
+        source.last_refresh_status = "ok"
+        source.last_refreshed_at = datetime.now(timezone.utc)
+
+    def mark_refresh_failed(self, source: CBLSource, exc: Exception) -> None:
+        # Remote unavailability must not delete the last successfully imported
+        # CBL-derived list -- only record that the refresh failed.
+        self.logger.warning("CBL refresh failed for source %s: %s", source.id, exc)
+        source.last_refresh_status = "failed"
+        source.last_refreshed_at = datetime.now(timezone.utc)
+
+    async def refresh(self, source_id: int) -> CBLSource:
+        source = self.db.get(CBLSource, source_id)
+        if not source:
+            raise ValueError(f"CBL source {source_id} not found")
+
+        if not source.source_url:
+            raise CBLSourceError("This CBL source has no URL to refresh from")
+
+        try:
+            content_bytes = await self._safe_fetch(source.source_url)
+            self.apply_refreshed_content(source, content_bytes)
+        except (CBLSourceError, httpx.HTTPError) as exc:
+            self.mark_refresh_failed(source, exc)
+
+        self.db.flush()
+        return source
+
+    def rebuild(self, source_id: int) -> CBLSource:
+        """
+        Parse the stored file, match its entries against the current DB, and
+        sync the CBL-owned ReadingList. Safe to call repeatedly (e.g. after
+        every library scan) -- matching only ever touches the ReadingList tied
+        to this source (see ReadingListService.sync_cbl_list).
+        """
+        source = self.db.get(CBLSource, source_id)
+        if not source:
+            raise ValueError(f"CBL source {source_id} not found")
+
+        content = Path(source.stored_path).read_bytes()
+        filename_stem = Path(source.original_filename or source.stored_path).stem
+
+        try:
+            parsed = parse_cbl(content, filename_stem=filename_stem)
+        except CBLParseError as exc:
+            self.logger.warning("CBL parse failed for source %s: %s", source_id, exc)
+            source.last_match_summary = json.dumps({"error": str(exc)})
+            self.db.flush()
+            return source
+
+        match_result = match_cbl_entries(self.db, parsed.entries)
+
+        reading_list_service = ReadingListService(self.db)
+        reading_list_service.sync_cbl_list(
+            source,
+            parsed.name,
+            parsed.description,
+            match_result.ordered_comic_ids,
+        )
+
+        source.entry_count = len(parsed.entries)
+        source.last_match_summary = match_result.summary_json()
+        self.db.flush()
+        return source
+
+    def delete(self, source_id: int) -> None:
+        source = self.db.get(CBLSource, source_id)
+        if not source:
+            raise ValueError(f"CBL source {source_id} not found")
+
+        reading_list = self.db.query(ReadingList).filter(ReadingList.source_cbl_id == source.id).first()
+        if reading_list:
+            self.db.delete(reading_list)
+
+        stored_path = Path(source.stored_path)
+        if stored_path.exists():
+            try:
+                stored_path.unlink()
+            except OSError as exc:
+                self.logger.warning("Failed to delete stored CBL file %s: %s", stored_path, exc)
+
+        self.db.delete(source)
+        self.db.commit()

--- a/app/services/enrichment.py
+++ b/app/services/enrichment.py
@@ -1,7 +1,8 @@
 import json
-import re
 from pathlib import Path
 from typing import Optional
+
+from app.core.text_utils import normalize_title
 
 
 class EnrichmentService:
@@ -20,18 +21,7 @@ class EnrichmentService:
             print(f"Failed to load event descriptions: {e}")
 
     def _normalize(self, text: str) -> str:
-        """
-        Normalize text for matching:
-        'The Infinity Gauntlet' -> 'infinity gauntlet'
-        """
-        if not text: return ""
-        text = text.lower()
-        # Remove 'the ' from start
-        if text.startswith("the "):
-            text = text[4:]
-        # Remove special chars
-        text = re.sub(r'[^a-z0-9\s]', '', text)
-        return text.strip()
+        return normalize_title(text)
 
     def get_description(self, event_name: str) -> Optional[str]:
         """

--- a/app/services/maintenance.py
+++ b/app/services/maintenance.py
@@ -103,8 +103,13 @@ class MaintenanceService:
             self.db.commit()  # Yield Lock
 
             # 7. Clean Empty Containers
+            # Scoped to "comicinfo" only -- never "manual" (a user may deliberately
+            # keep an empty one) and never "cbl" (CBL list lifecycle is owned by
+            # CBLSourceService.rebuild()/delete(); this cleanup job never rebuilds
+            # CBL sources afterward, so deleting an empty CBL list here would just
+            # orphan its CBLSource until the next full scan).
             stats["empty_lists"] = self.db.query(ReadingList).filter(~ReadingList.items.any()).filter(
-                ReadingList.auto_generated == True).delete(synchronize_session=False)
+                ReadingList.source == "comicinfo").delete(synchronize_session=False)
             self.db.commit()  # Yield Lock
 
             stats["empty_collections"] = self.db.query(Collection).filter(~Collection.items.any()).filter(
@@ -214,8 +219,13 @@ class MaintenanceService:
         return deleted_count
 
     def refresh_reading_list_descriptions(self) -> dict:
-        """Populate missing descriptions for auto-generated lists."""
-        lists = self.db.query(ReadingList).filter(ReadingList.auto_generated == True).all()
+        """Populate missing descriptions for ComicInfo-derived lists.
+
+        Scoped to source == "comicinfo" only -- a CBL-derived list's description
+        comes from the .cbl file itself and must not be clobbered by a Wikipedia
+        lookup here.
+        """
+        lists = self.db.query(ReadingList).filter(ReadingList.source == "comicinfo").all()
         updated_count = 0
 
         for r_list in lists:

--- a/app/services/reading_list.py
+++ b/app/services/reading_list.py
@@ -1,44 +1,69 @@
 import logging
 from sqlalchemy.orm import Session, joinedload
-from typing import Optional, Dict
+from typing import Optional, Dict, Tuple
 from app.models import ReadingList, ReadingListItem, Comic, Volume, Series
+from app.models.cbl_source import CBLSource
 from app.services.enrichment import EnrichmentService
 
 class ReadingListService:
     def __init__(self, db: Session):
         self.db = db
-        self.list_cache: Dict[str, ReadingList] = {}
+        self.list_cache: Dict[Tuple[str, str], Optional[ReadingList]] = {}
         self.logger = logging.getLogger(__name__)
         self.enrichment = EnrichmentService()
 
-    def get_or_create_reading_list(self, name: str) -> ReadingList:
+    def get_or_create_reading_list(self, name: str, source: str = "comicinfo") -> Optional[ReadingList]:
+        """
+        Get-or-create a reading list scoped by (name, source) -- never by name
+        alone. ComicInfo-derived list names are exactly the tagger's
+        AlternateSeries value and are never renamed or disambiguated, so if a
+        differently-sourced list (manual or cbl) already owns that exact name,
+        there's no safe name left to create under. Returns None in that case;
+        callers must skip rather than silently writing into someone else's list.
+        """
         name = name.strip()
+        cache_key = (name, source)
 
-        if name in self.list_cache:
-            return self.list_cache[name]
+        if cache_key in self.list_cache:
+            return self.list_cache[cache_key]
 
-        reading_list = self.db.query(ReadingList).filter(ReadingList.name == name).first()
+        reading_list = self.db.query(ReadingList).filter(
+            ReadingList.name == name, ReadingList.source == source
+        ).first()
 
         if not reading_list:
-            reading_list = ReadingList(name=name, auto_generated=1)
+            conflict = self.db.query(ReadingList).filter(
+                ReadingList.name == name, ReadingList.source != source
+            ).first()
+            if conflict:
+                self.logger.warning(
+                    "Skipping %s reading list '%s': name is already used by a %s list",
+                    source, name, conflict.source,
+                )
+                self.list_cache[cache_key] = None
+                return None
 
-            # Attempt to enrich description
-            # Since this is async, we ideally await it.
-            # If this method is sync, we might need to run it synchronously or background it.
-            # For simplicity, let's assume we can run it:
-            description = self.enrichment.get_description(name)
-            if description:
-                reading_list.description = description
+            reading_list = ReadingList(name=name, source=source)
+
+            # Wikipedia/local-seed enrichment only makes sense for ComicInfo-derived
+            # lists -- a CBL file supplies its own description, and a manual list is
+            # the user's own to write.
+            if source == "comicinfo":
+                description = self.enrichment.get_description(name)
+                if description:
+                    reading_list.description = description
 
             self.db.add(reading_list)
             self.db.flush()
             self.logger.debug(f"Created reading list: {name}")
 
-        self.list_cache[name] = reading_list
+        self.list_cache[cache_key] = reading_list
         return reading_list
 
     def add_comic_to_list(self, comic: Comic, list_name: str, position: float):
         reading_list = self.get_or_create_reading_list(list_name)
+        if reading_list is None:
+            return
 
         existing = self.db.query(ReadingListItem).filter(
             ReadingListItem.reading_list_id == reading_list.id,
@@ -75,11 +100,19 @@ class ReadingListService:
             ReadingListItem.comic_id.in_(comic_ids_query)
         ).delete(synchronize_session=False)
 
-    def _get_list_items_for_comic(self, comic_id: int) -> list[ReadingListItem]:
+    def _get_comicinfo_items_for_comic(self, comic_id: int) -> list[ReadingListItem]:
+        """
+        Items belonging to this comic's ComicInfo-derived ("source=comicinfo") list
+        memberships only. Scoped this way so this method never touches "manual" or
+        "cbl" memberships for the same comic -- a comic can belong to several
+        reading lists at once (one per source), and each source only ever owns
+        the items it created.
+        """
         return (
             self.db.query(ReadingListItem)
+            .join(ReadingList)
             .options(joinedload(ReadingListItem.reading_list))
-            .filter(ReadingListItem.comic_id == comic_id)
+            .filter(ReadingListItem.comic_id == comic_id, ReadingList.source == "comicinfo")
             .all()
         )
 
@@ -96,7 +129,7 @@ class ReadingListService:
         else:
             target_name = None
 
-        current_items = self._get_list_items_for_comic(comic.id)
+        current_items = self._get_comicinfo_items_for_comic(comic.id)
 
         if not current_items:
             if target_name and target_position is not None:
@@ -123,9 +156,76 @@ class ReadingListService:
     def cleanup_empty_lists(self):
         # This usually runs at the end of the scan, safe to run logic here
         # but let the scanner commit it.
-        empty_lists = self.db.query(ReadingList).filter(~ReadingList.items.any()).all()
+        # Scoped to "comicinfo" only -- never "manual" (a user may deliberately
+        # keep an empty one) and never "cbl" (an empty CBL list is a valid state,
+        # e.g. freshly imported with no local matches yet; CBL list lifecycle is
+        # owned entirely by CBLSourceService.rebuild()/delete(), not this generic
+        # cleanup, since nothing here would rebuild it afterward -- callers like
+        # metadata rehydrate invoke this without ever touching CBL sources).
+        empty_lists = self.db.query(ReadingList).filter(
+            ~ReadingList.items.any(), ReadingList.source == "comicinfo"
+        ).all()
         for rl in empty_lists:
             self.db.delete(rl)
             # Invalidate cache if we delete
-            if rl.name in self.list_cache:
-                del self.list_cache[rl.name]
+            cache_key = (rl.name, rl.source)
+            if cache_key in self.list_cache:
+                del self.list_cache[cache_key]
+
+    def _unique_cbl_list_name(self, name: str, cbl_source_id: int) -> str:
+        """
+        Avoid colliding with an existing manual/comicinfo list name. Only checked
+        at creation time -- once a CBL-derived list exists for a given source, its
+        name is left alone on subsequent resyncs. Callers only invoke this before
+        a ReadingList row for `cbl_source_id` exists yet, so any same-named row
+        found here belongs to a different source (manual, comicinfo, or another
+        CBL source) and counts as a collision.
+        """
+        candidate = name
+        suffix = 2
+        while self.db.query(ReadingList).filter(ReadingList.name == candidate).first():
+            candidate = f"{name} (CBL)" if suffix == 2 else f"{name} (CBL {suffix})"
+            suffix += 1
+        return candidate
+
+    def sync_cbl_list(
+        self,
+        cbl_source: CBLSource,
+        name: str,
+        description: Optional[str],
+        ordered_comic_ids: list[int],
+    ) -> ReadingList:
+        """
+        Create or update the single ReadingList owned by this CBL source, replacing
+        its items with `ordered_comic_ids` (1-indexed position order). Scoped
+        entirely by `source_cbl_id`, so this never touches "manual" or "comicinfo"
+        memberships for the same comics.
+        """
+        name = name.strip()
+
+        reading_list = self.db.query(ReadingList).filter(
+            ReadingList.source_cbl_id == cbl_source.id
+        ).first()
+
+        if not reading_list:
+            unique_name = self._unique_cbl_list_name(name, cbl_source.id)
+            reading_list = ReadingList(name=unique_name, source="cbl", source_cbl_id=cbl_source.id)
+            self.db.add(reading_list)
+            self.db.flush()
+
+        if description:
+            reading_list.description = description
+
+        self.db.query(ReadingListItem).filter(
+            ReadingListItem.reading_list_id == reading_list.id
+        ).delete(synchronize_session=False)
+
+        for position, comic_id in enumerate(ordered_comic_ids, start=1):
+            self.db.add(ReadingListItem(
+                reading_list_id=reading_list.id,
+                comic_id=comic_id,
+                position=float(position),
+            ))
+
+        self.db.flush()
+        return reading_list

--- a/app/services/scanner.py
+++ b/app/services/scanner.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Optional
+import hashlib
 import os
 import time
 import logging
@@ -17,12 +18,14 @@ from app.models.library_root import LibraryRoot
 from app.models.comic import Comic
 from app.models.comic import Volume
 from app.models.series import Series
+from app.models.cbl_source import CBLSource
 
 from app.services.workers.metadata_worker import metadata_worker
 from app.services.workers.metadata_writer import metadata_writer
 from app.services.sidecar_service import SidecarService
 from app.services.reading_list import ReadingListService
 from app.services.collection import CollectionService
+from app.services.cbl_source_service import CBLSourceService, CBLSourceError
 
 
 class LibraryScanner:
@@ -40,6 +43,7 @@ class LibraryScanner:
 
         self.reading_list_service = ReadingListService(db)
         self.collection_service = CollectionService(db)
+        self.cbl_source_service = CBLSourceService(db)
 
     def scan_parallel(self, force: bool = False, worker_limit: int = 0) -> dict:
         """
@@ -86,9 +90,14 @@ class LibraryScanner:
         tasks = []
         scanned_keys = set()
         skipped = 0
+        discovered_cbl_files: list[tuple] = []
 
         for library_root, library_path in root_paths:
             for file_path in library_path.rglob("*"):
+                if file_path.suffix.lower() == ".cbl":
+                    discovered_cbl_files.append((library_root, file_path))
+                    continue
+
                 if file_path.suffix.lower() not in self.supported_extensions:
                     continue
 
@@ -127,6 +136,29 @@ class LibraryScanner:
                         "library_root_id": library_root.id,
                         "library_root_path": library_root.path,
                     })
+
+        # --- Optional CBL discovery: import any .cbl files found under active
+        # roots into Parker-managed storage. This is an import source, not
+        # canonical storage -- the managed copy becomes the thing Parker
+        # re-parses/re-matches from here on, so already-known fingerprints are
+        # skipped silently rather than re-imported every scan.
+        for library_root, cbl_path in discovered_cbl_files:
+            try:
+                content = cbl_path.read_bytes()
+            except OSError as exc:
+                self.logger.warning("Could not read discovered CBL file %s: %s", cbl_path, exc)
+                continue
+
+            fingerprint = hashlib.sha256(content).hexdigest()
+            if self.db.query(CBLSource).filter(CBLSource.fingerprint == fingerprint).first():
+                continue
+
+            relative_path = compute_relative_path(library_root.path, str(cbl_path)) or cbl_path.name
+            try:
+                self.cbl_source_service.import_upload(content, relative_path, origin="library_import")
+                self.logger.info(f"Discovered and imported CBL file: {relative_path}")
+            except CBLSourceError as exc:
+                self.logger.warning("Skipping invalid discovered CBL file %s: %s", cbl_path, exc)
 
         # Persist any sidecar reconciliation updates found during discovery.
         self.db.commit()
@@ -229,6 +261,16 @@ class LibraryScanner:
         # Cleanup empty containers
         self.reading_list_service.cleanup_empty_lists()
         self.collection_service.cleanup_empty_collections()
+
+        # Rebuild/rematch every managed CBL source -- not just ones tied to this
+        # library, since CBL events can span comics from multiple libraries and
+        # this scan's newly-imported comics may resolve previously-unmatched
+        # entries from any of them. One bad source shouldn't sink the scan.
+        for cbl_source in self.db.query(CBLSource).all():
+            try:
+                self.cbl_source_service.rebuild(cbl_source.id)
+            except Exception as exc:
+                self.logger.error(f"Failed to rebuild CBL source {cbl_source.id}: {exc}")
 
         # Update library scan time
         scanned_at = datetime.now(timezone.utc)

--- a/app/services/workers/metadata_writer.py
+++ b/app/services/workers/metadata_writer.py
@@ -48,24 +48,11 @@ def _apply_metadata_batch(
 
     from pathlib import Path
     from app.models.comic import Comic
+    from app.core.comic_helpers import normalize_issue_number
     from app.core.path_utils import compute_relative_path
     from datetime import datetime, timezone
     from inspect import Parameter, signature
     import json
-
-    def _normalize_number(number: str) -> str:
-        """Normalize weird comic numbers"""
-        if not number:
-            return number
-
-        # Handle "½" -> "0.5"
-        if number == "½" or number == "1/2":
-            return "0.5"
-
-        # Handle "-1" (ensure it stays -1, though our casting handles it)
-        # Handle variants if needed in future
-
-        return number
 
     def _normalize_volume_number(raw_volume) -> int:
         """Normalize volume metadata, falling back to volume 1 on invalid input."""
@@ -184,7 +171,7 @@ def _apply_metadata_batch(
 
         # Normalize number
         raw_number = metadata.get("number")
-        comic.number = _normalize_number(raw_number)
+        comic.number = normalize_issue_number(raw_number)
 
         comic.filename = Path(file_path).name
         comic.title = metadata.get("title")

--- a/app/templates/admin/cbl_sources.html
+++ b/app/templates/admin/cbl_sources.html
@@ -129,6 +129,23 @@
         <div x-show="catalog.preview" class="mb-4 rounded border border-blue-500/30 bg-blue-950/30 px-4 py-3 text-sm text-blue-100">
             <p class="font-semibold text-blue-200" x-text="catalog.preview?.name"></p>
             <p class="text-blue-100/80 mt-1" x-text="`${catalog.preview?.entry_count ?? 0} entries · ${catalog.preview?.path ?? ''}`"></p>
+
+            <template x-if="catalog.preview?.sample_entries?.length">
+                <div class="mt-2">
+                    <p class="text-xs uppercase tracking-wide text-blue-300/70 mb-1">
+                        First <span x-text="catalog.preview.sample_entries.length"></span> entries (CBL order, not yet matched to your library)
+                    </p>
+                    <ol class="text-xs text-blue-100/90 list-decimal list-inside space-y-0.5">
+                        <template x-for="(sample, index) in catalog.preview.sample_entries" :key="index">
+                            <li x-text="sample"></li>
+                        </template>
+                    </ol>
+                    <p x-show="catalog.preview?.sample_truncated" class="text-xs text-blue-100/60 mt-1">
+                        + <span x-text="catalog.preview.entry_count - catalog.preview.sample_entries.length"></span> more
+                    </p>
+                </div>
+            </template>
+
             <template x-if="catalog.preview?.warnings?.length">
                 <ul class="mt-2 text-xs text-amber-200 list-disc list-inside">
                     <template x-for="warning in catalog.preview.warnings" :key="warning">

--- a/app/templates/admin/cbl_sources.html
+++ b/app/templates/admin/cbl_sources.html
@@ -1,0 +1,566 @@
+{% extends "base.html" %}
+
+{% block title %}CBL Reading Lists - Parker{% endblock %}
+
+{% block content %}
+<div class="max-w-6xl mx-auto" x-data="cblSourcesManager()">
+
+    {% from "partials/admin_header.html" import admin_header %}
+    {{ admin_header(
+        title="CBL Reading Lists",
+        description="Manage CBL-derived reading lists and browse the DieselTech catalog.",
+        action_label="+ Upload CBL",
+        action_func="openUploadModal()"
+    ) }}
+
+    <div class="border-b border-gray-700 mb-6 flex gap-6">
+        <button
+            x-on:click="activeTab = 'sources'"
+            class="pb-3 px-1 border-b-2 font-medium transition-colors"
+            :class="activeTab === 'sources' ? 'border-blue-500 text-white' : 'border-transparent text-gray-400 hover:text-white'"
+        >
+            Managed Sources
+        </button>
+        <button
+            x-on:click="activeTab = 'catalog'; if (!catalog.loaded) browseCatalog('')"
+            class="pb-3 px-1 border-b-2 font-medium transition-colors"
+            :class="activeTab === 'catalog' ? 'border-blue-500 text-white' : 'border-transparent text-gray-400 hover:text-white'"
+        >
+            Browse Catalog
+        </button>
+    </div>
+
+    <div x-show="activeTab === 'sources'">
+        <div class="flex justify-end mb-4">
+            <button x-on:click="openUrlModal()" class="text-sm text-blue-400 hover:text-white font-medium">+ Import from URL</button>
+        </div>
+
+        <div class="bg-gray-800 rounded-lg overflow-hidden shadow-lg border border-gray-700">
+            <table class="w-full text-left">
+                <thead class="bg-gray-900 text-gray-400 uppercase text-xs">
+                    <tr>
+                        <th class="px-6 py-3">Name</th>
+                        <th class="px-6 py-3">Origin</th>
+                        <th class="px-6 py-3">Entries</th>
+                        <th class="px-6 py-3">Match Summary</th>
+                        <th class="px-6 py-3">Last Refresh</th>
+                        <th class="px-6 py-3 text-right">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-700">
+                    <template x-for="source in sources" :key="source.id">
+                        <tr class="hover:bg-gray-750">
+                            <td class="px-6 py-4">
+                                <div class="font-bold text-white" x-text="source.reading_list_name || source.display_name"></div>
+                                <div
+                                    x-show="source.reading_list_name && source.reading_list_name !== source.display_name"
+                                    class="text-xs text-gray-500"
+                                    x-text="source.display_name"
+                                ></div>
+                            </td>
+                            <td class="px-6 py-4 text-sm">
+                                <span class="text-xs px-2 py-1 rounded uppercase font-bold" :class="originBadgeClass(source.origin)" x-text="source.origin"></span>
+                            </td>
+                            <td class="px-6 py-4 text-sm text-gray-400" x-text="source.entry_count ?? '-'"></td>
+                            <td class="px-6 py-4 text-xs text-gray-400" x-text="matchSummaryText(source)"></td>
+                            <td class="px-6 py-4 text-sm text-gray-400" x-text="formatDate(source.last_refreshed_at)"></td>
+                            <td class="px-6 py-4 text-right flex justify-end items-center gap-2">
+                                <button
+                                    x-show="source.reading_list_id"
+                                    x-on:click="openRenameModal(source)"
+                                    class="text-purple-300 hover:text-white text-sm font-medium px-2"
+                                >
+                                    Rename
+                                </button>
+                                <button
+                                    x-show="source.source_url || source.origin === 'catalog'"
+                                    x-on:click="refreshSource(source)"
+                                    class="text-blue-400 hover:text-white text-sm font-medium px-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                                    :disabled="busySourceId === source.id"
+                                >
+                                    Refresh
+                                </button>
+                                <button
+                                    x-on:click="deleteSource(source)"
+                                    class="text-red-400 hover:text-white text-sm font-medium px-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                                    :disabled="busySourceId === source.id"
+                                >
+                                    Delete
+                                </button>
+                            </td>
+                        </tr>
+                    </template>
+                    <tr x-show="sources.length === 0">
+                        <td colspan="6" class="px-6 py-8 text-center text-gray-500">
+                            No CBL sources yet. Upload one to get started.
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div x-show="activeTab === 'catalog'">
+        <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+            <div class="flex-1 min-w-0">
+                <p class="text-xs uppercase tracking-wide text-gray-500 mb-1">DieselTech/CBL-ReadingLists</p>
+                <p class="font-mono text-sm text-gray-300 truncate" x-text="'/' + catalog.path"></p>
+            </div>
+            <div class="flex items-center gap-2">
+                <input
+                    type="text"
+                    x-model="catalog.filterQuery"
+                    placeholder="Filter this folder..."
+                    class="bg-gray-900 border border-gray-700 rounded px-3 py-1.5 text-sm text-white focus:border-blue-500 outline-none"
+                >
+                <button
+                    x-on:click="browseCatalog(catalog.path, true)"
+                    class="bg-gray-700 hover:bg-gray-600 text-white text-sm px-3 py-1.5 rounded transition-colors disabled:opacity-50"
+                    :disabled="catalog.loading"
+                >
+                    Refresh Listing
+                </button>
+            </div>
+        </div>
+
+        <div x-show="catalog.error" class="mb-4 rounded border border-red-900/60 bg-red-950/30 px-3 py-2 text-sm text-red-200" x-text="catalog.error"></div>
+        <div x-show="catalog.loading" class="text-sm text-gray-400 mb-4">Loading...</div>
+
+        <div x-show="catalog.preview" class="mb-4 rounded border border-blue-500/30 bg-blue-950/30 px-4 py-3 text-sm text-blue-100">
+            <p class="font-semibold text-blue-200" x-text="catalog.preview?.name"></p>
+            <p class="text-blue-100/80 mt-1" x-text="`${catalog.preview?.entry_count ?? 0} entries · ${catalog.preview?.path ?? ''}`"></p>
+            <template x-if="catalog.preview?.warnings?.length">
+                <ul class="mt-2 text-xs text-amber-200 list-disc list-inside">
+                    <template x-for="warning in catalog.preview.warnings" :key="warning">
+                        <li x-text="warning"></li>
+                    </template>
+                </ul>
+            </template>
+        </div>
+
+        <div class="bg-gray-800 rounded-lg overflow-hidden shadow-lg border border-gray-700" x-show="!catalog.loading">
+            <div class="divide-y divide-gray-700">
+                <div
+                    x-show="catalog.path"
+                    x-on:click="browseCatalog(catalogParentPath())"
+                    class="px-6 py-3 text-sm text-gray-400 hover:bg-gray-750 cursor-pointer flex items-center gap-2"
+                >
+                    <span class="text-blue-300">../</span> Up one level
+                </div>
+
+                <template x-for="entry in filteredCatalogEntries()" :key="entry.path">
+                    <div class="px-6 py-3 flex items-center justify-between gap-4 hover:bg-gray-750">
+                        <div
+                            class="flex items-center gap-2 min-w-0 flex-1"
+                            :class="entry.type === 'dir' ? 'cursor-pointer' : ''"
+                            x-on:click="entry.type === 'dir' && browseCatalog(entry.path)"
+                        >
+                            <span x-text="entry.type === 'dir' ? '📁' : '📄'"></span>
+                            <span class="text-sm text-gray-200 truncate" x-text="entry.name"></span>
+                        </div>
+                        <div x-show="entry.type === 'file'" class="flex items-center gap-3 shrink-0">
+                            <button
+                                x-on:click="previewCatalogFile(entry)"
+                                class="text-blue-400 hover:text-white text-sm font-medium disabled:opacity-50"
+                                :disabled="catalog.previewLoading"
+                            >
+                                Preview
+                            </button>
+                            <button
+                                x-on:click="importCatalogFile(entry)"
+                                class="bg-blue-600 hover:bg-blue-500 text-white text-xs px-3 py-1.5 rounded transition-colors disabled:opacity-50"
+                                :disabled="catalog.importingPath === entry.path"
+                            >
+                                <span x-text="catalog.importingPath === entry.path ? 'Importing...' : 'Import'"></span>
+                            </button>
+                        </div>
+                    </div>
+                </template>
+
+                <div x-show="filteredCatalogEntries().length === 0 && !catalog.path" class="px-6 py-8 text-center text-gray-500">
+                    No folders or .cbl files found here.
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="showUploadModal" class="fixed inset-0 bg-black/80 flex items-center justify-center z-50" style="display: none;" x-transition.opacity>
+        <div class="bg-gray-800 p-6 rounded-lg w-full max-w-md border border-gray-700 shadow-2xl" x-on:click.away="showUploadModal = false">
+            <h2 class="text-xl font-bold mb-4">Upload CBL File</h2>
+
+            <input
+                type="file"
+                accept=".cbl,.xml"
+                @change="fileChange($event)"
+                class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-500/20 file:text-blue-400 hover:file:bg-blue-500/30"
+            >
+
+            <div x-show="uploadError" class="mt-3 text-sm text-red-300" x-text="uploadError"></div>
+
+            <div class="flex justify-end gap-2 mt-6">
+                <button x-on:click="showUploadModal = false" class="text-gray-400 hover:text-white px-4 py-2 transition-colors">Cancel</button>
+                <button
+                    x-on:click="uploadFile()"
+                    class="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded transition-colors shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                    :disabled="!uploadFileObj || uploading"
+                >
+                    <span x-text="uploading ? 'Uploading...' : 'Upload'"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="showUrlModal" class="fixed inset-0 bg-black/80 flex items-center justify-center z-50" style="display: none;" x-transition.opacity>
+        <div class="bg-gray-800 p-6 rounded-lg w-full max-w-md border border-gray-700 shadow-2xl" x-on:click.away="showUrlModal = false">
+            <h2 class="text-xl font-bold mb-4">Import CBL From URL</h2>
+
+            <label class="block text-sm text-gray-400 mb-1">URL (https:// only)</label>
+            <input
+                type="text"
+                x-model="urlInput"
+                placeholder="https://example.com/events/list.cbl"
+                class="w-full bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none"
+            >
+
+            <div x-show="urlError" class="mt-3 text-sm text-red-300" x-text="urlError"></div>
+
+            <div class="flex justify-end gap-2 mt-6">
+                <button x-on:click="showUrlModal = false" class="text-gray-400 hover:text-white px-4 py-2 transition-colors">Cancel</button>
+                <button
+                    x-on:click="importUrl()"
+                    class="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded transition-colors shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                    :disabled="!urlInput.trim() || urlImporting"
+                >
+                    <span x-text="urlImporting ? 'Importing...' : 'Import'"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div x-show="showRenameModal" class="fixed inset-0 bg-black/80 flex items-center justify-center z-50" style="display: none;" x-transition.opacity>
+        <div class="bg-gray-800 p-6 rounded-lg w-full max-w-md border border-gray-700 shadow-2xl" x-on:click.away="showRenameModal = false">
+            <h2 class="text-xl font-bold mb-4">Rename Reading List</h2>
+
+            <label class="block text-sm text-gray-400 mb-1">Name</label>
+            <input
+                type="text"
+                x-model="renameInput"
+                class="w-full bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white focus:border-blue-500 outline-none"
+            >
+
+            <div x-show="renameError" class="mt-3 text-sm text-red-300" x-text="renameError"></div>
+
+            <div class="flex justify-end gap-2 mt-6">
+                <button x-on:click="showRenameModal = false" class="text-gray-400 hover:text-white px-4 py-2 transition-colors">Cancel</button>
+                <button
+                    x-on:click="saveRename()"
+                    class="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded transition-colors shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+                    :disabled="!renameInput.trim() || renaming"
+                >
+                    <span x-text="renaming ? 'Saving...' : 'Save'"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+
+</div>
+
+<script>
+function cblSourcesManager() {
+    return {
+        activeTab: 'sources',
+        sources: [],
+        busySourceId: null,
+
+        showUploadModal: false,
+        uploadFileObj: null,
+        uploadError: '',
+        uploading: false,
+
+        showUrlModal: false,
+        urlInput: '',
+        urlError: '',
+        urlImporting: false,
+
+        showRenameModal: false,
+        renameTarget: null,
+        renameInput: '',
+        renameError: '',
+        renaming: false,
+
+        catalog: {
+            loaded: false,
+            loading: false,
+            error: '',
+            path: '',
+            entries: [],
+            filterQuery: '',
+            preview: null,
+            previewLoading: false,
+            importingPath: null,
+        },
+
+        init() {
+            this.loadSources();
+        },
+
+        async loadSources() {
+            try {
+                const res = await fetch(window.parker.route('cbl_sources.list'));
+                if (res.ok) {
+                    const data = await res.json();
+                    this.sources = data.items;
+                }
+            } catch (e) { console.error(e); }
+        },
+
+        originBadgeClass(origin) {
+            return {
+                upload: 'bg-blue-900/50 text-blue-300',
+                url: 'bg-purple-900/50 text-purple-300',
+                catalog: 'bg-pink-900/50 text-pink-300',
+                library_import: 'bg-green-900/50 text-green-300',
+            }[origin] || 'bg-gray-700 text-gray-300';
+        },
+
+        matchSummaryText(source) {
+            if (!source.last_match_summary) return '—';
+            try {
+                const summary = JSON.parse(source.last_match_summary);
+                if (summary.error) return `Parse error: ${summary.error}`;
+                const matched = (summary.matched_by_metadata || 0) + (summary.matched_by_metadata_year || 0) + (summary.matched_by_relaxed_metadata || 0);
+                const parts = [`${matched} matched`];
+                if (summary.unmatched) parts.push(`${summary.unmatched} unmatched`);
+                if (summary.ambiguous) parts.push(`${summary.ambiguous} ambiguous`);
+                return parts.join(' · ');
+            } catch (e) {
+                return '—';
+            }
+        },
+
+        formatDate(dateStr) {
+            if (!dateStr) return 'Never';
+            return new Date(dateStr).toLocaleString();
+        },
+
+        openUploadModal() {
+            this.uploadFileObj = null;
+            this.uploadError = '';
+            this.showUploadModal = true;
+        },
+
+        fileChange(event) {
+            this.uploadFileObj = event.target.files[0];
+        },
+
+        async uploadFile() {
+            if (!this.uploadFileObj) return;
+
+            this.uploading = true;
+            this.uploadError = '';
+
+            try {
+                const formData = new FormData();
+                formData.append('file', this.uploadFileObj);
+                const res = await fetch(window.parker.route('cbl_sources.upload'), { method: 'POST', body: formData });
+                const payload = await res.json();
+
+                if (!res.ok) throw new Error(payload.detail || 'Upload failed');
+
+                this.showUploadModal = false;
+                await this.loadSources();
+                window.parker.showToast('CBL file imported', 'success');
+            } catch (e) {
+                this.uploadError = e.message || 'Upload failed';
+            } finally {
+                this.uploading = false;
+            }
+        },
+
+        openUrlModal() {
+            this.urlInput = '';
+            this.urlError = '';
+            this.showUrlModal = true;
+        },
+
+        async importUrl() {
+            if (!this.urlInput.trim()) return;
+
+            this.urlImporting = true;
+            this.urlError = '';
+
+            try {
+                const res = await fetch(window.parker.route('cbl_sources.import_url'), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ url: this.urlInput.trim() }),
+                });
+                const payload = await res.json();
+
+                if (!res.ok) throw new Error(payload.detail || 'Import failed');
+
+                this.showUrlModal = false;
+                await this.loadSources();
+                window.parker.showToast('CBL file imported', 'success');
+            } catch (e) {
+                this.urlError = e.message || 'Import failed';
+            } finally {
+                this.urlImporting = false;
+            }
+        },
+
+        openRenameModal(source) {
+            this.renameTarget = source;
+            this.renameInput = source.reading_list_name || '';
+            this.renameError = '';
+            this.showRenameModal = true;
+        },
+
+        async saveRename() {
+            if (!this.renameInput.trim() || !this.renameTarget) return;
+
+            this.renaming = true;
+            this.renameError = '';
+
+            try {
+                const res = await fetch(window.parker.route('reading_lists.rename', { list_id: this.renameTarget.reading_list_id }), {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ name: this.renameInput.trim() }),
+                });
+                const payload = await res.json();
+
+                if (!res.ok) throw new Error(payload.detail || 'Rename failed');
+
+                this.showRenameModal = false;
+                await this.loadSources();
+                window.parker.showToast('Reading list renamed', 'success');
+            } catch (e) {
+                this.renameError = e.message || 'Rename failed';
+            } finally {
+                this.renaming = false;
+            }
+        },
+
+        async refreshSource(source) {
+            this.busySourceId = source.id;
+
+            try {
+                const res = await fetch(window.parker.route('cbl_sources.refresh', { source_id: source.id }), { method: 'POST' });
+                const payload = await res.json();
+
+                if (!res.ok) throw new Error(payload.detail || 'Refresh failed');
+
+                await this.loadSources();
+                const ok = payload.last_refresh_status === 'ok';
+                window.parker.showToast(ok ? 'Refreshed' : 'Refresh failed — keeping last good list', ok ? 'success' : 'warning');
+            } catch (e) {
+                await window.parker.dialog.alert('Error', e.message || 'Refresh failed');
+            } finally {
+                this.busySourceId = null;
+            }
+        },
+
+        async deleteSource(source) {
+            const confirmed = await window.parker.dialog.confirm(
+                `Delete "${source.display_name}"?`,
+                'This removes the managed CBL file and its derived reading list.',
+                { isDestructive: true, confirmText: 'Delete' }
+            );
+
+            if (!confirmed) return;
+
+            this.busySourceId = source.id;
+
+            try {
+                const res = await fetch(window.parker.route('cbl_sources.delete', { source_id: source.id }), { method: 'DELETE' });
+                if (res.ok) {
+                    await this.loadSources();
+                    window.parker.showToast('CBL source deleted', 'success');
+                }
+            } catch (e) {
+                await window.parker.dialog.alert('Error', 'Failed to delete CBL source');
+            } finally {
+                this.busySourceId = null;
+            }
+        },
+
+        async browseCatalog(path, forceRefresh = false) {
+            this.catalog.loading = true;
+            this.catalog.error = '';
+            this.catalog.preview = null;
+
+            try {
+                const query = `path=${encodeURIComponent(path || '')}${forceRefresh ? '&force_refresh=true' : ''}`;
+                const res = await fetch(window.parker.route('cbl_catalog.browse', {}, query));
+                const payload = await res.json();
+
+                if (!res.ok) throw new Error(payload.detail || 'Failed to browse catalog');
+
+                this.catalog.path = payload.path;
+                this.catalog.entries = payload.entries;
+                this.catalog.filterQuery = '';
+                this.catalog.loaded = true;
+            } catch (e) {
+                this.catalog.error = e.message || 'Failed to browse catalog';
+            } finally {
+                this.catalog.loading = false;
+            }
+        },
+
+        catalogParentPath() {
+            if (!this.catalog.path) return '';
+            const parts = this.catalog.path.split('/');
+            parts.pop();
+            return parts.join('/');
+        },
+
+        filteredCatalogEntries() {
+            const query = this.catalog.filterQuery.trim().toLowerCase();
+            if (!query) return this.catalog.entries;
+            return this.catalog.entries.filter((entry) => entry.name.toLowerCase().includes(query));
+        },
+
+        async previewCatalogFile(entry) {
+            this.catalog.previewLoading = true;
+
+            try {
+                const res = await fetch(window.parker.route('cbl_catalog.preview', {}, `path=${encodeURIComponent(entry.path)}`));
+                const payload = await res.json();
+
+                if (!res.ok) throw new Error(payload.detail || 'Failed to preview file');
+
+                this.catalog.preview = { path: entry.path, ...payload };
+            } catch (e) {
+                await window.parker.dialog.alert('Error', e.message || 'Failed to preview file');
+            } finally {
+                this.catalog.previewLoading = false;
+            }
+        },
+
+        async importCatalogFile(entry) {
+            this.catalog.importingPath = entry.path;
+
+            try {
+                const res = await fetch(window.parker.route('cbl_catalog.import_file'), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ path: entry.path }),
+                });
+                const payload = await res.json();
+
+                if (!res.ok) throw new Error(payload.detail || 'Failed to import file');
+
+                await this.loadSources();
+                this.activeTab = 'sources';
+                window.parker.showToast(`Imported "${payload.display_name}"`, 'success');
+            } catch (e) {
+                await window.parker.dialog.alert('Error', e.message || 'Failed to import file');
+            } finally {
+                this.catalog.importingPath = null;
+            }
+        },
+    }
+}
+</script>
+{% endblock %}

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -112,6 +112,17 @@
         </a>
 
 
+        <a :href="window.parker.route('admin.cbl_sources')" class="block bg-gray-800 hover:bg-gray-750 border border-gray-700 hover:border-pink-500 rounded-lg p-6 transition-all group shadow-lg">
+            <div class="flex items-center justify-between mb-4">
+                <div class="w-12 h-12 bg-pink-900/30 rounded-lg flex items-center justify-center text-2xl group-hover:scale-110 transition-transform">
+                    📖
+                </div>
+                <span class="text-gray-500 group-hover:text-pink-400 transition-colors">→</span>
+            </div>
+            <h3 class="text-xl font-bold text-white mb-2">CBL Reading Lists</h3>
+            <p class="text-sm text-gray-400">Upload, import, and browse a curated catalog of CBL reading lists.</p>
+        </a>
+
         <a :href="window.parker.route('admin.about')" class="block bg-gray-800 hover:bg-gray-750 border border-gray-700 hover:border-blue-400 rounded-lg p-6 transition-all group shadow-lg">
             <div class="flex items-center justify-between mb-4">
                 <div class="w-12 h-12 bg-blue-900/30 rounded-lg flex items-center justify-center text-2xl group-hover:scale-110 transition-transform">

--- a/app/templates/reading_lists/reading_list_detail.html
+++ b/app/templates/reading_lists/reading_list_detail.html
@@ -40,7 +40,7 @@
                     <div class="flex flex-wrap items-center gap-3 mb-2">
                         <h1 class="text-2xl md:text-3xl font-bold text-white break-words" x-text="readingList?.name"></h1>
 
-                        <span x-show="readingList?.auto_generated" class="bg-gray-700 text-xs px-2 py-1 rounded text-gray-300 border border-gray-600 whitespace-nowrap">Auto-Generated</span>
+                        <span x-show="readingList?.source && readingList.source !== 'manual'" class="bg-gray-700 text-xs px-2 py-1 rounded text-gray-300 border border-gray-600 whitespace-nowrap" x-text="readingList?.source_label"></span>
 
                         {% from "partials/cover_browser_link.html" import cover_browser_link %}
                         {{ cover_browser_link("reading_list", reading_list_id) }}

--- a/docs/cbl-reading-list-support-scope.md
+++ b/docs/cbl-reading-list-support-scope.md
@@ -226,23 +226,39 @@ Implementation should include real fixture files before finalizing field mapping
 
 ## Matching Strategy
 
-Matching should favor filesystem identity when available, then fall back to metadata.
+Implemented in `app/services/cbl_matching.py`.
 
-Recommended order:
+Real ComicRack-style CBL `<Book>` entries carry only `Series`/`Number`/`Volume`/`Year`/`Format`
+attributes -- no filesystem path or filename -- so a path/filename tier (as originally
+considered here) has nothing to match against for real-world CBL files and was not built.
+Matching goes straight to metadata, in three tiers:
 
-1. Path match, if the CBL entry provides a file path and it can be normalized against known Parker library roots.
-2. Filename match, only when unique within the target matching scope.
-3. Metadata match using normalized series, issue number, volume, and year.
-4. Optional relaxed metadata match using series and number only when unique.
+1. `series + number + volume + year`, normalized. Only works when the library's `Volume`
+   tagging convention agrees with the CBL file's -- both usually meaning "the year this
+   print run started."
+2. `series + number + year`, dropping the volume comparison. Needed because plenty of
+   libraries tag `Volume` as a plain sequential index (1, 2, 3...) instead of a start year,
+   which would otherwise never agree with a CBL file's `Volume` value and silently degrade
+   every match in that library to tier 3.
+3. `series + number` only, as a last resort when no year is available on either side.
+
+Each tier only ever compares values the tagger/CBL file actually asserted -- never a
+derived or inferred one (e.g. approximating a volume's start year from the earliest
+issue's publication year was considered and rejected: it can be confidently *wrong* for
+any issue published after a volume's first year, which is worse than not matching).
 
 Ambiguity policy:
 
-- never guess when multiple comics match
-- skip unmatched or ambiguous entries
-- keep the rest of the list usable
-- surface skipped entries in scan summary/admin reporting
+- never guess when multiple comics match a tier's key
+- an ambiguous result at any tier is terminal for that entry -- it does not fall through
+  to a looser tier, since every later tier is a strict superset of the same match space
+  and can only be equally or more ambiguous, never less
+- skip unmatched or ambiguous entries; keep the rest of the list usable
+- surface skipped entries in scan summary/admin reporting (`CBLSource.last_match_summary`)
 
-Matching should reuse existing path normalization helpers from `app/core/path_utils.py` and existing issue-number parsing/sort behavior where practical.
+Series-name normalization (`app/core/text_utils.py::normalize_title`) and issue-number
+normalization (`app/core/comic_helpers.py::normalize_issue_number`) are shared with the
+ComicInfo-derived matching path rather than duplicated.
 
 ## Generated List Naming
 
@@ -288,9 +304,9 @@ Useful scan/report fields:
 - CBL parse failures
 - reading lists created
 - reading lists updated
-- entries matched by path
-- entries matched by filename
-- entries matched by metadata
+- entries matched by metadata (series + number + volume + year)
+- entries matched by metadata (series + number + year)
+- entries matched by relaxed metadata (series + number only)
 - unmatched entries
 - ambiguous entries
 
@@ -351,9 +367,9 @@ Derived list edit/delete behavior should be deliberate:
 
 ### 5. Matching Service
 
-- implement deterministic matching by path, filename, then metadata
+- implement deterministic matching: series+number+volume+year, then series+number+year, then series+number only
 - collect unmatched and ambiguous entries
-- add tests for duplicate filenames, duplicate metadata, missing years, and multi-root relative paths
+- add tests for duplicate metadata, missing years, and mismatched volume-tagging conventions (sequential vs. year-based)
 
 ### 6. Scan Integration
 
@@ -397,7 +413,7 @@ Unit coverage:
 - URL import safety checks
 - managed CBL file lifecycle
 - catalog listing cache behavior
-- matching by path, filename, and metadata
+- matching by metadata (strict volume+year, year-only, and relaxed series+number tiers)
 - ambiguous/unmatched entry handling
 - CBL delete/stale behavior for managed source deletion and failed refresh
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ python-dotenv==1.2.2
 aiofiles==25.1.0
 portalocker==3.2.0
 concurrent-log-handler==0.9.29
+httpx==0.28.1
 
 # Templating
 jinja2==3.1.6

--- a/tests/api/test_cbl_catalog.py
+++ b/tests/api/test_cbl_catalog.py
@@ -141,6 +141,8 @@ def test_preview_success(admin_client, monkeypatch):
     payload = response.json()
     assert payload["name"] == "API Catalog List"
     assert payload["entry_count"] == 1
+    assert payload["sample_entries"] == ["Catalog Series #1"]
+    assert payload["sample_truncated"] is False
 
 
 def test_import_creates_source_and_reading_list(admin_client, db, tmp_path, monkeypatch):

--- a/tests/api/test_cbl_catalog.py
+++ b/tests/api/test_cbl_catalog.py
@@ -1,0 +1,197 @@
+import pytest
+
+import app.services.cbl_catalog_service as cbl_catalog_service_module
+import app.services.cbl_source_service as cbl_source_service_module
+from app.services.cbl_catalog_service import CBLCatalogService
+from app.models.cbl_source import CBLSource
+from app.models.reading_list import ReadingList
+from app.models.comic import Volume
+from app.models.series import Series
+from tests.factories import create_comic, create_library_with_root
+
+VALID_CBL = (
+    b'<?xml version="1.0"?><ReadingList><Name>API Catalog List</Name>'
+    b'<Books><Book Series="Catalog Series" Number="1" /></Books></ReadingList>'
+)
+
+LISTING_JSON = [
+    {"name": "Marvel", "path": "Marvel", "type": "dir"},
+    {"name": "readme.txt", "path": "readme.txt", "type": "file"},
+    {"name": "Infinity-Gauntlet.cbl", "path": "Infinity-Gauntlet.cbl", "type": "file"},
+]
+
+FILE_META_JSON = {
+    "name": "Infinity-Gauntlet.cbl",
+    "path": "Infinity-Gauntlet.cbl",
+    "type": "file",
+    "download_url": "https://raw.githubusercontent.com/DieselTech/CBL-ReadingLists/main/Infinity-Gauntlet.cbl",
+}
+
+
+class _FakeGetResponse:
+    def __init__(self, status_code, json_data):
+        self.status_code = status_code
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
+
+
+class _FakeStreamResponse:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeStreamCtx:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeCatalogClient:
+    def __init__(self, get_response=None, stream_chunks=None):
+        self._get_response = get_response
+        self._stream_chunks = stream_chunks
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, headers=None):
+        return self._get_response
+
+    def stream(self, method, url, headers=None):
+        return _FakeStreamCtx(_FakeStreamResponse(self._stream_chunks or []))
+
+
+def _patch_client_sequence(monkeypatch, clients):
+    queue = list(clients)
+
+    def factory(*args, **kwargs):
+        return queue.pop(0)
+
+    monkeypatch.setattr(cbl_catalog_service_module.httpx, "AsyncClient", factory)
+
+
+def _patch_cbl_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", tmp_path / "cbl")
+
+
+@pytest.fixture(autouse=True)
+def _clear_catalog_cache():
+    CBLCatalogService._cache.clear()
+    yield
+    CBLCatalogService._cache.clear()
+
+
+def test_browse_requires_admin(auth_client):
+    response = auth_client.get("/api/cbl-catalog/browse")
+    assert response.status_code == 400
+
+
+def test_browse_success_filters_entries(admin_client, monkeypatch):
+    _patch_client_sequence(monkeypatch, [_FakeCatalogClient(get_response=_FakeGetResponse(200, LISTING_JSON))])
+
+    response = admin_client.get("/api/cbl-catalog/browse")
+
+    assert response.status_code == 200
+    names = [e["name"] for e in response.json()["entries"]]
+    assert names == ["Marvel", "Infinity-Gauntlet.cbl"]
+
+
+def test_browse_not_found_maps_to_404(admin_client, monkeypatch):
+    _patch_client_sequence(monkeypatch, [_FakeCatalogClient(get_response=_FakeGetResponse(404, {"message": "Not Found"}))])
+
+    response = admin_client.get("/api/cbl-catalog/browse?path=Nope")
+
+    assert response.status_code == 404
+
+
+def test_browse_rate_limited_maps_to_502(admin_client, monkeypatch):
+    _patch_client_sequence(monkeypatch, [_FakeCatalogClient(get_response=_FakeGetResponse(403, {"message": "rate limited"}))])
+
+    response = admin_client.get("/api/cbl-catalog/browse")
+
+    assert response.status_code == 502
+
+
+def test_preview_success(admin_client, monkeypatch):
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[VALID_CBL]),
+    ])
+
+    response = admin_client.get("/api/cbl-catalog/preview?path=Infinity-Gauntlet.cbl")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["name"] == "API Catalog List"
+    assert payload["entry_count"] == 1
+
+
+def test_import_creates_source_and_reading_list(admin_client, db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+
+    library = create_library_with_root(db, "cbl-catalog-api-lib", str(tmp_path / "lib"))
+    series = Series(name="Catalog Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+    comic = create_comic(
+        db, volume, library.active_root, "catalog-1.cbz",
+        number="1", filename="catalog-1.cbz", page_count=1,
+    )
+    db.commit()
+
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[VALID_CBL]),
+    ])
+
+    response = admin_client.post("/api/cbl-catalog/import", json={"path": "Infinity-Gauntlet.cbl"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["origin"] == "catalog"
+    assert payload["catalog_provider"] == "dieseltech"
+    assert payload["catalog_path"] == "Infinity-Gauntlet.cbl"
+    assert payload["entry_count"] == 1
+
+    source = db.query(CBLSource).filter(CBLSource.id == payload["id"]).first()
+    reading_list = db.query(ReadingList).filter(ReadingList.source_cbl_id == source.id).first()
+    assert reading_list is not None
+    assert reading_list.name == "API Catalog List"
+
+
+def test_import_duplicate_maps_to_400(admin_client, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[VALID_CBL]),
+    ])
+    first = admin_client.post("/api/cbl-catalog/import", json={"path": "Infinity-Gauntlet.cbl"})
+    assert first.status_code == 200
+
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[VALID_CBL]),
+    ])
+    second = admin_client.post("/api/cbl-catalog/import", json={"path": "Infinity-Gauntlet.cbl"})
+
+    assert second.status_code == 400
+    assert "already imported" in second.json()["detail"]

--- a/tests/api/test_cbl_sources.py
+++ b/tests/api/test_cbl_sources.py
@@ -1,0 +1,249 @@
+import hashlib
+from pathlib import Path
+
+import app.services.cbl_catalog_service as cbl_catalog_service_module
+import app.services.cbl_source_service as cbl_source_service_module
+from app.models.cbl_source import CBLSource
+
+VALID_CBL = (
+    b'<?xml version="1.0"?><ReadingList><Name>API Test List</Name>'
+    b'<Books><Book Series="A" Number="1" /></Books></ReadingList>'
+)
+
+
+def _patch_cbl_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", tmp_path / "cbl")
+
+
+class _FakeGetResponse:
+    def __init__(self, status_code, json_data):
+        self.status_code = status_code
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
+
+
+class _FakeStreamResponse:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeStreamCtx:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeCatalogClient:
+    def __init__(self, get_response=None, stream_chunks=None):
+        self._get_response = get_response
+        self._stream_chunks = stream_chunks
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, headers=None):
+        return self._get_response
+
+    def stream(self, method, url, headers=None):
+        return _FakeStreamCtx(_FakeStreamResponse(self._stream_chunks or []))
+
+
+def _patch_catalog_client_sequence(monkeypatch, clients):
+    queue = list(clients)
+
+    def factory(*args, **kwargs):
+        return queue.pop(0)
+
+    monkeypatch.setattr(cbl_catalog_service_module.httpx, "AsyncClient", factory)
+
+
+def test_upload_requires_admin(auth_client):
+    response = auth_client.post(
+        "/api/cbl-sources/upload",
+        files={"file": ("test.cbl", VALID_CBL, "application/xml")},
+    )
+    assert response.status_code == 400  # get_current_active_superuser raises 400 for non-admins
+
+
+def test_upload_success_creates_source(admin_client, db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+
+    response = admin_client.post(
+        "/api/cbl-sources/upload",
+        files={"file": ("api-test.cbl", VALID_CBL, "application/xml")},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["display_name"] == "api-test"
+    assert payload["origin"] == "upload"
+    assert payload["entry_count"] == 1
+    assert payload["reading_list_id"] is not None
+    assert payload["reading_list_name"] == "API Test List"
+
+
+def test_list_includes_reading_list_fields(admin_client, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+
+    admin_client.post(
+        "/api/cbl-sources/upload",
+        files={"file": ("list-fields.cbl", VALID_CBL, "application/xml")},
+    )
+
+    response = admin_client.get("/api/cbl-sources/")
+
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["reading_list_id"] is not None
+    assert item["reading_list_name"] == "API Test List"
+
+
+def test_upload_rejects_bad_extension(admin_client, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+
+    response = admin_client.post(
+        "/api/cbl-sources/upload",
+        files={"file": ("not-a-list.txt", VALID_CBL, "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert "extension" in response.json()["detail"]
+
+
+def test_upload_rejects_duplicate(admin_client, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+
+    first = admin_client.post(
+        "/api/cbl-sources/upload",
+        files={"file": ("first.cbl", VALID_CBL, "application/xml")},
+    )
+    assert first.status_code == 200
+
+    second = admin_client.post(
+        "/api/cbl-sources/upload",
+        files={"file": ("second.cbl", VALID_CBL, "application/xml")},
+    )
+    assert second.status_code == 400
+    assert "already imported" in second.json()["detail"]
+
+
+def test_list_and_detail(admin_client, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+
+    uploaded = admin_client.post(
+        "/api/cbl-sources/upload",
+        files={"file": ("list-detail.cbl", VALID_CBL, "application/xml")},
+    ).json()
+
+    listed = admin_client.get("/api/cbl-sources/")
+    assert listed.status_code == 200
+    assert any(item["id"] == uploaded["id"] for item in listed.json()["items"])
+
+    detail = admin_client.get(f"/api/cbl-sources/{uploaded['id']}")
+    assert detail.status_code == 200
+    assert detail.json()["id"] == uploaded["id"]
+
+    missing = admin_client.get("/api/cbl-sources/999999")
+    assert missing.status_code == 404
+
+
+def test_delete_removes_source(admin_client, db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+
+    uploaded = admin_client.post(
+        "/api/cbl-sources/upload",
+        files={"file": ("delete-me.cbl", VALID_CBL, "application/xml")},
+    ).json()
+
+    deleted = admin_client.delete(f"/api/cbl-sources/{uploaded['id']}")
+    assert deleted.status_code == 200
+
+    missing = admin_client.delete(f"/api/cbl-sources/{uploaded['id']}")
+    assert missing.status_code == 404
+
+    assert db.query(CBLSource).filter(CBLSource.id == uploaded["id"]).count() == 0
+
+
+def test_import_url_rejects_non_https(admin_client):
+    response = admin_client.post("/api/cbl-sources/url", json={"url": "http://example.com/list.cbl"})
+    assert response.status_code == 400
+    assert "https" in response.json()["detail"]
+
+
+def test_refresh_rejects_source_with_no_url(admin_client, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+
+    uploaded = admin_client.post(
+        "/api/cbl-sources/upload",
+        files={"file": ("no-url.cbl", VALID_CBL, "application/xml")},
+    ).json()
+
+    response = admin_client.post(f"/api/cbl-sources/{uploaded['id']}/refresh")
+    assert response.status_code == 400
+    assert "no URL to refresh" in response.json()["detail"]
+
+
+def test_refresh_missing_source_404(admin_client):
+    response = admin_client.post("/api/cbl-sources/999999/refresh")
+    assert response.status_code == 404
+
+
+def test_refresh_dispatches_to_catalog_path_for_catalog_origin_sources(admin_client, db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+
+    fingerprint = hashlib.sha256(VALID_CBL).hexdigest()
+    cbl_dir = tmp_path / "cbl"
+    cbl_dir.mkdir(parents=True, exist_ok=True)
+    stored_path = cbl_dir / f"{fingerprint}.cbl"
+    stored_path.write_bytes(VALID_CBL)
+
+    source = CBLSource(
+        display_name="Catalog Source",
+        stored_path=str(stored_path),
+        original_filename="Catalog-Source.cbl",
+        origin="catalog",
+        catalog_provider="dieseltech",
+        catalog_path="Marvel/Catalog-Source.cbl",
+        fingerprint=fingerprint,
+        last_refresh_status="never",
+    )
+    db.add(source)
+    db.commit()
+
+    new_content = VALID_CBL.replace(b"API Test List", b"Updated Catalog Source")
+    new_meta = {
+        "name": "Catalog-Source.cbl",
+        "path": "Marvel/Catalog-Source.cbl",
+        "type": "file",
+        "download_url": "https://raw.githubusercontent.com/DieselTech/CBL-ReadingLists/main/Marvel/Catalog-Source.cbl",
+    }
+    _patch_catalog_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, new_meta)),
+        _FakeCatalogClient(stream_chunks=[new_content]),
+    ])
+
+    response = admin_client.post(f"/api/cbl-sources/{source.id}/refresh")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["last_refresh_status"] == "ok"
+
+    db.refresh(source)
+    assert Path(source.stored_path).read_bytes() == new_content

--- a/tests/api/test_reading_lists.py
+++ b/tests/api/test_reading_lists.py
@@ -42,8 +42,8 @@ def test_list_reading_lists_admin_shows_counts(admin_client, db):
     c1 = _create_comic(db, volume_id=vol.id, prefix="reading-lists-admin", number="1", year=2021)
     c2 = _create_comic(db, volume_id=vol.id, prefix="reading-lists-admin", number="2", year=2022)
 
-    alpha = ReadingList(name="Alpha Reading List", description="A", auto_generated=0)
-    beta = ReadingList(name="Beta Reading List", description="B", auto_generated=1)
+    alpha = ReadingList(name="Alpha Reading List", description="A", source="manual")
+    beta = ReadingList(name="Beta Reading List", description="B", source="comicinfo")
     db.add_all([alpha, beta])
     db.flush()
     db.add_all([
@@ -109,9 +109,9 @@ def test_list_reading_lists_applies_library_and_banned_filters(auth_client, db, 
         age_rating="Teen",
     )
 
-    visible_list = ReadingList(name="Visible Reading List", auto_generated=0)
-    mature_list = ReadingList(name="Mature Reading List", auto_generated=0)
-    hidden_list = ReadingList(name="Hidden Reading List", auto_generated=0)
+    visible_list = ReadingList(name="Visible Reading List", source="manual")
+    mature_list = ReadingList(name="Mature Reading List", source="manual")
+    hidden_list = ReadingList(name="Hidden Reading List", source="manual")
     db.add_all([visible_list, mature_list, hidden_list])
     db.flush()
     db.add_all([
@@ -149,7 +149,7 @@ def test_list_reading_lists_hides_entries_when_library_parsing_disabled(admin_cl
         number="1",
         year=2024,
     )
-    reading_list = ReadingList(name="Parse Off Reading List", auto_generated=0)
+    reading_list = ReadingList(name="Parse Off Reading List", source="manual")
     db.add(reading_list)
     db.flush()
     db.add(ReadingListItem(reading_list_id=reading_list.id, comic_id=comic.id, position=1))
@@ -171,7 +171,7 @@ def test_get_reading_list_success_returns_position_order_and_details(auth_client
     c1 = _create_comic(db, volume_id=vol.id, prefix="reading-lists-detail", number="1", year=2020)
     c2 = _create_comic(db, volume_id=vol.id, prefix="reading-lists-detail", number="2", year=2021)
 
-    reading_list = ReadingList(name="Detail Reading List", description="Detail", auto_generated=0)
+    reading_list = ReadingList(name="Detail Reading List", description="Detail", source="manual")
     db.add(reading_list)
     db.flush()
     db.add_all([
@@ -215,7 +215,7 @@ def test_get_reading_list_404_when_user_has_no_visible_comics(auth_client, db):
     )
     comic = _create_comic(db, volume_id=vol.id, prefix="reading-lists-hidden-detail", number="1", year=2020)
 
-    reading_list = ReadingList(name="Hidden Detail Reading List", auto_generated=0)
+    reading_list = ReadingList(name="Hidden Detail Reading List", source="manual")
     db.add(reading_list)
     db.flush()
     db.add(ReadingListItem(reading_list_id=reading_list.id, comic_id=comic.id, position=1))
@@ -243,7 +243,7 @@ def test_get_reading_list_restriction_blocks_banned_content(auth_client, db, nor
         age_rating="Mature 17+",
     )
 
-    reading_list = ReadingList(name="Restricted Reading List", auto_generated=0)
+    reading_list = ReadingList(name="Restricted Reading List", source="manual")
     db.add(reading_list)
     db.flush()
     db.add(ReadingListItem(reading_list_id=reading_list.id, comic_id=mature.id, position=1))
@@ -259,15 +259,115 @@ def test_get_reading_list_restriction_blocks_banned_content(auth_client, db, nor
     assert "age-restricted" in response.json()["detail"].lower()
 
 
-def test_delete_reading_list_success_and_missing(auth_client, db):
-    reading_list = ReadingList(name="Delete Reading List", auto_generated=0)
+def test_delete_reading_list_success_and_missing(admin_client, db):
+    reading_list = ReadingList(name="Delete Reading List", source="manual")
     db.add(reading_list)
     db.commit()
 
-    deleted = auth_client.delete(f"/api/reading-lists/{reading_list.id}")
+    deleted = admin_client.delete(f"/api/reading-lists/{reading_list.id}")
     assert deleted.status_code == 200
     assert deleted.json() == {"message": "Reading list 'Delete Reading List' deleted"}
 
-    missing = auth_client.delete(f"/api/reading-lists/{reading_list.id}")
+    missing = admin_client.delete(f"/api/reading-lists/{reading_list.id}")
     assert missing.status_code == 404
     assert missing.json()["detail"] == "Reading list not found"
+
+
+def test_delete_rejects_cbl_reading_list(admin_client, db):
+    reading_list = ReadingList(name="CBL Delete Attempt", source="cbl", source_cbl_id=None)
+    db.add(reading_list)
+    db.commit()
+
+    response = admin_client.delete(f"/api/reading-lists/{reading_list.id}")
+
+    assert response.status_code == 400
+    assert "cbl-sources" in response.json()["detail"]
+    assert db.query(ReadingList).filter(ReadingList.id == reading_list.id).count() == 1
+
+
+def test_delete_reading_list_requires_admin(auth_client, db):
+    reading_list = ReadingList(name="Non-Admin Delete Attempt", source="manual")
+    db.add(reading_list)
+    db.commit()
+
+    response = auth_client.delete(f"/api/reading-lists/{reading_list.id}")
+
+    assert response.status_code == 400  # get_current_active_superuser rejects non-admins
+    assert db.query(ReadingList).filter(ReadingList.id == reading_list.id).count() == 1
+
+
+def test_rename_cbl_reading_list_success(admin_client, db):
+    reading_list = ReadingList(name="Old CBL Name", source="cbl", source_cbl_id=None)
+    db.add(reading_list)
+    db.commit()
+
+    response = admin_client.patch(f"/api/reading-lists/{reading_list.id}", json={"name": "New CBL Name"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["name"] == "New CBL Name"
+    assert payload["source"] == "cbl"
+
+    db.refresh(reading_list)
+    assert reading_list.name == "New CBL Name"
+
+
+def test_rename_requires_admin(auth_client, db):
+    reading_list = ReadingList(name="Needs Admin CBL List", source="cbl")
+    db.add(reading_list)
+    db.commit()
+
+    response = auth_client.patch(f"/api/reading-lists/{reading_list.id}", json={"name": "New Name"})
+
+    assert response.status_code == 400  # get_current_active_superuser rejects non-admins
+
+
+def test_rename_rejects_comicinfo_reading_list(admin_client, db):
+    reading_list = ReadingList(name="Auto Generated List", source="comicinfo")
+    db.add(reading_list)
+    db.commit()
+
+    response = admin_client.patch(f"/api/reading-lists/{reading_list.id}", json={"name": "New Name"})
+
+    assert response.status_code == 400
+    assert "CBL-derived" in response.json()["detail"]
+
+
+def test_rename_rejects_manual_reading_list(admin_client, db):
+    reading_list = ReadingList(name="Manual List", source="manual")
+    db.add(reading_list)
+    db.commit()
+
+    response = admin_client.patch(f"/api/reading-lists/{reading_list.id}", json={"name": "New Name"})
+
+    assert response.status_code == 400
+    assert "CBL-derived" in response.json()["detail"]
+
+
+def test_rename_rejects_duplicate_name(admin_client, db):
+    db.add(ReadingList(name="Taken Name", source="manual"))
+    reading_list = ReadingList(name="Rename Me", source="cbl")
+    db.add(reading_list)
+    db.commit()
+
+    response = admin_client.patch(f"/api/reading-lists/{reading_list.id}", json={"name": "Taken Name"})
+
+    assert response.status_code == 400
+    assert "already exists" in response.json()["detail"]
+
+
+def test_rename_rejects_empty_name(admin_client, db):
+    reading_list = ReadingList(name="Rename Me Too", source="cbl")
+    db.add(reading_list)
+    db.commit()
+
+    response = admin_client.patch(f"/api/reading-lists/{reading_list.id}", json={"name": "   "})
+
+    assert response.status_code == 400
+    assert "empty" in response.json()["detail"].lower()
+
+
+def test_rename_404_for_missing_list(admin_client):
+    response = admin_client.patch("/api/reading-lists/999999", json={"name": "Whatever"})
+
+    assert response.status_code == 404

--- a/tests/async_helpers.py
+++ b/tests/async_helpers.py
@@ -1,0 +1,17 @@
+import asyncio
+import concurrent.futures
+
+
+def run_async(coro):
+    """
+    Run a coroutine to completion from a plain sync test function.
+
+    Playwright's sync API (used by tests/browser/*) leaves the main thread's
+    asyncio state such that a later bare `asyncio.run(...)` call raises
+    "cannot be called from a running event loop", even though no event loop
+    is actually running from the test's own point of view. Running the
+    coroutine in a fresh worker thread sidesteps that pollution entirely,
+    since asyncio's "current running loop" tracking is thread-local.
+    """
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -104,7 +104,7 @@ def browser_seed_data(browser_db_factory):
     reading_list = ReadingList(
         name="Smoke Crossover",
         description="A compact browser-test event list.",
-        auto_generated=0,
+        source="manual",
     )
     writer = Person(name="Casey Smoke")
     character = Character(name="Captain Smoke")

--- a/tests/browser/test_admin_cbl_sources.py
+++ b/tests/browser/test_admin_cbl_sources.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+import app.services.cbl_source_service as cbl_source_service_module
+from app.models.user import User
+
+FIXTURE_CBL = Path(__file__).resolve().parent.parent / "fixtures" / "cbl" / "valid.cbl"
+
+
+@pytest.mark.browser
+def test_admin_cbl_sources_upload_and_delete_flow(page, browser_server, tmp_path, monkeypatch):
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", tmp_path / "cbl")
+
+    session = browser_server["db_factory"]()
+    try:
+        user = session.get(User, browser_server["seed"]["user_id"])
+        user.is_superuser = True
+        session.commit()
+    finally:
+        session.close()
+
+    try:
+        page.goto(f"{browser_server['base_url']}/admin/cbl-sources", wait_until="networkidle")
+
+        page.get_by_role("button", name="+ Upload CBL").click()
+        modal = page.locator('[x-show="showUploadModal"]')
+        modal.get_by_role("heading", name="Upload CBL File").wait_for()
+
+        modal.locator('input[type="file"]').set_input_files(str(FIXTURE_CBL))
+        modal.get_by_role("button", name="Upload").click()
+
+        row = page.get_by_role("row").filter(has_text="valid")
+        row.wait_for()
+        row.get_by_text("upload").wait_for()
+        row.get_by_text("Infinity Gauntlet").wait_for()
+
+        row.get_by_role("button", name="Rename").click()
+        rename_modal = page.locator('[x-show="showRenameModal"]')
+        rename_modal.get_by_role("heading", name="Rename Reading List").wait_for()
+        name_input = rename_modal.locator('input[type="text"]')
+        assert name_input.input_value() == "Infinity Gauntlet"
+        name_input.fill("My Renamed Event")
+        rename_modal.get_by_role("button", name="Save").click()
+
+        row.get_by_text("My Renamed Event").wait_for()
+
+        row.get_by_role("button", name="Delete").click()
+        page.get_by_role("heading", name='Delete "valid"?').wait_for()
+        page.locator('[x-data="globalDialog()"]').get_by_role("button", name="Delete").click()
+
+        page.get_by_text("No CBL sources yet.").wait_for()
+    finally:
+        session = browser_server["db_factory"]()
+        try:
+            user = session.get(User, browser_server["seed"]["user_id"])
+            if user is not None:
+                user.is_superuser = False
+                session.commit()
+        finally:
+            session.close()

--- a/tests/fixtures/cbl/half_issue.cbl
+++ b/tests/fixtures/cbl/half_issue.cbl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList>
+  <Name>Half Issue Test</Name>
+  <Books>
+    <Book Series="Weird Test Series" Number="1" Volume="2020" Year="2020" />
+    <Book Series="Weird Test Series" Number="&#189;" Volume="2020" Year="2020" />
+  </Books>
+</ReadingList>

--- a/tests/fixtures/cbl/malformed.cbl
+++ b/tests/fixtures/cbl/malformed.cbl
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList>
+  <Name>Broken File
+  <Books>
+    <Book Series="Silver Surfer" Number="34" />

--- a/tests/fixtures/cbl/missing_name.cbl
+++ b/tests/fixtures/cbl/missing_name.cbl
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList>
+  <Books>
+    <Book Series="Silver Surfer" Number="34" Volume="1987" Year="1990" />
+  </Books>
+</ReadingList>

--- a/tests/fixtures/cbl/unknown_fields.cbl
+++ b/tests/fixtures/cbl/unknown_fields.cbl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList>
+  <Name>Unknown Fields Test</Name>
+  <Books>
+    <Book Series="Silver Surfer" Number="34" Volume="1987" Year="1990" Format="TPB" Id="12345" Database="ComicVine">
+      <Matcher Type="ComicVine" Value="12345" />
+    </Book>
+  </Books>
+</ReadingList>

--- a/tests/fixtures/cbl/valid.cbl
+++ b/tests/fixtures/cbl/valid.cbl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReadingList>
+  <Name>Infinity Gauntlet</Name>
+  <Summary>The original Infinity Gauntlet crossover reading order.</Summary>
+  <Books>
+    <Book Series="Silver Surfer" Number="34" Volume="1987" Year="1990" />
+    <Book Series="Infinity Gauntlet" Number="1" Volume="1991" Year="1991" />
+    <Book Series="Infinity Gauntlet" Number="2" Volume="1991" Year="1991" />
+  </Books>
+</ReadingList>

--- a/tests/services/test_cbl_catalog_service.py
+++ b/tests/services/test_cbl_catalog_service.py
@@ -191,6 +191,28 @@ def test_preview_returns_name_entry_count_and_warnings(db, monkeypatch):
     assert result["name"] == "Catalog Test List"
     assert result["entry_count"] == 1
     assert result["warnings"] == []
+    assert result["sample_entries"] == ["A #1"]
+    assert result["sample_truncated"] is False
+
+
+def test_preview_caps_sample_entries_and_flags_truncation(db, monkeypatch):
+    books = "".join(f'<Book Series="Series" Number="{i}" Year="199{i % 9}" />' for i in range(1, 16))
+    big_cbl = (
+        b'<?xml version="1.0"?><ReadingList><Name>Big Event</Name>'
+        + f"<Books>{books}</Books></ReadingList>".encode()
+    )
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[big_cbl]),
+    ])
+    service = CBLCatalogService(db)
+
+    result = run_async(service.preview("Marvel/Infinity-Gauntlet.cbl"))
+
+    assert result["entry_count"] == 15
+    assert len(result["sample_entries"]) == 10
+    assert result["sample_entries"][0] == "Series #1 (1991)"
+    assert result["sample_truncated"] is True
 
 
 def test_import_file_sets_catalog_origin_and_metadata(db, monkeypatch, tmp_path):

--- a/tests/services/test_cbl_catalog_service.py
+++ b/tests/services/test_cbl_catalog_service.py
@@ -1,0 +1,322 @@
+from pathlib import Path
+
+import httpx
+import pytest
+
+import app.services.cbl_catalog_service as cbl_catalog_service_module
+import app.services.cbl_source_service as cbl_source_service_module
+from tests.async_helpers import run_async
+from app.services.cbl_catalog_service import (
+    CBLCatalogNotFoundError,
+    CBLCatalogService,
+    CBLCatalogUpstreamError,
+    CBLCatalogError,
+)
+from app.services.cbl_source_service import CBLSourceError, CBLSourceService
+
+VALID_CBL = (
+    b'<?xml version="1.0"?><ReadingList><Name>Catalog Test List</Name>'
+    b'<Books><Book Series="A" Number="1" /></Books></ReadingList>'
+)
+
+
+class _FakeGetResponse:
+    def __init__(self, status_code, json_data):
+        self.status_code = status_code
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
+
+
+class _FakeStreamResponse:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeStreamCtx:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeCatalogClient:
+    """One instance == one `async with httpx.AsyncClient(...) as client:` block."""
+
+    def __init__(self, get_response=None, stream_chunks=None, raise_on_get=None, raise_on_stream=None):
+        self._get_response = get_response
+        self._stream_chunks = stream_chunks
+        self._raise_on_get = raise_on_get
+        self._raise_on_stream = raise_on_stream
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, headers=None):
+        if self._raise_on_get:
+            raise self._raise_on_get
+        return self._get_response
+
+    def stream(self, method, url, headers=None):
+        if self._raise_on_stream:
+            raise self._raise_on_stream
+        return _FakeStreamCtx(_FakeStreamResponse(self._stream_chunks or []))
+
+
+def _patch_client_sequence(monkeypatch, clients):
+    queue = list(clients)
+
+    def factory(*args, **kwargs):
+        return queue.pop(0)
+
+    monkeypatch.setattr(cbl_catalog_service_module.httpx, "AsyncClient", factory)
+    return queue
+
+
+@pytest.fixture(autouse=True)
+def _clear_catalog_cache():
+    CBLCatalogService._cache.clear()
+    yield
+    CBLCatalogService._cache.clear()
+
+
+LISTING_JSON = [
+    {"name": "Marvel", "path": "Marvel", "type": "dir"},
+    {"name": "readme.txt", "path": "readme.txt", "type": "file"},
+    {"name": "Infinity-Gauntlet.cbl", "path": "Infinity-Gauntlet.cbl", "type": "file"},
+]
+
+FILE_META_JSON = {
+    "name": "Infinity-Gauntlet.cbl",
+    "path": "Marvel/Infinity-Gauntlet.cbl",
+    "type": "file",
+    "download_url": "https://raw.githubusercontent.com/DieselTech/CBL-ReadingLists/main/Marvel/Infinity-Gauntlet.cbl",
+}
+
+
+def test_browse_filters_to_dirs_and_cbl_files_only(db, monkeypatch):
+    _patch_client_sequence(monkeypatch, [_FakeCatalogClient(get_response=_FakeGetResponse(200, LISTING_JSON))])
+    service = CBLCatalogService(db)
+
+    result = run_async(service.browse(""))
+
+    names = [e["name"] for e in result["entries"]]
+    assert names == ["Marvel", "Infinity-Gauntlet.cbl"]
+    assert result["entries"][0]["type"] == "dir"
+    assert result["entries"][1]["type"] == "file"
+
+
+def test_browse_uses_cache_within_ttl(db, monkeypatch):
+    queue = _patch_client_sequence(monkeypatch, [_FakeCatalogClient(get_response=_FakeGetResponse(200, LISTING_JSON))])
+    service = CBLCatalogService(db)
+
+    first = run_async(service.browse("Marvel"))
+    second = run_async(service.browse("Marvel"))
+
+    assert first == second
+    assert queue == []  # only one AsyncClient() call happened -- second browse was served from cache
+
+
+def test_browse_force_refresh_bypasses_cache(db, monkeypatch):
+    other_listing = [{"name": "DC", "path": "DC", "type": "dir"}]
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, LISTING_JSON)),
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, other_listing)),
+    ])
+    service = CBLCatalogService(db)
+
+    first = run_async(service.browse(""))
+    second = run_async(service.browse("", force_refresh=True))
+
+    assert first["entries"][0]["name"] == "Marvel"
+    assert second["entries"][0]["name"] == "DC"
+
+
+def test_browse_404_raises_not_found(db, monkeypatch):
+    _patch_client_sequence(monkeypatch, [_FakeCatalogClient(get_response=_FakeGetResponse(404, {"message": "Not Found"}))])
+    service = CBLCatalogService(db)
+
+    with pytest.raises(CBLCatalogNotFoundError):
+        run_async(service.browse("Nonexistent"))
+
+
+def test_browse_rate_limit_raises_upstream_error(db, monkeypatch):
+    _patch_client_sequence(monkeypatch, [_FakeCatalogClient(get_response=_FakeGetResponse(403, {"message": "rate limited"}))])
+    service = CBLCatalogService(db)
+
+    with pytest.raises(CBLCatalogUpstreamError):
+        run_async(service.browse(""))
+
+
+def test_browse_network_error_raises_upstream_error(db, monkeypatch):
+    _patch_client_sequence(monkeypatch, [_FakeCatalogClient(raise_on_get=httpx.HTTPError("boom"))])
+    service = CBLCatalogService(db)
+
+    with pytest.raises(CBLCatalogUpstreamError):
+        run_async(service.browse(""))
+
+
+def test_browse_rejects_path_pointing_at_a_file(db, monkeypatch):
+    _patch_client_sequence(monkeypatch, [_FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON))])
+    service = CBLCatalogService(db)
+
+    with pytest.raises(CBLCatalogNotFoundError):
+        run_async(service.browse("Marvel/Infinity-Gauntlet.cbl"))
+
+
+def test_preview_returns_name_entry_count_and_warnings(db, monkeypatch):
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[VALID_CBL]),
+    ])
+    service = CBLCatalogService(db)
+
+    result = run_async(service.preview("Marvel/Infinity-Gauntlet.cbl"))
+
+    assert result["name"] == "Catalog Test List"
+    assert result["entry_count"] == 1
+    assert result["warnings"] == []
+
+
+def test_import_file_sets_catalog_origin_and_metadata(db, monkeypatch, tmp_path):
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", tmp_path / "cbl")
+
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[VALID_CBL]),
+    ])
+    service = CBLCatalogService(db)
+
+    source = run_async(service.import_file("Marvel/Infinity-Gauntlet.cbl"))
+    db.commit()
+
+    assert source.origin == "catalog"
+    assert source.catalog_provider == "dieseltech"
+    assert source.catalog_path == "Marvel/Infinity-Gauntlet.cbl"
+
+
+def test_fetch_raw_bytes_rejects_non_github_host(db):
+    service = CBLCatalogService(db)
+
+    with pytest.raises(CBLCatalogError, match="unexpected host"):
+        run_async(service._fetch_raw_bytes("https://evil.example.com/payload.cbl"))
+
+
+def test_refresh_source_success_updates_fingerprint_and_removes_old_file(db, tmp_path, monkeypatch):
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", tmp_path / "cbl")
+
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[VALID_CBL]),
+    ])
+    service = CBLCatalogService(db)
+    source = run_async(service.import_file("Marvel/Infinity-Gauntlet.cbl"))
+    db.commit()
+
+    old_path = Path(source.stored_path)
+    old_fingerprint = source.fingerprint
+    assert old_path.exists()
+
+    new_content = VALID_CBL.replace(b"Catalog Test List", b"Updated Catalog List")
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[new_content]),
+    ])
+
+    refreshed = run_async(service.refresh_source(source.id))
+    db.commit()
+
+    assert refreshed.last_refresh_status == "ok"
+    assert refreshed.fingerprint != old_fingerprint
+    assert not old_path.exists()
+    assert Path(refreshed.stored_path).read_bytes() == new_content
+
+
+def test_refresh_source_failure_keeps_last_good_state(db, tmp_path, monkeypatch):
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", tmp_path / "cbl")
+
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[VALID_CBL]),
+    ])
+    service = CBLCatalogService(db)
+    source = run_async(service.import_file("Marvel/Infinity-Gauntlet.cbl"))
+    db.commit()
+
+    original_fingerprint = source.fingerprint
+    original_path = Path(source.stored_path)
+
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(404, {"message": "Not Found"})),
+    ])
+
+    refreshed = run_async(service.refresh_source(source.id))
+    db.commit()
+
+    assert refreshed.last_refresh_status == "failed"
+    assert refreshed.fingerprint == original_fingerprint
+    assert original_path.exists()
+    assert original_path.read_bytes() == VALID_CBL
+
+
+def test_refresh_source_rejects_unparseable_content_and_preserves_last_good_file(db, tmp_path, monkeypatch):
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", tmp_path / "cbl")
+
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[VALID_CBL]),
+    ])
+    service = CBLCatalogService(db)
+    source = run_async(service.import_file("Marvel/Infinity-Gauntlet.cbl"))
+    db.commit()
+
+    original_fingerprint = source.fingerprint
+    original_path = Path(source.stored_path)
+
+    # Passes the cheap "looks like CBL/XML" sniff but is not well-formed XML.
+    broken_content = b'<?xml version="1.0"?><ReadingList><Name>Broken'
+    _patch_client_sequence(monkeypatch, [
+        _FakeCatalogClient(get_response=_FakeGetResponse(200, FILE_META_JSON)),
+        _FakeCatalogClient(stream_chunks=[broken_content]),
+    ])
+
+    refreshed = run_async(service.refresh_source(source.id))
+    db.commit()
+
+    assert refreshed.last_refresh_status == "failed"
+    assert refreshed.fingerprint == original_fingerprint
+    assert original_path.exists()
+    assert original_path.read_bytes() == VALID_CBL
+
+
+def test_refresh_source_rejects_non_catalog_origin(db, tmp_path, monkeypatch):
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", tmp_path / "cbl")
+
+    source = CBLSourceService(db).import_upload(VALID_CBL, "uploaded.cbl")
+    db.commit()
+
+    service = CBLCatalogService(db)
+    with pytest.raises(CBLSourceError, match="catalog path"):
+        run_async(service.refresh_source(source.id))
+
+
+def test_refresh_source_missing_id_raises_value_error(db):
+    service = CBLCatalogService(db)
+
+    with pytest.raises(ValueError):
+        run_async(service.refresh_source(999999))

--- a/tests/services/test_cbl_matching.py
+++ b/tests/services/test_cbl_matching.py
@@ -1,0 +1,174 @@
+import json
+
+from app.models.comic import Volume
+from app.models.series import Series
+from app.services.cbl_matching import match_cbl_entries
+from app.services.cbl_parser import CBLEntry
+from tests.factories import create_comic, create_library_with_root
+
+
+def _make_comic(db, library, series_name, *, number, volume_number=1, year=None, prefix):
+    series = Series(name=series_name, library=library)
+    volume = Volume(series=series, volume_number=volume_number)
+    db.add_all([series, volume])
+    db.flush()
+    comic = create_comic(
+        db,
+        volume,
+        library.active_root,
+        f"{prefix}.cbz",
+        number=number,
+        year=year,
+        filename=f"{prefix}.cbz",
+        page_count=1,
+    )
+    return comic
+
+
+def test_match_unique_metadata_with_volume_and_year(db, tmp_path):
+    library = create_library_with_root(db, "cbl-match-lib", str(tmp_path / "lib"))
+    comic = _make_comic(db, library, "Infinity Gauntlet", number="1", volume_number=1991, year=1991, prefix="ig-1")
+    db.commit()
+
+    entries = [CBLEntry(series="The Infinity Gauntlet", number="1", volume="1991", year="1991")]
+    result = match_cbl_entries(db, entries)
+
+    assert result.ordered_comic_ids == [comic.id]
+    assert result.matched[0].matched_by == "metadata"
+    assert result.unmatched == []
+
+
+def test_match_falls_back_to_relaxed_when_entry_missing_volume_or_year(db, tmp_path):
+    library = create_library_with_root(db, "cbl-relaxed-lib", str(tmp_path / "lib"))
+    comic = _make_comic(db, library, "Silver Surfer", number="34", volume_number=1987, year=1990, prefix="ss-34")
+    db.commit()
+
+    # No Volume/Year on the CBL entry -- can't use the strict tier at all.
+    entries = [CBLEntry(series="Silver Surfer", number="34")]
+    result = match_cbl_entries(db, entries)
+
+    assert result.ordered_comic_ids == [comic.id]
+    assert result.matched[0].matched_by == "relaxed_metadata"
+
+
+def test_match_falls_back_to_relaxed_when_comic_missing_year(db, tmp_path):
+    library = create_library_with_root(db, "cbl-no-year-lib", str(tmp_path / "lib"))
+    # Comic has no year -- can never populate the strict index for this row.
+    comic = _make_comic(db, library, "No Year Series", number="5", volume_number=1, year=None, prefix="ny-5")
+    db.commit()
+
+    entries = [CBLEntry(series="No Year Series", number="5", volume="1", year="2020")]
+    result = match_cbl_entries(db, entries)
+
+    assert result.ordered_comic_ids == [comic.id]
+    assert result.matched[0].matched_by == "relaxed_metadata"
+
+
+def test_match_uses_metadata_year_tier_when_volume_tagging_conventions_differ(db, tmp_path):
+    library = create_library_with_root(db, "cbl-sequential-volume-lib", str(tmp_path / "lib"))
+    # Locally tagged with a sequential volume number (1, 2, 3...), not a start year --
+    # a real-world convention mismatch against CBL files, which use Volume="1991"
+    # (year-style) here. Strict tier can't agree on volume, but year alone still does.
+    comic = _make_comic(
+        db, library, "Infinity Gauntlet", number="1", volume_number=1, year=1991, prefix="ig-seq-1"
+    )
+    db.commit()
+
+    entries = [CBLEntry(series="Infinity Gauntlet", number="1", volume="1991", year="1991")]
+    result = match_cbl_entries(db, entries)
+
+    assert result.ordered_comic_ids == [comic.id]
+    assert result.matched[0].matched_by == "metadata_year"
+
+
+def test_match_ambiguous_at_metadata_year_tier_does_not_fall_through_to_relaxed(db, tmp_path):
+    library = create_library_with_root(db, "cbl-ambiguous-year-lib", str(tmp_path / "lib"))
+    # Two different volumes (reboots) sharing series + number + year -- exactly the
+    # case tier 2 exists to disambiguate, but here it genuinely can't.
+    _make_comic(db, library, "Ambig Year", number="1", volume_number=1, year=2020, prefix="ambig-year-a")
+    _make_comic(db, library, "Ambig Year", number="1", volume_number=2, year=2020, prefix="ambig-year-b")
+    db.commit()
+
+    entries = [CBLEntry(series="Ambig Year", number="1", year="2020")]
+    result = match_cbl_entries(db, entries)
+
+    assert result.ordered_comic_ids == []
+    assert result.unmatched[0].reason == "ambiguous"
+
+
+def test_match_reports_ambiguous_when_multiple_comics_share_strict_key(db, tmp_path):
+    library = create_library_with_root(db, "cbl-ambiguous-lib", str(tmp_path / "lib"))
+    _make_comic(db, library, "Dupes", number="1", volume_number=2020, year=2020, prefix="dupe-a")
+    _make_comic(db, library, "Dupes", number="1", volume_number=2020, year=2020, prefix="dupe-b")
+    db.commit()
+
+    entries = [CBLEntry(series="Dupes", number="1", volume="2020", year="2020")]
+    result = match_cbl_entries(db, entries)
+
+    assert result.ordered_comic_ids == []
+    assert result.unmatched[0].reason == "ambiguous"
+
+
+def test_match_reports_unmatched_when_no_comic_found(db, tmp_path):
+    entries = [CBLEntry(series="Nonexistent Series", number="99")]
+    result = match_cbl_entries(db, entries)
+
+    assert result.ordered_comic_ids == []
+    assert result.unmatched[0].reason == "unmatched"
+
+
+def test_match_reports_duplicate_target_when_two_entries_resolve_to_same_comic(db, tmp_path):
+    library = create_library_with_root(db, "cbl-dup-target-lib", str(tmp_path / "lib"))
+    comic = _make_comic(db, library, "Solo Series", number="1", volume_number=1, year=2000, prefix="solo-1")
+    db.commit()
+
+    # Two differently-specified entries that both resolve to the same underlying comic.
+    entries = [
+        CBLEntry(series="Solo Series", number="1", volume="1", year="2000"),
+        CBLEntry(series="Solo Series", number="1"),
+    ]
+    result = match_cbl_entries(db, entries)
+
+    assert result.ordered_comic_ids == [comic.id]
+    assert len(result.unmatched) == 1
+    assert result.unmatched[0].reason == "duplicate_target"
+
+
+def test_match_preserves_entry_order_in_ordered_comic_ids(db, tmp_path):
+    library = create_library_with_root(db, "cbl-order-lib", str(tmp_path / "lib"))
+    c1 = _make_comic(db, library, "Order Series", number="2", volume_number=1, year=2000, prefix="order-2")
+    c2 = _make_comic(db, library, "Order Series", number="1", volume_number=1, year=2000, prefix="order-1")
+    db.commit()
+
+    entries = [
+        CBLEntry(series="Order Series", number="2", volume="1", year="2000"),
+        CBLEntry(series="Order Series", number="1", volume="1", year="2000"),
+    ]
+    result = match_cbl_entries(db, entries)
+
+    assert result.ordered_comic_ids == [c1.id, c2.id]
+
+
+def test_summary_json_reports_counts_and_sample():
+    from app.services.cbl_matching import CBLMatchResult, CBLMatchedEntry, CBLUnmatchedEntry
+
+    result = CBLMatchResult(
+        matched=[
+            CBLMatchedEntry(entry=CBLEntry(series="A", number="1"), comic_id=1, matched_by="metadata"),
+            CBLMatchedEntry(entry=CBLEntry(series="B", number="2"), comic_id=2, matched_by="metadata_year"),
+            CBLMatchedEntry(entry=CBLEntry(series="E", number="5"), comic_id=3, matched_by="relaxed_metadata"),
+        ],
+        unmatched=[
+            CBLUnmatchedEntry(entry=CBLEntry(series="C", number="3"), reason="unmatched"),
+            CBLUnmatchedEntry(entry=CBLEntry(series="D", number="4"), reason="ambiguous"),
+        ],
+    )
+
+    payload = json.loads(result.summary_json())
+    assert payload["matched_by_metadata"] == 1
+    assert payload["matched_by_metadata_year"] == 1
+    assert payload["matched_by_relaxed_metadata"] == 1
+    assert payload["unmatched"] == 1
+    assert payload["ambiguous"] == 1
+    assert payload["duplicate_target"] == 0
+    assert "C #3 (unmatched)" in payload["sample_unmatched"]

--- a/tests/services/test_cbl_parser.py
+++ b/tests/services/test_cbl_parser.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+import pytest
+
+from app.services.cbl_parser import CBLParseError, parse_cbl
+
+FIXTURES = Path(__file__).parent.parent / "fixtures" / "cbl"
+
+
+def _load(name: str) -> bytes:
+    return (FIXTURES / name).read_bytes()
+
+
+def test_parse_valid_cbl_reads_name_summary_and_ordered_entries():
+    result = parse_cbl(_load("valid.cbl"), filename_stem="valid")
+
+    assert result.name == "Infinity Gauntlet"
+    assert result.description == "The original Infinity Gauntlet crossover reading order."
+    assert result.warnings == []
+    assert [e.series for e in result.entries] == ["Silver Surfer", "Infinity Gauntlet", "Infinity Gauntlet"]
+    assert [e.number for e in result.entries] == ["34", "1", "2"]
+
+
+def test_parse_falls_back_to_filename_stem_when_name_missing():
+    result = parse_cbl(_load("missing_name.cbl"), filename_stem="missing_name")
+
+    assert result.name == "missing_name"
+    assert len(result.entries) == 1
+
+
+def test_parse_preserves_half_issue_glyph_from_numeric_entity():
+    result = parse_cbl(_load("half_issue.cbl"), filename_stem="half_issue")
+
+    assert [e.number for e in result.entries] == ["1", "½"]
+
+
+def test_parse_malformed_xml_raises_cbl_parse_error():
+    with pytest.raises(CBLParseError):
+        parse_cbl(_load("malformed.cbl"), filename_stem="malformed")
+
+
+def test_parse_ignores_unknown_fields_and_nested_matcher():
+    result = parse_cbl(_load("unknown_fields.cbl"), filename_stem="unknown_fields")
+
+    assert result.name == "Unknown Fields Test"
+    assert len(result.entries) == 1
+    entry = result.entries[0]
+    assert entry.series == "Silver Surfer"
+    assert entry.number == "34"
+    assert entry.volume == "1987"
+    assert entry.year == "1990"
+    assert entry.format == "TPB"
+
+
+def test_parse_warns_and_skips_book_with_no_identifying_attributes():
+    xml = b"""<?xml version="1.0"?>
+    <ReadingList>
+      <Name>No Identity</Name>
+      <Books>
+        <Book Format="TPB" />
+      </Books>
+    </ReadingList>"""
+
+    result = parse_cbl(xml, filename_stem="no_identity")
+
+    assert result.entries == []
+    assert any("no Series or Number" in w for w in result.warnings)
+    assert any("no usable" in w for w in result.warnings)
+
+
+def test_parse_hardened_parser_does_not_expand_internal_entity():
+    xml = b"""<?xml version="1.0"?>
+    <!DOCTYPE ReadingList [
+      <!ENTITY xxe "INJECTED">
+    ]>
+    <ReadingList>
+      <Name>&xxe;</Name>
+      <Books><Book Series="A" Number="1" /></Books>
+    </ReadingList>"""
+
+    result = parse_cbl(xml, filename_stem="xxe_test")
+
+    assert result.name != "INJECTED"

--- a/tests/services/test_cbl_source_service.py
+++ b/tests/services/test_cbl_source_service.py
@@ -1,0 +1,371 @@
+from pathlib import Path
+
+import httpx
+import pytest
+
+import app.services.cbl_source_service as cbl_source_service_module
+from app.services.cbl_source_service import CBLSourceError, CBLSourceService, _pin_url_to_address
+from app.models.cbl_source import CBLSource
+from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.comic import Volume
+from app.models.series import Series
+from tests.async_helpers import run_async
+from tests.factories import create_comic, create_library_with_root
+
+VALID_CBL = (
+    b'<?xml version="1.0"?><ReadingList><Name>Test List</Name>'
+    b'<Books><Book Series="A" Number="1" /></Books></ReadingList>'
+)
+
+
+class _FakeResponse:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _FakeStreamCtx:
+    def __init__(self, response):
+        self._response = response
+
+    async def __aenter__(self):
+        return self._response
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeAsyncClient:
+    def __init__(self, chunks=None, raise_on_stream=None):
+        self._chunks = chunks or []
+        self._raise_on_stream = raise_on_stream
+        self.stream_calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def stream(self, method, url, headers=None, extensions=None):
+        self.stream_calls.append({"method": method, "url": url, "headers": headers, "extensions": extensions})
+        if self._raise_on_stream:
+            raise self._raise_on_stream
+        return _FakeStreamCtx(_FakeResponse(self._chunks))
+
+
+def _patch_fake_client(monkeypatch, chunks=None, raise_on_stream=None):
+    created = []
+
+    def factory(*a, **kw):
+        client = _FakeAsyncClient(chunks=chunks, raise_on_stream=raise_on_stream)
+        created.append(client)
+        return client
+
+    monkeypatch.setattr(cbl_source_service_module.httpx, "AsyncClient", factory)
+    return created
+
+
+def _patch_cbl_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", tmp_path / "cbl")
+
+
+FAKE_SAFE_ADDRESS = "203.0.113.5"
+
+
+@pytest.fixture(autouse=True)
+def _skip_host_check(monkeypatch):
+    """Most tests exercise validation/storage logic, not real DNS -- bypass the
+    host-safety/resolution check by default; specific tests re-enable it explicitly."""
+    monkeypatch.setattr(
+        CBLSourceService, "_resolve_safe_addresses", lambda self, host: [FAKE_SAFE_ADDRESS]
+    )
+
+
+def test_import_upload_success_writes_file_and_creates_source(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    service = CBLSourceService(db)
+
+    source = service.import_upload(VALID_CBL, "my-event.cbl")
+    db.commit()
+
+    assert source.id is not None
+    assert source.origin == "upload"
+    assert source.display_name == "my-event"
+    assert Path(source.stored_path).exists()
+    assert Path(source.stored_path).read_bytes() == VALID_CBL
+
+
+def test_import_upload_sets_catalog_fields_when_provided(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    service = CBLSourceService(db)
+
+    source = service.import_upload(
+        VALID_CBL, "catalog-file.cbl",
+        origin="catalog", catalog_provider="dieseltech", catalog_path="Marvel/catalog-file.cbl",
+    )
+    db.commit()
+
+    assert source.origin == "catalog"
+    assert source.catalog_provider == "dieseltech"
+    assert source.catalog_path == "Marvel/catalog-file.cbl"
+
+
+def test_import_upload_rejects_duplicate_fingerprint(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    service = CBLSourceService(db)
+    service.import_upload(VALID_CBL, "first.cbl")
+    db.commit()
+
+    with pytest.raises(CBLSourceError, match="already imported"):
+        service.import_upload(VALID_CBL, "second.cbl")
+
+
+def test_import_upload_rejects_bad_extension(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    service = CBLSourceService(db)
+
+    with pytest.raises(CBLSourceError, match="extension"):
+        service.import_upload(VALID_CBL, "not-a-cbl.txt")
+
+
+def test_import_upload_rejects_oversized_file(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(cbl_source_service_module, "MAX_CBL_SIZE_BYTES", 10)
+    service = CBLSourceService(db)
+
+    with pytest.raises(CBLSourceError, match="too large"):
+        service.import_upload(VALID_CBL, "big.cbl")
+
+
+def test_import_upload_rejects_non_xml_content(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    service = CBLSourceService(db)
+
+    with pytest.raises(CBLSourceError, match="does not look like"):
+        service.import_upload(b"just some text, not xml", "fake.cbl")
+
+
+def test_import_url_rejects_non_https(db):
+    service = CBLSourceService(db)
+    with pytest.raises(CBLSourceError, match="https"):
+        run_async(service.import_url("http://example.com/list.cbl"))
+
+
+def test_import_url_rejects_loopback_host(db, monkeypatch):
+    monkeypatch.undo()  # restore the real _resolve_safe_addresses for this test only
+    service = CBLSourceService(db)
+    with pytest.raises(CBLSourceError, match="non-public"):
+        run_async(service.import_url("https://127.0.0.1/list.cbl"))
+
+
+def test_import_url_success_downloads_and_stores(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    _patch_fake_client(monkeypatch, chunks=[VALID_CBL])
+    service = CBLSourceService(db)
+
+    source = run_async(service.import_url("https://example.com/events/list.cbl"))
+    db.commit()
+
+    assert source.origin == "url"
+    assert source.source_url == "https://example.com/events/list.cbl"
+    assert Path(source.stored_path).read_bytes() == VALID_CBL
+
+
+def test_import_url_pins_connection_to_resolved_address(db, tmp_path, monkeypatch):
+    """
+    The actual HTTP request must target the pre-validated IP (not let httpx
+    re-resolve the hostname independently), with the real hostname preserved
+    via the Host header and sni_hostname extension for TLS/virtual hosting --
+    this is the fix for the DNS-rebinding TOCTOU gap between the safety check
+    and the real connection.
+    """
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    created_clients = _patch_fake_client(monkeypatch, chunks=[VALID_CBL])
+    service = CBLSourceService(db)
+
+    run_async(service.import_url("https://example.com/events/list.cbl"))
+
+    assert len(created_clients) == 1
+    call = created_clients[0].stream_calls[0]
+    assert call["url"] == f"https://{FAKE_SAFE_ADDRESS}/events/list.cbl"
+    assert call["headers"] == {"Host": "example.com"}
+    assert call["extensions"] == {"sni_hostname": "example.com"}
+
+
+def test_pin_url_to_address_ipv4_rewrites_host_only():
+    assert _pin_url_to_address("https://example.com/path?q=1", "203.0.113.5") == "https://203.0.113.5/path?q=1"
+
+
+def test_pin_url_to_address_preserves_explicit_port():
+    assert _pin_url_to_address("https://example.com:8443/x", "203.0.113.5") == "https://203.0.113.5:8443/x"
+
+
+def test_pin_url_to_address_ipv6_is_bracketed():
+    assert _pin_url_to_address("https://example.com/x", "2001:db8::1") == "https://[2001:db8::1]/x"
+
+
+def test_import_url_enforces_size_cap(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    monkeypatch.setattr(cbl_source_service_module, "MAX_CBL_SIZE_BYTES", 10)
+    _patch_fake_client(monkeypatch, chunks=[VALID_CBL])
+    service = CBLSourceService(db)
+
+    with pytest.raises(CBLSourceError, match="exceeds maximum size"):
+        run_async(service.import_url("https://example.com/big.cbl"))
+
+    assert db.query(CBLSource).count() == 0
+
+
+def test_refresh_failure_does_not_touch_existing_reading_list(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    service = CBLSourceService(db)
+    _patch_fake_client(monkeypatch, chunks=[VALID_CBL])
+    source = run_async(service.import_url("https://example.com/list.cbl"))
+
+    library = create_library_with_root(db, "cbl-refresh-lib", str(tmp_path / "lib"))
+    series = Series(name="cbl-refresh-series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+    comic = create_comic(db, volume, library.active_root, "issue.cbz", number="1", filename="issue.cbz", page_count=1)
+
+    reading_list = ReadingList(name="CBL Refresh List", source="cbl", source_cbl_id=source.id)
+    db.add(reading_list)
+    db.flush()
+    db.add(ReadingListItem(reading_list_id=reading_list.id, comic_id=comic.id, position=1))
+    db.commit()
+
+    original_fingerprint = source.fingerprint
+
+    _patch_fake_client(monkeypatch, raise_on_stream=httpx.HTTPError("network exploded"))
+    refreshed = run_async(service.refresh(source.id))
+    db.commit()
+
+    assert refreshed.last_refresh_status == "failed"
+    assert refreshed.fingerprint == original_fingerprint
+    assert db.query(ReadingList).filter(ReadingList.id == reading_list.id).count() == 1
+    assert db.query(ReadingListItem).filter(ReadingListItem.reading_list_id == reading_list.id).count() == 1
+
+
+def test_refresh_success_updates_fingerprint_and_removes_old_file(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    _patch_fake_client(monkeypatch, chunks=[VALID_CBL])
+    service = CBLSourceService(db)
+    source = run_async(service.import_url("https://example.com/list.cbl"))
+    db.commit()
+
+    old_path = Path(source.stored_path)
+    old_fingerprint = source.fingerprint
+    assert old_path.exists()
+
+    new_content = VALID_CBL.replace(b"Test List", b"Updated List")
+    _patch_fake_client(monkeypatch, chunks=[new_content])
+
+    refreshed = run_async(service.refresh(source.id))
+    db.commit()
+
+    assert refreshed.last_refresh_status == "ok"
+    assert refreshed.fingerprint != old_fingerprint
+    assert not old_path.exists()
+    assert Path(refreshed.stored_path).read_bytes() == new_content
+
+
+def test_refresh_rejects_unparseable_content_and_preserves_last_good_file(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    _patch_fake_client(monkeypatch, chunks=[VALID_CBL])
+    service = CBLSourceService(db)
+    source = run_async(service.import_url("https://example.com/list.cbl"))
+    db.commit()
+
+    old_path = Path(source.stored_path)
+    old_fingerprint = source.fingerprint
+    assert old_path.exists()
+
+    # Passes the cheap "looks like CBL/XML" sniff (starts with <?xml, has
+    # <ReadingList) but is not well-formed XML -- parse_cbl must reject it.
+    broken_content = b'<?xml version="1.0"?><ReadingList><Name>Broken'
+    _patch_fake_client(monkeypatch, chunks=[broken_content])
+
+    refreshed = run_async(service.refresh(source.id))
+    db.commit()
+
+    assert refreshed.last_refresh_status == "failed"
+    assert refreshed.fingerprint == old_fingerprint
+    assert old_path.exists()
+    assert old_path.read_bytes() == VALID_CBL
+
+
+def test_rebuild_creates_reading_list_from_matched_entries(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    library = create_library_with_root(db, "cbl-rebuild-lib", str(tmp_path / "lib"))
+    series = Series(name="Rebuild Series", library=library)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+    comic = create_comic(
+        db, volume, library.active_root, "rebuild-1.cbz",
+        number="1", filename="rebuild-1.cbz", page_count=1,
+    )
+    db.commit()
+
+    cbl_content = (
+        b'<?xml version="1.0"?><ReadingList><Name>Rebuild Event</Name>'
+        b'<Books><Book Series="Rebuild Series" Number="1" /></Books></ReadingList>'
+    )
+    service = CBLSourceService(db)
+    source = service.import_upload(cbl_content, "rebuild-event.cbl")
+    db.commit()
+
+    rebuilt = service.rebuild(source.id)
+    db.commit()
+
+    assert rebuilt.entry_count == 1
+    reading_list = db.query(ReadingList).filter(ReadingList.source_cbl_id == source.id).first()
+    assert reading_list is not None
+    assert reading_list.name == "Rebuild Event"
+    assert reading_list.source == "cbl"
+    items = db.query(ReadingListItem).filter(ReadingListItem.reading_list_id == reading_list.id).all()
+    assert [item.comic_id for item in items] == [comic.id]
+
+
+def test_rebuild_records_parse_error_without_raising(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    service = CBLSourceService(db)
+    source = service.import_upload(VALID_CBL, "will-corrupt.cbl")
+    db.commit()
+
+    # Corrupt the stored file on disk after import to simulate a broken file.
+    Path(source.stored_path).write_bytes(b"<ReadingList><Name>Broken")
+
+    rebuilt = service.rebuild(source.id)
+    db.commit()
+
+    assert "error" in rebuilt.last_match_summary
+    assert db.query(ReadingList).filter(ReadingList.source_cbl_id == source.id).count() == 0
+
+
+def test_delete_removes_file_reading_list_and_row(db, tmp_path, monkeypatch):
+    _patch_cbl_dir(monkeypatch, tmp_path)
+    service = CBLSourceService(db)
+    source = service.import_upload(VALID_CBL, "delete-me.cbl")
+    db.commit()
+
+    reading_list = ReadingList(name="Delete Me CBL List", source="cbl", source_cbl_id=source.id)
+    db.add(reading_list)
+    db.commit()
+
+    stored_path = Path(source.stored_path)
+    assert stored_path.exists()
+
+    service.delete(source.id)
+
+    assert not stored_path.exists()
+    assert db.query(CBLSource).filter(CBLSource.id == source.id).count() == 0
+    assert db.query(ReadingList).filter(ReadingList.id == reading_list.id).count() == 0

--- a/tests/services/test_generated_container_services.py
+++ b/tests/services/test_generated_container_services.py
@@ -1,6 +1,7 @@
 from app.models import (
     CollectionItem,
     Comic,
+    ReadingList,
     ReadingListItem,
     Series,
     Volume,
@@ -139,3 +140,58 @@ def test_update_comic_reading_lists_clears_membership_when_number_is_invalid(db)
     db.commit()
 
     assert db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).count() == 0
+
+
+def test_update_comic_reading_lists_skips_when_name_collides_with_manual_list(db):
+    comic = _create_comic(db, "list-collision")
+    manual_list = ReadingList(name="Crisis", source="manual")
+    db.add(manual_list)
+    db.commit()
+
+    service = ReadingListService(db)
+    service.update_comic_reading_lists(comic, "Crisis", "1")
+    db.commit()
+
+    # The comic gets no membership at all -- it must not be silently written
+    # into the manual list, and no second "Crisis" list gets created either
+    # (ComicInfo-derived names are never renamed/disambiguated).
+    assert db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic.id).count() == 0
+    lists = db.query(ReadingList).filter(ReadingList.name == "Crisis").all()
+    assert len(lists) == 1
+    assert lists[0].id == manual_list.id
+    assert lists[0].source == "manual"
+
+
+def test_update_comic_reading_lists_skips_repeated_collision_via_cache(db):
+    comic_a = _create_comic(db, "list-collision-a")
+    comic_b = _create_comic(db, "list-collision-b")
+    db.add(ReadingList(name="Crisis", source="manual"))
+    db.commit()
+
+    service = ReadingListService(db)
+    service.update_comic_reading_lists(comic_a, "Crisis", "1")
+    service.update_comic_reading_lists(comic_b, "Crisis", "2")
+    db.commit()
+
+    assert db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic_a.id).count() == 0
+    assert db.query(ReadingListItem).filter(ReadingListItem.comic_id == comic_b.id).count() == 0
+    assert db.query(ReadingList).filter(ReadingList.name == "Crisis").count() == 1
+
+
+def test_cleanup_empty_lists_only_removes_comicinfo_lists(db):
+    manual_empty = ReadingList(name="Manual Empty", source="manual")
+    cbl_empty = ReadingList(name="CBL Empty", source="cbl")
+    comicinfo_empty = ReadingList(name="Comicinfo Empty", source="comicinfo")
+    db.add_all([manual_empty, cbl_empty, comicinfo_empty])
+    db.commit()
+
+    service = ReadingListService(db)
+    service.cleanup_empty_lists()
+    db.commit()
+
+    # CBL list lifecycle is owned by CBLSourceService.rebuild()/delete() --
+    # deleting an empty one here (e.g. from a rehydrate pass that never
+    # rebuilds CBL sources) would orphan its CBLSource until the next scan.
+    assert db.query(ReadingList).filter(ReadingList.id == manual_empty.id).count() == 1
+    assert db.query(ReadingList).filter(ReadingList.id == cbl_empty.id).count() == 1
+    assert db.query(ReadingList).filter(ReadingList.id == comicinfo_empty.id).count() == 0

--- a/tests/services/test_maintenance_service.py
+++ b/tests/services/test_maintenance_service.py
@@ -85,9 +85,10 @@ def test_cleanup_orphans_global_removes_only_orphans(db, tmp_path):
     person_keep = Person(name="person-keep")
     person_orphan = Person(name="person-orphan")
 
-    rl_auto_empty = ReadingList(name="rl-auto-empty", auto_generated=1)
-    rl_manual_empty = ReadingList(name="rl-manual-empty", auto_generated=0)
-    rl_auto_filled = ReadingList(name="rl-auto-filled", auto_generated=1)
+    rl_auto_empty = ReadingList(name="rl-auto-empty", source="comicinfo")
+    rl_manual_empty = ReadingList(name="rl-manual-empty", source="manual")
+    rl_auto_filled = ReadingList(name="rl-auto-filled", source="comicinfo")
+    rl_cbl_empty = ReadingList(name="rl-cbl-empty", source="cbl")
 
     col_auto_empty = Collection(name="col-auto-empty", auto_generated=1)
     col_manual_empty = Collection(name="col-manual-empty", auto_generated=0)
@@ -111,6 +112,7 @@ def test_cleanup_orphans_global_removes_only_orphans(db, tmp_path):
         rl_auto_empty,
         rl_manual_empty,
         rl_auto_filled,
+        rl_cbl_empty,
         col_auto_empty,
         col_manual_empty,
         col_auto_filled,
@@ -151,6 +153,10 @@ def test_cleanup_orphans_global_removes_only_orphans(db, tmp_path):
     assert db.query(ReadingList).filter(ReadingList.name == "rl-auto-empty").count() == 0
     assert db.query(ReadingList).filter(ReadingList.name == "rl-manual-empty").count() == 1
     assert db.query(ReadingList).filter(ReadingList.name == "rl-auto-filled").count() == 1
+    # Empty CBL lists must survive this generic cleanup too -- CBL list lifecycle
+    # is owned by CBLSourceService.rebuild()/delete(), and nothing here rebuilds
+    # CBL sources afterward, so deleting an empty one here would orphan it.
+    assert db.query(ReadingList).filter(ReadingList.name == "rl-cbl-empty").count() == 1
 
     assert db.query(Collection).filter(Collection.name == "col-auto-empty").count() == 0
     assert db.query(Collection).filter(Collection.name == "col-manual-empty").count() == 1
@@ -454,7 +460,7 @@ def test_cleanup_orphaned_thumbnails_deletes_unreferenced_and_logs_errors(db, tm
 
 
 def test_refresh_reading_list_descriptions_batches_and_commits(db, monkeypatch):
-    lists = [ReadingList(name=f"auto-{i}", auto_generated=1, description=None) for i in range(52)]
+    lists = [ReadingList(name=f"auto-{i}", source="comicinfo", description=None) for i in range(52)]
     db.add_all(lists)
     db.commit()
 
@@ -474,9 +480,9 @@ def test_refresh_reading_list_descriptions_batches_and_commits(db, monkeypatch):
 
 def test_refresh_reading_list_descriptions_no_updates(db, monkeypatch):
     db.add_all([
-        ReadingList(name="same-a", auto_generated=1, description="desc-same-a"),
-        ReadingList(name="same-b", auto_generated=1, description="desc-same-b"),
-        ReadingList(name="none-c", auto_generated=1, description="existing"),
+        ReadingList(name="same-a", source="comicinfo", description="desc-same-a"),
+        ReadingList(name="same-b", source="comicinfo", description="desc-same-b"),
+        ReadingList(name="none-c", source="comicinfo", description="existing"),
     ])
     db.commit()
 

--- a/tests/services/test_scanner_cbl.py
+++ b/tests/services/test_scanner_cbl.py
@@ -1,0 +1,99 @@
+import hashlib
+from unittest.mock import MagicMock
+
+from app.models.cbl_source import CBLSource
+from app.models.comic import Volume
+from app.models.reading_list import ReadingList, ReadingListItem
+from app.models.series import Series
+from app.services.scanner import LibraryScanner
+import app.services.cbl_source_service as cbl_source_service_module
+from tests.factories import create_comic, create_library_with_root
+
+VALID_CBL = (
+    b'<?xml version="1.0"?><ReadingList><Name>Scanner CBL Event</Name>'
+    b'<Books><Book Series="Scanner Series" Number="1" /></Books></ReadingList>'
+)
+
+
+def _build_scanner(db, tmp_path, *, name="scanner-cbl-lib"):
+    library = create_library_with_root(db, name, str(tmp_path))
+    db.commit()
+
+    scanner = LibraryScanner(library, db)
+    scanner.reading_list_service.cleanup_empty_lists = MagicMock()
+    scanner.collection_service.cleanup_empty_collections = MagicMock()
+
+    return scanner, library
+
+
+def test_scan_parallel_discovers_and_imports_library_root_cbl_file(db, tmp_path, monkeypatch):
+    managed_dir = tmp_path / "cbl_managed"
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", managed_dir)
+
+    scanner, library = _build_scanner(db, tmp_path)
+
+    events_dir = tmp_path / "Events"
+    events_dir.mkdir()
+    (events_dir / "test-event.cbl").write_bytes(VALID_CBL)
+
+    result = scanner.scan_parallel(force=False, worker_limit=1)
+
+    assert result["errors"] == 0
+    sources = db.query(CBLSource).all()
+    assert len(sources) == 1
+    assert sources[0].origin == "library_import"
+    assert sources[0].original_filename == "Events/test-event.cbl"
+    assert managed_dir.exists()
+
+    # Re-scanning must not re-import the same file as a duplicate source.
+    scanner.scan_parallel(force=False, worker_limit=1)
+    assert db.query(CBLSource).count() == 1
+
+
+def test_scan_parallel_rebuilds_existing_cbl_sources_after_scan(db, tmp_path, monkeypatch):
+    managed_dir = tmp_path / "cbl_managed"
+    managed_dir.mkdir(parents=True)
+    monkeypatch.setattr(cbl_source_service_module.settings, "cbl_dir", managed_dir)
+
+    scanner, library = _build_scanner(db, tmp_path)
+    root = library.active_root
+
+    series = Series(name="Scanner Series", library_id=library.id)
+    volume = Volume(series=series, volume_number=1)
+    db.add_all([series, volume])
+    db.flush()
+
+    comic_path = tmp_path / "scanner-1.cbz"
+    comic_path.write_bytes(b"x")
+    future_mtime = comic_path.stat().st_mtime + 60
+    comic = create_comic(
+        db, volume, root, "scanner-1.cbz",
+        number="1", filename="scanner-1.cbz",
+        file_modified_at=future_mtime, page_count=10,
+    )
+
+    fingerprint = hashlib.sha256(VALID_CBL).hexdigest()
+    stored_path = managed_dir / f"{fingerprint}.cbl"
+    stored_path.write_bytes(VALID_CBL)
+    cbl_source = CBLSource(
+        display_name="Scanner CBL Event",
+        stored_path=str(stored_path),
+        original_filename="scanner-event.cbl",
+        origin="upload",
+        fingerprint=fingerprint,
+        last_refresh_status="never",
+    )
+    db.add(cbl_source)
+    db.commit()
+
+    result = scanner.scan_parallel(force=False, worker_limit=1)
+
+    assert result["skipped"] == 1  # comic unchanged -- no multiprocessing writer invoked
+    db.refresh(cbl_source)
+    assert cbl_source.entry_count == 1
+
+    reading_list = db.query(ReadingList).filter(ReadingList.source_cbl_id == cbl_source.id).first()
+    assert reading_list is not None
+    assert reading_list.name == "Scanner CBL Event"
+    items = db.query(ReadingListItem).filter(ReadingListItem.reading_list_id == reading_list.id).all()
+    assert [item.comic_id for item in items] == [comic.id]

--- a/tests/services/test_scanner_parallel.py
+++ b/tests/services/test_scanner_parallel.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import sessionmaker
 import app.services.scanner as scanner_module
 from app.database import Base
 from app.models import (
+    CBLSource,
     Collection,
     CollectionItem,
     Comic,
@@ -41,6 +42,8 @@ class DummyQuery:
     def all(self):
         if self._model is LibraryRoot:
             return list(self._library_roots)
+        if self._model is CBLSource:
+            return []
         return list(self._existing)
 
     def first(self):


### PR DESCRIPTION

Adds first-class CBL reading list support to Parker.

This introduces Parker-managed CBL sources as a new reading-list companion alongside manual lists and ComicInfo-derived auto-generated lists. Admins can now upload CBL files, import them from direct HTTPS URLs, browse/import from the DieselTech/CBL-ReadingLists catalog, refresh managed sources, rename derived reading lists, and delete CBL sources cleanly through a dedicated admin path.

CBL files are stored in Parker-managed storage rather than inside comic series folders, since events often span multiple titles and libraries.

## Added

- Added `cbl_sources` persistence model and Alembic migration.
- Replaced the old reading-list `auto_generated` boolean with explicit `source` provenance:
  - `manual`
  - `comicinfo`
  - `cbl`
- Added CBL parser, matcher, source service, and catalog service.
- Added admin APIs for:
  - Uploading CBL files.
  - Importing CBL files from HTTPS URLs.
  - Listing CBL sources.
  - Refreshing URL/catalog-backed CBL sources.
  - Deleting CBL sources and their derived reading lists.
- Added DieselTech catalog browsing/import support using the GitHub contents API.
- Added admin UI for managing CBL reading list sources.
- Added CBL-derived reading-list labels in the UI.
- Added support for scanner rebuild/rematch of existing CBL sources after library scans.
- Added safe remote URL fetching protections:
  - HTTPS-only.
  - Public-address DNS validation.
  - Connection pinned to a prevalidated resolved address.
  - Redirects disabled.
  - File size cap enforced while streaming.

## Changed

- Reading list generation is now source-aware so ComicInfo-derived lists do not collide with manual or CBL-derived lists.
- ComicInfo reading-list sync now only owns `source="comicinfo"` memberships.
- Empty generated reading-list cleanup is scoped to ComicInfo lists only.
- CBL list lifecycle is owned by `CBLSourceService`, so generic reading-list cleanup/delete paths do not orphan CBL sources.
- Generic reading-list deletion is now admin-only.
- Generic reading-list deletion rejects CBL-derived lists and directs callers to delete the CBL source instead.
- Refresh handling preserves the last good CBL file when remote/catalog refresh fails or returns malformed content.
- README/docs updated to describe CBL support and the dedicated CBL storage model.

## Fixed / Guardrails

- Prevented generated ComicInfo lists from writing into existing manual/CBL lists with the same name.
- Prevented non-admin users from deleting reading lists.
- Prevented catalog-imported CBL sources from becoming non-refreshable by refreshing through catalog provider/path metadata.
- Closed the DNS rebinding window in direct URL imports by pinning fetches to validated resolved addresses.
- Prevented malformed refreshed CBL content from replacing the last good stored CBL file.
- Prevented generic empty-list cleanup from deleting CBL-derived reading lists.
- Prevented generic reading-list deletion from orphaning CBL sources.

## Validation

- Full `pytest` suite passed.
- Expected result: `1 skipped`, known `4 warnings`.
- Focused CBL/reading-list validation also passed during development.
- Alembic checked with a single migration head:
  - `6601fdcd204e`