### PR TITLE
Removes Parker’s legacy first-run `admin` / `admin` bootstrap path 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ PARKER_PORT=8000
 # Generate a unique value with: openssl rand -hex 32
 SECRET_KEY=
 
+# Initial admin bootstrap
+# INITIAL_ADMIN_PASSWORD is required only when Parker starts without an active admin.
+# After the first admin exists, Parker ignores these values.
+INITIAL_ADMIN_USERNAME=admin
+INITIAL_ADMIN_PASSWORD=
+
 # CORS (comma-separated origins)
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -23,6 +23,14 @@ It includes the newest features and fixes, but may be less stable.
 ### Quick Start (Docker Run)
 If you want to test Parker quickly, run the following command. Replace the paths on the left side of the `:` with your actual local directories:
 
+Generate an initial admin password first and keep it somewhere safe until you
+log in:
+
+```bash
+export PARKER_INITIAL_ADMIN_PASSWORD="$(openssl rand -base64 24)"
+echo "$PARKER_INITIAL_ADMIN_PASSWORD"
+```
+
 ```bash
 docker run -d \
   --name parker \
@@ -32,6 +40,7 @@ docker run -d \
   -e BASE_URL=/ \
   -e COMICS_PATH=/comics \
   -e SECRET_KEY="$(openssl rand -hex 32)" \
+  -e INITIAL_ADMIN_PASSWORD="$PARKER_INITIAL_ADMIN_PASSWORD" \
   ghcr.io/parker-server/parker:latest
 ```
 
@@ -49,6 +58,7 @@ docker run -d \
   -e BASE_URL=/comics \
   -e COMICS_PATH=/comics \
   -e SECRET_KEY="$(openssl rand -hex 32)" \
+  -e INITIAL_ADMIN_PASSWORD="$PARKER_INITIAL_ADMIN_PASSWORD" \
   -e TRUSTED_PROXIES="172.18.0.1,192.168.1.50" \
   -e ALLOWED_ORIGINS="https://comics.yourdomain.com" \
   -v /path/to/config:/app/storage \
@@ -82,16 +92,23 @@ BASE_URL=/
 COMICS_PATH=/comics
 # Generate a unique value first: openssl rand -hex 32
 SECRET_KEY=
+# Optional; defaults to admin
+INITIAL_ADMIN_USERNAME=admin
+# Required only before Parker creates the first administrator
+INITIAL_ADMIN_PASSWORD=
 ```
 
 ### Initial Configuration
 Parker requires `SECRET_KEY` to be set to a unique random value before startup. It will refuse to start if the key is empty or still uses a known placeholder.
 
+For a new database, Parker also requires `INITIAL_ADMIN_PASSWORD` so it can
+create the first administrator without using a shared default password.
+`INITIAL_ADMIN_USERNAME` defaults to `admin` if omitted. These values are
+ignored after an active administrator exists.
+
 Once the container is running, access the web UI at http://localhost:8000, or the host port you mapped with `PARKER_PORT` / `-p`.
 
-Admin Account: Parker automatically creates the user **admin**, password **admin** on first boot.
-
-Change the admin password after first login, especially before exposing Parker outside a trusted local network.
+Admin Account: log in with the bootstrap username and password you configured before first startup.
 
 Once logged in, navigate to the administration area at `/admin`, such as `http://localhost:8000/admin`.
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,23 @@ openssl rand -hex 32
 Put the generated value in `.env` as `SECRET_KEY=<generated value>`. Parker will
 refuse to start if the key is empty or still uses a known placeholder.
 
+### Initial Admin Bootstrap
+
+On a new database, Parker creates the first administrator from bootstrap
+environment variables instead of using a shared default password.
+
+Set `INITIAL_ADMIN_PASSWORD` before first startup. It must be at least 8
+characters and should be unique to this server. `INITIAL_ADMIN_USERNAME` is
+optional and defaults to `admin`.
+
+```env
+INITIAL_ADMIN_USERNAME=admin
+INITIAL_ADMIN_PASSWORD=<your initial admin password>
+```
+
+After an active administrator exists, Parker ignores these bootstrap values so
+upgrades do not reset or overwrite existing accounts.
+
 ### OPDS Reader Compatibility
 
 Parker's OPDS feed serves original comic archives and preserves their file type.

--- a/alembic/versions/f6c333d647a5_create_default_admin.py
+++ b/alembic/versions/f6c333d647a5_create_default_admin.py
@@ -1,4 +1,4 @@
-"""create default admin
+"""legacy default admin seed retired
 
 Revision ID: f6c333d647a5
 Revises: 23bc0e2cee25
@@ -6,10 +6,6 @@ Create Date: 2025-12-13 11:50:24.008539
 
 """
 from typing import Sequence, Union
-
-from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.sql import table, column
 
 
 # revision identifiers, used by Alembic.
@@ -20,31 +16,10 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    users = table(
-        'users',
-        column('email', sa.String),
-        column('username', sa.String),
-        column('hashed_password', sa.String),
-        column('is_superuser', sa.Boolean),
-        column('is_active', sa.Boolean),
-
-    )
-
-    # Insert only if table is empty
-    conn = op.get_bind()
-    result = conn.execute(sa.text("SELECT COUNT(*) FROM users"))
-    count = result.scalar()
-
-    if count == 0:
-        conn.execute(
-            users.insert().values(
-                username="admin",
-                email="admin@example.com",
-                hashed_password='$2b$12$A//4Gkpn1.4pwUJE4nrMMef5iFScpRG3qq3fNFZXTC4M6mkmthF0C', # admin
-                is_superuser=True,
-                is_active=True,
-            )
-        )
+    # Parker now creates the first administrator through startup bootstrap
+    # using INITIAL_ADMIN_PASSWORD. Existing databases that already ran the
+    # legacy seed are intentionally left untouched.
+    pass
 
 
 

--- a/app/api/stats.py
+++ b/app/api/stats.py
@@ -26,6 +26,7 @@ async def get_startup_diagnostics(
     return collect_startup_diagnostics(
         db,
         database_url=settings.database_url,
+        include_security_checks=True,
     )
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -54,6 +54,8 @@ class Settings(BaseSettings):
     secret_key: str = Field(default="", repr=False, validate_default=True)
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
+    initial_admin_username: str = "admin"
+    initial_admin_password: str = Field(default="", repr=False)
 
     @field_validator("secret_key")
     @classmethod
@@ -72,6 +74,14 @@ class Settings(BaseSettings):
             )
 
         return key
+
+    @field_validator("initial_admin_username")
+    @classmethod
+    def validate_initial_admin_username(cls, value: str) -> str:
+        username = value.strip()
+        if not username:
+            raise ValueError("INITIAL_ADMIN_USERNAME cannot be empty")
+        return username
 
     # Paths
     unrar_path: str = "unrar"
@@ -112,8 +122,9 @@ settings = Settings()
 def debug_print_settings():
     import json
     values = settings.model_dump(mode="json")
-    if "secret_key" in values:
-        values["secret_key"] = "<redacted>"
+    for secret_name in ("secret_key", "initial_admin_password"):
+        if secret_name in values:
+            values[secret_name] = "<redacted>"
     print("\n=== Parker Configuration ===")
     print(json.dumps(values, indent=2))
     print("Allowed origins:", settings.allowed_origins)

--- a/app/main.py
+++ b/app/main.py
@@ -21,13 +21,11 @@ from app.database import engine, Base
 from app.config import settings, debug_print_settings
 from app.database import SessionLocal
 from app.logging import log_config
-from app.core.security import get_password_hash
+from app.services.admin_bootstrap import AdminBootstrapError, ensure_initial_admin
 from app.services.settings_service import SettingsService
 from app.services.scheduler import scheduler_service
 from app.services.startup_diagnostics import log_startup_diagnostics
 
-
-from app.models.user import User
 
 from app.services.watcher import library_watcher
 
@@ -77,7 +75,12 @@ async def lifespan(app: FastAPI):
     # -- Init DB defaults when necessary (Safe, idempotent)
     db = SessionLocal()
     try:
+        if not getattr(app.state, "skip_admin_bootstrap", False):
+            ensure_initial_admin(db, app_settings=settings)
         SettingsService(db).initialize_defaults()
+    except AdminBootstrapError as exc:
+        logger.critical("Admin bootstrap failed: %s", exc)
+        raise
     finally:
         db.close()
     # --------------------------------------

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -122,6 +122,7 @@ async def admin_diagnostics_page(request: Request, db: SessionDep, admin_user: A
     diagnostics = collect_startup_diagnostics(
         db,
         database_url=settings.database_url,
+        include_security_checks=True,
     )
     support_snapshot = build_support_snapshot(
         diagnostics,

--- a/app/routers/pages.py
+++ b/app/routers/pages.py
@@ -28,6 +28,7 @@ async def home(request: Request, db: SessionDep, user: CurrentUser):
         diagnostics = collect_startup_diagnostics(
             db,
             database_url=settings.database_url,
+            include_security_checks=bool(user.is_superuser),
         )
     except Exception:
         diagnostics = None

--- a/app/services/admin_bootstrap.py
+++ b/app/services/admin_bootstrap.py
@@ -1,0 +1,156 @@
+import logging
+from typing import Protocol
+
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.security import get_password_hash
+from app.models.user import User
+
+
+logger = logging.getLogger("app.startup")
+
+DEFAULT_INITIAL_ADMIN_USERNAME = "admin"
+DEFAULT_INITIAL_ADMIN_EMAIL = "admin@example.com"
+INITIAL_ADMIN_PASSWORD_MIN_LENGTH = 8
+INSECURE_INITIAL_ADMIN_PASSWORD_VALUES = {
+    "admin",
+    "changeme",
+    "change-me",
+    "change_this_to_a_real_password",
+    "change_this_to_a_secure_password",
+    "letmein",
+    "parker",
+    "parkeradmin",
+    "password",
+    "password123",
+    "your-password-here",
+}
+
+
+class AdminBootstrapSettings(Protocol):
+    initial_admin_username: str
+    initial_admin_password: str
+
+
+class AdminBootstrapError(RuntimeError):
+    pass
+
+
+def _active_superuser_exists(db: Session) -> bool:
+    return (
+        db.query(User.id)
+        .filter(
+            User.is_superuser == True,
+            User.is_active == True,
+        )
+        .first()
+        is not None
+    )
+
+
+def _normalize_initial_admin_username(username: str) -> str:
+    cleaned = username.strip() or DEFAULT_INITIAL_ADMIN_USERNAME
+    return cleaned
+
+
+def _initial_admin_email(username: str) -> str:
+    if username == DEFAULT_INITIAL_ADMIN_USERNAME:
+        return DEFAULT_INITIAL_ADMIN_EMAIL
+    return f"{username}@parker.local"
+
+
+def _validate_initial_admin_password(password: str) -> str:
+    cleaned = password.strip()
+    if not cleaned:
+        raise AdminBootstrapError(
+            "Parker needs to create the first administrator account, but INITIAL_ADMIN_PASSWORD is not set. "
+            "Set INITIAL_ADMIN_PASSWORD to a unique password before starting Parker."
+        )
+
+    if len(cleaned) < INITIAL_ADMIN_PASSWORD_MIN_LENGTH:
+        raise AdminBootstrapError(
+            f"INITIAL_ADMIN_PASSWORD must be at least {INITIAL_ADMIN_PASSWORD_MIN_LENGTH} characters long."
+        )
+
+    if cleaned.lower() in INSECURE_INITIAL_ADMIN_PASSWORD_VALUES:
+        raise AdminBootstrapError(
+            "INITIAL_ADMIN_PASSWORD is set to an insecure placeholder value. "
+            "Set it to a unique password before starting Parker."
+        )
+
+    return cleaned
+
+
+def ensure_initial_admin(db: Session, *, app_settings: AdminBootstrapSettings) -> User | None:
+    """
+    Create the first admin only when the database has no active superuser.
+
+    Existing superusers are never modified. This keeps upgrades safe even when
+    an existing installation still uses the legacy admin/admin credential.
+    """
+    if _active_superuser_exists(db):
+        if app_settings.initial_admin_password.strip():
+            logger.warning(
+                "INITIAL_ADMIN_PASSWORD is set, but an active administrator already exists. "
+                "Ignoring the bootstrap password."
+            )
+        return None
+
+    username = _normalize_initial_admin_username(app_settings.initial_admin_username)
+    password = _validate_initial_admin_password(app_settings.initial_admin_password)
+    email = _initial_admin_email(username)
+
+    username_conflict = (
+        db.query(User.id)
+        .filter(func.lower(User.username) == username.lower())
+        .first()
+        is not None
+    )
+    if username_conflict:
+        raise AdminBootstrapError(
+            f"Cannot create initial administrator {username!r} because that username already exists. "
+            "Set INITIAL_ADMIN_USERNAME to an unused username and restart Parker."
+        )
+
+    email_conflict = (
+        db.query(User.id)
+        .filter(func.lower(User.email) == email.lower())
+        .first()
+        is not None
+    )
+    if email_conflict:
+        raise AdminBootstrapError(
+            f"Cannot create initial administrator {username!r} because bootstrap email {email!r} already exists. "
+            "Set INITIAL_ADMIN_USERNAME to an unused username and restart Parker."
+        )
+
+    user = User(
+        username=username,
+        email=email,
+        hashed_password=get_password_hash(password),
+        is_superuser=True,
+        is_active=True,
+    )
+    db.add(user)
+
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        if _active_superuser_exists(db):
+            logger.info("Initial administrator was created by another startup worker.")
+            return None
+        raise AdminBootstrapError(
+            "Parker could not create the initial administrator because the configured username or email conflicts "
+            "with an existing user."
+        ) from exc
+
+    db.refresh(user)
+    logger.warning(
+        "Created initial administrator account username=%r. Change INITIAL_ADMIN_PASSWORD or remove it after setup; "
+        "Parker ignores it once an administrator exists.",
+        username,
+    )
+    return user

--- a/app/services/startup_diagnostics.py
+++ b/app/services/startup_diagnostics.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from sqlalchemy import text
 from sqlalchemy.orm import Session, selectinload
 
+from app.core.security import verify_password
 from app.models.comic import Comic
 from app.models.library import Library
 from app.models.series import Series
@@ -95,6 +96,21 @@ def _safe_alembic_version(db: Session) -> str | None:
         return None
 
     return row[0]
+
+
+def _legacy_default_admin_password_active(db: Session) -> bool:
+    user = db.query(User).filter(
+        User.username == "admin",
+        User.is_superuser == True,
+        User.is_active == True,
+    ).first()
+    if user is None:
+        return False
+
+    try:
+        return verify_password("admin", user.hashed_password)
+    except Exception:
+        return False
 
 
 def _looks_like_container_library_path(path: str) -> bool:
@@ -193,6 +209,7 @@ def collect_startup_diagnostics(
     *,
     database_url: str,
     comics_root: Path = Path("/comics"),
+    include_security_checks: bool = False,
 ) -> dict:
     db_path = resolve_sqlite_db_path(database_url)
     db_exists = bool(db_path and db_path.exists())
@@ -210,6 +227,11 @@ def collect_startup_diagnostics(
         User.email == "admin@example.com",
         User.is_superuser == True,
     ).first() is not None
+    legacy_default_admin_password_active = (
+        _legacy_default_admin_password_active(db)
+        if include_security_checks
+        else False
+    )
 
     library_sample = []
     for library in (
@@ -281,6 +303,7 @@ def collect_startup_diagnostics(
             "comics": comics_count,
         },
         "default_admin_present": default_admin_present,
+        "legacy_default_admin_password_active": legacy_default_admin_password_active,
         "library_sample": library_sample,
         "runtime": {
             "mode": runtime_mode,
@@ -298,6 +321,8 @@ def collect_startup_diagnostics(
 def build_home_startup_notice(diagnostics: dict, *, is_admin: bool) -> dict | None:
     status = diagnostics.get("status")
     if status == STARTUP_STATUS_HEALTHY:
+        if diagnostics.get("legacy_default_admin_password_active") and is_admin:
+            return _build_legacy_default_admin_password_notice()
         return None
 
     if status == STARTUP_STATUS_STORAGE_MISMATCH:
@@ -309,9 +334,35 @@ def build_home_startup_notice(diagnostics: dict, *, is_admin: bool) -> dict | No
             "is_admin": is_admin,
             "recommended_actions": diagnostics["recommended_actions"],
             "diagnostics_url": "/admin/diagnostics" if is_admin else None,
+            "primary_action_url": "/admin/diagnostics" if is_admin else None,
+            "primary_action_title": "Open Diagnostics",
+            "primary_action_summary": "Inspect the active database path, counts, configured libraries, and comics probe before making any changes.",
         }
 
+    if diagnostics.get("legacy_default_admin_password_active") and is_admin:
+        return _build_legacy_default_admin_password_notice()
+
     return None
+
+
+def _build_legacy_default_admin_password_notice() -> dict:
+    return {
+        "status": "legacy_default_admin_password_active",
+        "title": "Legacy Default Admin Password",
+        "summary": (
+            "The built-in admin account still accepts Parker's legacy default password. "
+            "Change it before exposing Parker outside a trusted network."
+        ),
+        "is_suspicious": True,
+        "is_admin": True,
+        "recommended_actions": [
+            "Open Account Settings and change the admin password.",
+            "Use a unique password that is not shared with other services.",
+        ],
+        "primary_action_url": "/user/settings",
+        "primary_action_title": "Update Password",
+        "primary_action_summary": "Change the current admin password from your account settings.",
+    }
 
 
 def build_support_snapshot(

--- a/app/templates/admin/diagnostics.html
+++ b/app/templates/admin/diagnostics.html
@@ -10,6 +10,30 @@
         description="Inspect the active storage and startup state Parker is using right now."
     ) }}
 
+    {% if diagnostics.legacy_default_admin_password_active %}
+    <div class="rounded-2xl border border-rose-500/40 bg-rose-950/30 p-6 shadow-xl">
+        <div class="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+            <div class="space-y-3">
+                <div class="flex flex-wrap items-center gap-3">
+                    <span class="inline-flex rounded-full border border-rose-400/40 bg-rose-500/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-rose-100">
+                        Security Warning
+                    </span>
+                    <span class="text-sm font-semibold text-rose-100">Legacy default admin password detected</span>
+                </div>
+                <p class="max-w-3xl text-sm leading-6 text-rose-100/85">
+                    The <code class="rounded bg-black/30 px-1.5 py-0.5 text-rose-50">admin</code> account still accepts Parker's legacy default password. Change it before exposing Parker outside a trusted network.
+                </p>
+            </div>
+            <a
+                href="{{ url('/user/settings') }}"
+                class="inline-flex shrink-0 items-center justify-center rounded-lg border border-rose-300/40 bg-rose-500/15 px-4 py-2 text-sm font-bold text-rose-50 transition-colors hover:border-rose-200/70 hover:bg-rose-500/25"
+            >
+                Update Password
+            </a>
+        </div>
+    </div>
+    {% endif %}
+
     <div class="rounded-2xl border border-gray-700 bg-gray-800/60 p-6 shadow-xl space-y-4">
         <div class="flex flex-wrap items-center gap-3">
             <span class="text-xs font-bold uppercase tracking-[0.25em] text-gray-400">Status</span>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -425,15 +425,15 @@
                 </div>
 
                 <div class="max-w-2xl mx-auto space-y-4" x-show="startupNotice.is_admin">
-                    <a :href="startupNotice.diagnostics_url" class="group flex items-start gap-4 rounded-xl border border-amber-400/40 bg-amber-500/10 px-6 py-5 text-left shadow-lg transition-all hover:border-amber-300/60 hover:bg-amber-500/15">
+                    <a :href="startupNotice.primary_action_url || startupNotice.diagnostics_url ? window.parker.url(startupNotice.primary_action_url || startupNotice.diagnostics_url) : '#'" class="group flex items-start gap-4 rounded-xl border border-amber-400/40 bg-amber-500/10 px-6 py-5 text-left shadow-lg transition-all hover:border-amber-300/60 hover:bg-amber-500/15">
                         <div class="text-2xl">!</div>
                         <div>
-                            <h3 class="font-bold text-white group-hover:text-amber-100 transition-colors">Open Diagnostics</h3>
-                            <p class="text-sm text-amber-100/70 mt-1">Inspect the active database path, counts, configured libraries, and comics probe before making any changes.</p>
+                            <h3 class="font-bold text-white group-hover:text-amber-100 transition-colors" x-text="startupNotice.primary_action_title || 'Open Diagnostics'"></h3>
+                            <p class="text-sm text-amber-100/70 mt-1" x-text="startupNotice.primary_action_summary || 'Inspect the active database path, counts, configured libraries, and comics probe before making any changes.'"></p>
                         </div>
                     </a>
 
-                    <div class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm">
+                    <div class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm" x-show="startupNotice.status === 'storage_mismatch_suspected'">
                         <a :href="window.parker.url('/admin')" class="text-gray-300 hover:text-white transition-colors">Back to Admin</a>
                         <a :href="window.parker.url('/admin/libraries')" class="text-amber-200/55 hover:text-amber-200/80 transition-colors">Manage Libraries Anyway</a>
                     </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - DATABASE_URL=sqlite:////app/storage/database/comics.db
       - COMICS_PATH=/comics
       - "SECRET_KEY=${SECRET_KEY:?Set SECRET_KEY in .env to a unique random value. Generate one with: openssl rand -hex 32}"
+      - INITIAL_ADMIN_USERNAME=${INITIAL_ADMIN_USERNAME:-admin}
+      - INITIAL_ADMIN_PASSWORD=${INITIAL_ADMIN_PASSWORD:-}
       # If you need to tell the app where unrar is in the container
       # (Note: standard Linux unrar path is usually /usr/bin/unrar)
       - UNRAR_PATH=/usr/bin/unrar

--- a/docs/releases/0.1.30.md
+++ b/docs/releases/0.1.30.md
@@ -1,0 +1,26 @@
+# Parker 0.1.30 Release Notes
+
+Status: Unreleased
+
+`0.1.30` hardens first-run administrator bootstrap so new installs no longer start with a shared default admin password.
+
+## Added
+
+- Added `INITIAL_ADMIN_PASSWORD` bootstrap support for creating the first administrator when no active superuser exists.
+- Added optional `INITIAL_ADMIN_USERNAME`, defaulting to `admin`, for first administrator creation.
+- Added an admin-only warning when Parker detects that the `admin` account still accepts the legacy `admin` password.
+
+## Changed
+
+- Fresh databases no longer receive the legacy `admin` / `admin` account from the historical Alembic seed migration.
+- Docker, `.env`, README, and Quickstart documentation now describe the first-admin bootstrap variables.
+
+## Fixed
+
+- Prevented first-run bootstrap from mutating or locking out existing administrator accounts during upgrades.
+
+## Validation
+
+- Verified focused config, bootstrap, diagnostics, page, and startup stats coverage: `73 passed`.
+- Verified a fresh Alembic upgrade reaches head without seeding any users: `users=0`.
+- Verified the full test suite: `828 passed, 4 warnings`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,12 +13,17 @@ alembic upgrade head
 
 # Initialize default settings
 python - << 'EOF'
+from app.config import settings
 from app.database import SessionLocal
+from app.services.admin_bootstrap import ensure_initial_admin
 from app.services.settings_service import SettingsService
 
 db = SessionLocal()
-SettingsService(db).initialize_defaults()
-db.close()
+try:
+    ensure_initial_admin(db, app_settings=settings)
+    SettingsService(db).initialize_defaults()
+finally:
+    db.close()
 EOF
 
 # Start Uvicorn

--- a/tests/api/test_pages.py
+++ b/tests/api/test_pages.py
@@ -39,7 +39,7 @@ def _seed_series_page_data(db, volume_count=1):
 def test_home_page_shows_storage_warning_for_admin_when_startup_looks_suspicious(admin_client, monkeypatch):
     monkeypatch.setattr(
         "app.routers.pages.collect_startup_diagnostics",
-        lambda db, database_url: {
+        lambda db, database_url, **kwargs: {
             "status": "storage_mismatch_suspected",
             "status_title": "Storage Mismatch Suspected",
             "status_summary": "Parker can see comics but the database has no libraries configured.",
@@ -61,7 +61,7 @@ def test_home_page_shows_storage_warning_for_admin_when_startup_looks_suspicious
 def test_home_page_keeps_normal_onboarding_when_startup_state_is_healthy(admin_client, monkeypatch):
     monkeypatch.setattr(
         "app.routers.pages.collect_startup_diagnostics",
-        lambda db, database_url: {
+        lambda db, database_url, **kwargs: {
             "status": "healthy",
             "status_title": "Healthy",
             "status_summary": "Healthy",
@@ -74,7 +74,29 @@ def test_home_page_keeps_normal_onboarding_when_startup_state_is_healthy(admin_c
     assert response.status_code == 200
     body = response.text
     assert "Welcome to Parker!" in body
-    assert "storage_mismatch_suspected" not in body
+    assert '{"startupNotice": null}' in body
+
+
+def test_home_page_shows_legacy_default_password_warning_for_admin(admin_client, monkeypatch):
+    monkeypatch.setattr(
+        "app.routers.pages.collect_startup_diagnostics",
+        lambda db, database_url, **kwargs: {
+            "status": "healthy",
+            "status_title": "Healthy",
+            "status_summary": "Everything looks good.",
+            "recommended_actions": [],
+            "legacy_default_admin_password_active": True,
+        },
+    )
+
+    response = admin_client.get("/")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Legacy Default Admin Password" in body
+    assert "Update Password" in body
+    assert "/user/settings" in body
+    assert "legacy_default_admin_password_active" in body
 
 
 def test_admin_dashboard_links_to_diagnostics(admin_client):
@@ -125,10 +147,51 @@ def test_admin_diagnostics_page_exposes_support_snapshot_actions(admin_client):
     assert "document.execCommand('copy')" in body
 
 
+def test_admin_diagnostics_page_shows_legacy_default_password_warning(admin_client, monkeypatch):
+    def fake_collect_startup_diagnostics(db, database_url, **kwargs):
+        assert kwargs["include_security_checks"] is True
+        return {
+            "status": "healthy",
+            "status_title": "Healthy",
+            "status_summary": "Everything looks good.",
+            "is_suspicious": False,
+            "recommended_actions": [],
+            "runtime": {"mode": "local_filesystem", "label": "Local filesystem"},
+            "database": {
+                "url": "sqlite:///test.db",
+                "path": "test.db",
+                "exists": True,
+                "size_bytes": 0,
+                "size_display": "0 B",
+                "wal_size_bytes": None,
+                "wal_size_display": None,
+                "shm_size_bytes": None,
+                "shm_size_display": None,
+                "alembic_version": "head",
+            },
+            "counts": {"users": 1, "libraries": 0, "series": 0, "comics": 0},
+            "default_admin_present": True,
+            "legacy_default_admin_password_active": True,
+            "library_sample": [],
+            "comics_root": {"path": "/comics", "exists": False, "sample": []},
+        }
+
+    monkeypatch.setattr("app.routers.admin.collect_startup_diagnostics", fake_collect_startup_diagnostics)
+
+    response = admin_client.get("/admin/diagnostics")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "Security Warning" in body
+    assert "Legacy default admin password detected" in body
+    assert "Update Password" in body
+    assert "/user/settings" in body
+
+
 def test_admin_diagnostics_page_renders_configured_library_roots(admin_client, monkeypatch):
     monkeypatch.setattr(
         "app.routers.admin.collect_startup_diagnostics",
-        lambda db, database_url: {
+        lambda db, database_url, **kwargs: {
             "status": "healthy",
             "status_title": "Healthy",
             "status_summary": "Everything looks good.",
@@ -187,7 +250,7 @@ def test_admin_diagnostics_page_renders_configured_library_roots(admin_client, m
 def test_admin_diagnostics_page_labels_sampled_library_count(admin_client, monkeypatch):
     monkeypatch.setattr(
         "app.routers.admin.collect_startup_diagnostics",
-        lambda db, database_url: {
+        lambda db, database_url, **kwargs: {
             "status": "healthy",
             "status_title": "Healthy",
             "status_summary": "Everything looks good.",

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -59,7 +59,11 @@ def test_startup_diagnostics_endpoint_returns_collected_payload(admin_client, mo
         "recommended_actions": ["Check storage"],
     }
 
-    monkeypatch.setattr("app.api.stats.collect_startup_diagnostics", lambda db, database_url: sentinel)
+    def fake_collect_startup_diagnostics(db, database_url, **kwargs):
+        assert kwargs["include_security_checks"] is True
+        return sentinel
+
+    monkeypatch.setattr("app.api.stats.collect_startup_diagnostics", fake_collect_startup_diagnostics)
 
     response = admin_client.get("/api/stats/startup")
 
@@ -71,7 +75,11 @@ def test_startup_support_snapshot_endpoint_returns_structured_snapshot(admin_cli
     sentinel = {"status": "healthy"}
     snapshot = {"snapshot_type": "parker_startup_diagnostics", "schema_version": 1}
 
-    monkeypatch.setattr("app.api.stats.collect_startup_diagnostics", lambda db, database_url: sentinel)
+    def fake_collect_startup_diagnostics(db, database_url, **kwargs):
+        assert "include_security_checks" not in kwargs
+        return sentinel
+
+    monkeypatch.setattr("app.api.stats.collect_startup_diagnostics", fake_collect_startup_diagnostics)
     monkeypatch.setattr("app.api.stats.get_build_commit_hash", lambda: "abc123def456")
     monkeypatch.setattr(
         "app.api.stats.build_support_snapshot",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,12 +85,15 @@ def client(db) -> Generator:
             pass
 
     app.dependency_overrides[get_db] = override_get_db
+    app.state.skip_admin_bootstrap = True
 
-    with TestClient(app) as c:
-        yield c
-
-    # Reset overrides after test
-    app.dependency_overrides.clear()
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        # Reset overrides after test
+        app.dependency_overrides.clear()
+        app.state.skip_admin_bootstrap = False
 
 
 # 4. USER FIXTURES

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -38,3 +38,52 @@ def test_settings_reads_secret_key_from_environment(monkeypatch):
     settings = Settings(_env_file=None)
 
     assert settings.secret_key == value
+
+
+def test_settings_reads_initial_admin_bootstrap_values_from_environment(monkeypatch):
+    value = "parker-env-secret-key-not-for-production-000000"
+    monkeypatch.setenv("SECRET_KEY", value)
+    monkeypatch.setenv("INITIAL_ADMIN_USERNAME", "owner")
+    monkeypatch.setenv("INITIAL_ADMIN_PASSWORD", "owner-bootstrap-password")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.initial_admin_username == "owner"
+    assert settings.initial_admin_password == "owner-bootstrap-password"
+
+
+def test_settings_allows_blank_initial_admin_password_until_bootstrap_is_needed():
+    settings = Settings(
+        secret_key="parker-unit-test-secret-key-not-for-production-000000",
+        initial_admin_password="",
+        _env_file=None,
+    )
+
+    assert settings.initial_admin_password == ""
+
+
+def test_settings_rejects_blank_initial_admin_username():
+    with pytest.raises(ValidationError, match="INITIAL_ADMIN_USERNAME cannot be empty"):
+        Settings(
+            secret_key="parker-unit-test-secret-key-not-for-production-000000",
+            initial_admin_username="   ",
+            _env_file=None,
+        )
+
+
+def test_debug_print_settings_redacts_bootstrap_password(monkeypatch, capsys):
+    from app import config
+
+    configured = Settings(
+        secret_key="private-secret-key-value",
+        initial_admin_password="private-bootstrap-password",
+        _env_file=None,
+    )
+    monkeypatch.setattr(config, "settings", configured)
+
+    config.debug_print_settings()
+
+    output = capsys.readouterr().out
+    assert "private-secret-key-value" not in output
+    assert "private-bootstrap-password" not in output
+    assert output.count("<redacted>") == 2

--- a/tests/services/test_admin_bootstrap.py
+++ b/tests/services/test_admin_bootstrap.py
@@ -1,0 +1,93 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.security import verify_password, get_password_hash
+from app.models.user import User
+from app.services.admin_bootstrap import AdminBootstrapError, ensure_initial_admin
+
+
+def _settings(username: str = "admin", password: str = "unique-admin-password-123"):
+    return SimpleNamespace(
+        initial_admin_username=username,
+        initial_admin_password=password,
+    )
+
+
+def test_ensure_initial_admin_creates_default_admin_when_no_superuser_exists(db):
+    user = ensure_initial_admin(db, app_settings=_settings())
+
+    assert user is not None
+    assert user.username == "admin"
+    assert user.email == "admin@example.com"
+    assert user.is_superuser is True
+    assert user.is_active is True
+    assert verify_password("unique-admin-password-123", user.hashed_password)
+
+
+def test_ensure_initial_admin_uses_configured_username(db):
+    user = ensure_initial_admin(db, app_settings=_settings(username="owner"))
+
+    assert user is not None
+    assert user.username == "owner"
+    assert user.email == "owner@parker.local"
+    assert user.is_superuser is True
+
+
+def test_ensure_initial_admin_requires_password_when_bootstrap_is_needed(db):
+    with pytest.raises(AdminBootstrapError, match="INITIAL_ADMIN_PASSWORD is not set"):
+        ensure_initial_admin(db, app_settings=_settings(password=""))
+
+    assert db.query(User).count() == 0
+
+
+def test_ensure_initial_admin_rejects_insecure_password_placeholder(db):
+    with pytest.raises(AdminBootstrapError, match="insecure placeholder"):
+        ensure_initial_admin(db, app_settings=_settings(password="password123"))
+
+    assert db.query(User).count() == 0
+
+
+def test_ensure_initial_admin_rejects_short_password(db):
+    with pytest.raises(AdminBootstrapError, match="at least 8 characters"):
+        ensure_initial_admin(db, app_settings=_settings(password="short"))
+
+    assert db.query(User).count() == 0
+
+
+def test_ensure_initial_admin_does_not_modify_existing_superuser(db):
+    existing_hash = get_password_hash("admin")
+    user = User(
+        username="admin",
+        email="admin@example.com",
+        hashed_password=existing_hash,
+        is_superuser=True,
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+
+    created = ensure_initial_admin(db, app_settings=_settings(password=""))
+
+    assert created is None
+    db.refresh(user)
+    assert user.hashed_password == existing_hash
+    assert verify_password("admin", user.hashed_password)
+
+
+def test_ensure_initial_admin_rejects_existing_username_when_no_superuser_exists(db):
+    db.add(
+        User(
+            username="admin",
+            email="admin@example.com",
+            hashed_password=get_password_hash("reader-password"),
+            is_superuser=False,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    with pytest.raises(AdminBootstrapError, match="username already exists"):
+        ensure_initial_admin(db, app_settings=_settings())
+
+    assert db.query(User).filter(User.is_superuser == True).count() == 0

--- a/tests/services/test_startup_diagnostics.py
+++ b/tests/services/test_startup_diagnostics.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
+from app.core.security import get_password_hash
 from app.models.comic import Comic, Volume
 from app.models.library_root import LibraryRoot
 from app.models.series import Series
@@ -141,6 +142,50 @@ def test_collect_startup_diagnostics_classifies_storage_mismatch(db, tmp_path):
     assert diagnostics["database"]["size_display"] == "432 B"
 
 
+def test_collect_startup_diagnostics_detects_legacy_default_admin_password(db, tmp_path):
+    db.add(
+        User(
+            username="admin",
+            email="admin@example.com",
+            hashed_password=get_password_hash("admin"),
+            is_superuser=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    diagnostics = collect_startup_diagnostics(
+        db,
+        database_url=f"sqlite:///{(tmp_path / 'comics.db').as_posix()}",
+        comics_root=tmp_path / "probe",
+        include_security_checks=True,
+    )
+
+    assert diagnostics["legacy_default_admin_password_active"] is True
+
+
+def test_collect_startup_diagnostics_ignores_changed_admin_password(db, tmp_path):
+    db.add(
+        User(
+            username="admin",
+            email="admin@example.com",
+            hashed_password=get_password_hash("changed-password"),
+            is_superuser=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    diagnostics = collect_startup_diagnostics(
+        db,
+        database_url=f"sqlite:///{(tmp_path / 'comics.db').as_posix()}",
+        comics_root=tmp_path / "probe",
+        include_security_checks=True,
+    )
+
+    assert diagnostics["legacy_default_admin_password_active"] is False
+
+
 def test_build_home_startup_notice_returns_admin_notice_for_storage_mismatch():
     diagnostics = {
         "status": STARTUP_STATUS_STORAGE_MISMATCH,
@@ -165,6 +210,24 @@ def test_build_home_startup_notice_ignores_healthy_state():
     }
 
     assert build_home_startup_notice(diagnostics, is_admin=True) is None
+
+
+def test_build_home_startup_notice_returns_admin_legacy_password_warning():
+    diagnostics = {
+        "status": STARTUP_STATUS_HEALTHY,
+        "status_title": "Healthy",
+        "status_summary": "Healthy summary",
+        "recommended_actions": [],
+        "legacy_default_admin_password_active": True,
+    }
+
+    notice = build_home_startup_notice(diagnostics, is_admin=True)
+
+    assert notice is not None
+    assert notice["status"] == "legacy_default_admin_password_active"
+    assert notice["primary_action_url"] == "/user/settings"
+    assert "legacy default password" in notice["summary"]
+    assert build_home_startup_notice(diagnostics, is_admin=False) is None
 
 
 def test_build_support_snapshot_wraps_diagnostics_with_metadata():
@@ -199,6 +262,7 @@ def test_build_support_snapshot_wraps_diagnostics_with_metadata():
     }
     assert snapshot["status"]["code"] == "healthy"
     assert snapshot["configured_library_sample"] == [{"name": "Main", "path": "C:/Comics"}]
+    assert "legacy_default_admin_password_active" not in snapshot
 
 
 def test_collect_startup_diagnostics_marks_default_comics_root_as_container_runtime(db, tmp_path):


### PR DESCRIPTION

This PR removes Parker’s legacy first-run `admin` / `admin` bootstrap path and replaces it with explicit first-admin configuration.

## Changes

- Adds `INITIAL_ADMIN_PASSWORD` support for creating the first admin only when no active superuser exists.
- Adds optional `INITIAL_ADMIN_USERNAME`, defaulting to `admin`.
- Prevents bootstrap from mutating existing admin accounts during upgrades, including existing installs still using `admin` / `admin`.
- Retires the historical Alembic default-admin seed for fresh databases.
- Adds admin-only warnings when Parker detects that the `admin` account still accepts the legacy default password.
- Shows the legacy password warning on both the home startup notice and at the top of the admin diagnostics page.
- Updates Docker, `.env.example`, README, Quickstart, and 0.1.30 release notes.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests/core/test_config.py tests/services/test_admin_bootstrap.py tests/services/test_startup_diagnostics.py tests/api/test_pages.py tests/api/test_stats.py`
  - `73 passed`
- `.\.venv\Scripts\python.exe -m pytest`
  - `828 passed, 4 warnings`
- Fresh Alembic upgrade verified to reach head without seeding users:
  - `users=0`
- `git diff --check`
  - clean, aside from normal CRLF notices